### PR TITLE
Integrate GraphQL codegen for Gatsby

### DIFF
--- a/apps/silverback-website/.gitignore
+++ b/apps/silverback-website/.gitignore
@@ -69,5 +69,5 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 
-# Ignore the exported schema
-schema.gql
+# Ignore generated files
+generated

--- a/apps/silverback-website/.gitignore
+++ b/apps/silverback-website/.gitignore
@@ -68,3 +68,6 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+
+# Ignore the exported schema
+schema.gql

--- a/apps/silverback-website/.gitignore
+++ b/apps/silverback-website/.gitignore
@@ -70,4 +70,5 @@ yarn-error.log
 .yarn-integrity
 
 # Ignore generated files
-generated
+generated/*
+!generated/.gitkeep

--- a/apps/silverback-website/.prettierignore
+++ b/apps/silverback-website/.prettierignore
@@ -6,3 +6,4 @@ CHANGELOG.md
 package.json
 package-lock.json
 public
+generated

--- a/apps/silverback-website/codegen.yml
+++ b/apps/silverback-website/codegen.yml
@@ -1,0 +1,12 @@
+overwrite: true
+schema: generated/schema.graphql
+documents:
+  - ./src/**/*.{ts,tsx}
+  - ./gatsby-node.ts
+generates:
+  generated/types/gatsby.d.ts:
+    plugins:
+      - "typescript"
+      - "typescript-operations"
+    config:
+      noExport: true

--- a/apps/silverback-website/gatsby-config.ts
+++ b/apps/silverback-website/gatsby-config.ts
@@ -40,6 +40,7 @@ export const plugins = [
       ],
     },
   },
+  'gatsby-plugin-schema-export',
   {
     resolve: 'gatsby-source-filesystem',
     options: {

--- a/apps/silverback-website/gatsby-node.ts
+++ b/apps/silverback-website/gatsby-node.ts
@@ -45,21 +45,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
   // whose URLs are dynamically determined at build time.
   // https://www.gatsbyjs.org/docs/creating-and-modifying-pages/
 
-  const allDocs: {
-    data?: {
-      allMdx: {
-        edges: {
-          node: {
-            id: string;
-            frontmatter: {
-              path: string | null;
-            };
-          };
-        }[];
-      };
-    };
-    errors?: any;
-  } = await graphql(`
+  const allDocs = await graphql<AllDocsQuery>(`
     query AllDocs {
       allMdx {
         edges {
@@ -84,7 +70,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
 
   allDocs.data?.allMdx.edges.forEach(({ node }) => {
     createPage<{ id: string }>({
-      path: node.frontmatter.path || '/',
+      path: node.frontmatter?.path || '/',
       component: pathResolve(`./src/templates/documentation.tsx`),
       context: {
         id: node.id,

--- a/apps/silverback-website/package.json
+++ b/apps/silverback-website/package.json
@@ -25,6 +25,9 @@
   "devDependencies": {
     "@amazeelabs/eslint-config-react": "^1.0.7",
     "@amazeelabs/prettier-config": "^1.1.0",
+    "@graphql-codegen/cli": "1.17.10",
+    "@graphql-codegen/typescript": "1.17.10",
+    "@graphql-codegen/typescript-operations": "1.17.8",
     "@types/classnames": "^2.2.10",
     "@types/mdx-js__react": "^1.5.2",
     "@types/node": "^14.11.2",
@@ -50,7 +53,9 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "pretest": "yarn lint && yarn format",
-    "test": "echo \"Add tests already\""
+    "typecheck": "yarn build && yarn codegen && tsc --noEmit",
+    "codegen": "graphql-codegen --config codegen.yml",
+    "test": "yarn typecheck"
   },
   "repository": {
     "type": "git",

--- a/apps/silverback-website/package.json
+++ b/apps/silverback-website/package.json
@@ -32,7 +32,8 @@
     "fork-ts-checker-webpack-plugin": "^5.2.0",
     "prettier": "2.1.1",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "gatsby-plugin-schema-export": "^1.0.0"
   },
   "keywords": [
     "gatsby"

--- a/apps/silverback-website/src/templates/documentation.tsx
+++ b/apps/silverback-website/src/templates/documentation.tsx
@@ -4,11 +4,11 @@ import { graphql, PageProps } from 'gatsby';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 import React from 'react';
 
-import { Code, TOC, TOCItem } from '../components';
+import { Code, TOC } from '../components';
 import { preToCodeBlock } from '../utils';
 
 export const pageQuery = graphql`
-  query DocQuery($id: String) {
+  query Documentation($id: String) {
     mdx(id: { eq: $id }) {
       id
       body
@@ -20,43 +20,36 @@ export const pageQuery = graphql`
   }
 `;
 
-const Documentation: React.FC<PageProps<{
-  mdx: {
-    body: string;
-    frontmatter: {
-      title: string;
-    };
-    tableOfContents: {
-      items: TOCItem[];
-    };
-  };
-}>> = ({ data: { mdx } }) => (
-  <>
-    <SEO title={mdx.frontmatter.title} />
-    <MDXProvider
-      components={{
-        pre: (preProps) => {
-          const props = preToCodeBlock(preProps);
-          // if there's a codeString and some props, we passed the test
-          if (props) {
-            return <Code {...props} />;
-          } else {
-            // it's possible to have a pre without a code in it
-            return <pre {...preProps} />;
-          }
-        },
-      }}
-    >
-      <div className="items-start md:flex">
-        {mdx.tableOfContents.items[0].items!.length > 1 && (
-          <TOC items={mdx.tableOfContents.items[0].items!} />
-        )}
-        <article className="min-w-0 p-6 bg-white rounded-lg shadow-xl lg:p-8 xl:p-10 prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none sm:max-w-none">
-          <MDXRenderer>{mdx.body}</MDXRenderer>
-        </article>
-      </div>
-    </MDXProvider>
-  </>
-);
+const Documentation: React.FC<PageProps<DocumentationQuery>> = ({
+  data: { mdx },
+}) =>
+  mdx ? (
+    <>
+      {mdx.frontmatter?.title ? <SEO title={mdx.frontmatter.title} /> : null}
+      <MDXProvider
+        components={{
+          pre: (preProps) => {
+            const props = preToCodeBlock(preProps);
+            // if there's a codeString and some props, we passed the test
+            if (props) {
+              return <Code {...props} />;
+            } else {
+              // it's possible to have a pre without a code in it
+              return <pre {...preProps} />;
+            }
+          },
+        }}
+      >
+        <div className="items-start md:flex">
+          {mdx.tableOfContents.items[0].items!.length > 1 && (
+            <TOC items={mdx.tableOfContents.items[0].items!} />
+          )}
+          <article className="min-w-0 p-6 bg-white rounded-lg shadow-xl lg:p-8 xl:p-10 prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none sm:max-w-none">
+            <MDXRenderer>{mdx.body}</MDXRenderer>
+          </article>
+        </div>
+      </MDXProvider>
+    </>
+  ) : null;
 
 export default Documentation;

--- a/apps/silverback-website/tsconfig.json
+++ b/apps/silverback-website/tsconfig.json
@@ -14,10 +14,19 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",
-    "typeRoots": ["./node_modules/@types"],
-    "types": ["./src/types/images.d.ts"],
+    "typeRoots": ["./node_modules/@types", "./src/types", "./generated/types"],
     "sourceMap": true
   },
-  "include": ["./src"],
-  "exclude": ["node_modules"]
+  "include": [
+    "./src",
+    "./generated",
+    "gatsby-node.ts",
+    "gatsby-config.ts",
+    "gatsby-browser.ts",
+    "gatsby-ssr.ts"
+  ],
+  "exclude": ["node_modules"],
+  "ts-node": {
+    "transpileOnly": true
+  }
 }

--- a/packages/npm/@amazeelabs/gatsby-starter/.gitignore
+++ b/packages/npm/@amazeelabs/gatsby-starter/.gitignore
@@ -69,5 +69,5 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 
-# The graphql schema exported by `gatsby-plugin-schema-export`
-schema.gql
+# Ignore generated files
+generated

--- a/packages/npm/@amazeelabs/gatsby-starter/.gitignore
+++ b/packages/npm/@amazeelabs/gatsby-starter/.gitignore
@@ -70,4 +70,5 @@ yarn-error.log
 .yarn-integrity
 
 # Ignore generated files
-generated
+generated/*
+!generated/.gitkeep

--- a/packages/npm/@amazeelabs/gatsby-starter/.gitignore
+++ b/packages/npm/@amazeelabs/gatsby-starter/.gitignore
@@ -68,3 +68,6 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+
+# The graphql schema exported by `gatsby-plugin-schema-export`
+schema.gql

--- a/packages/npm/@amazeelabs/gatsby-starter/.prettierignore
+++ b/packages/npm/@amazeelabs/gatsby-starter/.prettierignore
@@ -6,3 +6,4 @@ CHANGELOG.md
 package.json
 package-lock.json
 public
+generated

--- a/packages/npm/@amazeelabs/gatsby-starter/codegen.yml
+++ b/packages/npm/@amazeelabs/gatsby-starter/codegen.yml
@@ -1,0 +1,12 @@
+overwrite: true
+schema: generated/schema.graphql
+documents:
+  - ./src/**/*.{ts,tsx}
+  - ./gatsby-node.ts
+generates:
+  generated/types/gatsby.d.ts:
+    plugins:
+      - "typescript"
+      - "typescript-operations"
+    config:
+      noExport: true

--- a/packages/npm/@amazeelabs/gatsby-starter/gatsby-config.ts
+++ b/packages/npm/@amazeelabs/gatsby-starter/gatsby-config.ts
@@ -24,4 +24,5 @@ export const plugins = [
     },
   },
   '@amazeelabs/gatsby-theme-core',
+  'gatsby-plugin-schema-export',
 ];

--- a/packages/npm/@amazeelabs/gatsby-starter/package.json
+++ b/packages/npm/@amazeelabs/gatsby-starter/package.json
@@ -37,7 +37,9 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "pretest": "yarn lint && yarn format",
-    "test": "echo \"Add tests\""
+    "typecheck": "yarn build && yarn codegen && tsc --noEmit",
+    "codegen": "graphql-codegen --config codegen.yml",
+    "test": "yarn typecheck"
   },
   "repository": {
     "type": "git",

--- a/packages/npm/@amazeelabs/gatsby-starter/src/pages/index.tsx
+++ b/packages/npm/@amazeelabs/gatsby-starter/src/pages/index.tsx
@@ -1,10 +1,20 @@
 import { SEO } from '@amazeelabs/gatsby-theme-core';
-import { PageProps } from 'gatsby';
+import { graphql, PageProps } from 'gatsby';
 import React from 'react';
 
-const IndexPage: React.FC<PageProps> = () => (
+export const query = graphql`
+  query HomePage {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+`;
+
+const IndexPage: React.FC<PageProps & HomePageQuery> = ({ site }) => (
   <>
-    <SEO title="Home" />
+    <SEO title={site?.siteMetadata?.title || 'No title'} />
     <h1>Hi people</h1>
     <p>Welcome to your new Gatsby site.</p>
     <p>Now go build something great.</p>

--- a/packages/npm/@amazeelabs/gatsby-starter/tsconfig.json
+++ b/packages/npm/@amazeelabs/gatsby-starter/tsconfig.json
@@ -14,9 +14,19 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",
-    "typeRoots": ["./node_modules/@types"],
+    "typeRoots": ["./node_modules/@types", "./src/types", "./generated/types"],
     "sourceMap": true
   },
-  "include": ["./src"],
-  "exclude": ["node_modules"]
+  "include": [
+    "./src",
+    "./generated",
+    "gatsby-node.ts",
+    "gatsby-config.ts",
+    "gatsby-browser.ts",
+    "gatsby-ssr.ts"
+  ],
+  "exclude": ["node_modules"],
+  "ts-node": {
+    "transpileOnly": true
+  }
 }

--- a/packages/npm/@amazeelabs/gatsby-theme-core/gatsby-config.js
+++ b/packages/npm/@amazeelabs/gatsby-theme-core/gatsby-config.js
@@ -1,5 +1,6 @@
 module.exports = ({ postCssPlugins = [], cssLoaderOptions = {} }) => ({
   plugins: [
+    'gatsby-plugin-schema-export',
     'gatsby-plugin-react-helmet',
     {
       resolve: `gatsby-plugin-postcss`,

--- a/packages/npm/@amazeelabs/gatsby-theme-core/package.json
+++ b/packages/npm/@amazeelabs/gatsby-theme-core/package.json
@@ -25,7 +25,8 @@
     "eslint": "^7.9.0",
     "prettier": "2.1.1",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "gatsby-plugin-schema-export": "^1.0.0"
   },
   "peerDependencies": {
     "gatsby": "^2.24.58",

--- a/packages/npm/gatsby-plugin-schema-export/gatsby-node.js
+++ b/packages/npm/gatsby-plugin-schema-export/gatsby-node.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+const {
+  introspectionQuery,
+  graphql,
+  buildClientSchema,
+  printSchema,
+} = require("gatsby/graphql");
+
+const defaultLocation = path.resolve(process.cwd(), "schema.gql");
+
+module.exports.onPostBootstrap = ({ store }, options) => {
+  const dest = options.dest || defaultLocation;
+  new Promise((resolve, reject) => {
+    const { schema } = store.getState();
+    graphql(schema, introspectionQuery)
+      .then((res) => {
+        fs.writeFileSync(dest, printSchema(buildClientSchema(res.data)));
+        return undefined;
+      })
+      .then(() => {
+        console.log(`[gatsby-plugin-schema-export] Exported schema to ${dest}`);
+        return resolve();
+      })
+      .catch((e) => {
+        console.error(
+          `[gatsby-plugin-schema-export] Failed to export schema: ${e}`,
+          e
+        );
+        reject();
+      });
+  });
+};

--- a/packages/npm/gatsby-plugin-schema-export/gatsby-node.js
+++ b/packages/npm/gatsby-plugin-schema-export/gatsby-node.js
@@ -7,9 +7,9 @@ const {
   printSchema,
 } = require("gatsby/graphql");
 
-const defaultLocation = path.resolve(process.cwd(), "schema.gql");
+const defaultLocation = path.resolve(process.cwd(), "generated/schema.graphql");
 
-module.exports.onPostBootstrap = ({ store }, options) => {
+module.exports.onPostBootstrap = ({ store, reporter }, options) => {
   const dest = options.dest || defaultLocation;
   new Promise((resolve, reject) => {
     const { schema } = store.getState();
@@ -19,11 +19,13 @@ module.exports.onPostBootstrap = ({ store }, options) => {
         return undefined;
       })
       .then(() => {
-        console.log(`[gatsby-plugin-schema-export] Exported schema to ${dest}`);
+        reporter.info(
+          `[gatsby-plugin-schema-export] Exported schema to ${dest}`
+        );
         return resolve();
       })
       .catch((e) => {
-        console.error(
+        reporter.info(
           `[gatsby-plugin-schema-export] Failed to export schema: ${e}`,
           e
         );

--- a/packages/npm/gatsby-plugin-schema-export/package.json
+++ b/packages/npm/gatsby-plugin-schema-export/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gatsby-plugin-schema-export",
+  "version": "1.0.0",
+  "description": "Export the current Gatsby schema to a *.gql file.",
+  "main": "dist/index.ts",
+  "author": "Philipp Melab",
+  "license": "MIT",
+  "private": false,
+  "peerDependencies": {
+    "gatsby": "^2.24.67"
+  }
+}


### PR DESCRIPTION
## Package(s) involved
@amazeelabs/gatsby-starter
silverback-website
gatsby-plugin-schema-export

## Description of changes
* Added a tiny gatsby plugin that will write a `generated/schema.graphql` file, containing the current Gatsby GraphQL schema.
* Added and configured GraphQL-Codegen to generate global type definitions for GraphQL types and operations in `generated/types/gatsby.d.ts`
* Added a `codegen` script to `silverback-website`
* Fixed typescript configuration to properly include global types and also typecheck `gatsby-*.ts` files
* Added a test command to `silverback-website` that runs the typecheck
* Replicated all changes into `@amazeelabs/gatsby-starter`

## Motivation and context
GraphQL codegen provides us with automatic typing for GraphQL query results and variables. Unfortunately, the corresponding [Gatsby plugin](https://www.gatsbyjs.com/plugins/gatsby-plugin-graphql-codegen/) directly hooks into the build process and has been a constant source of errors. This pull request separates the two processes, but simply exporting the current schema definition on build, and providing a separate `codegen` script that can be executed when necessary.

As a side effect, the generated `schema.graphql` file is picked up by most graphql editor plugins and allows code assistance in graphql queries without a working connection to Gatsby's graphql endpoint.

## How has this been tested?
The `silverback-website` app uses this for typechecking it's sourcecode.