### PR TITLE
fix: make gatsby-plugin-schema-export visible in Gatsby plugin library

### DIFF
--- a/packages/npm/gatsby-plugin-schema-export/README.md
+++ b/packages/npm/gatsby-plugin-schema-export/README.md
@@ -1,0 +1,42 @@
+# gatsby-plugin-schema-export
+
+Exports the current Gatsby schema to a `*.graphql` file.
+
+## Installation
+
+Install
+
+```bash
+yarn add gatsby-plugin-schema-export
+```
+
+### Without options
+The generated schema will be written to `generated/schema.graphql`.
+```js
+// gatsby-config.js
+  ...
+  plugins: [
+    'gatsby-plugin-schema-export',
+     ...
+  ],
+```
+
+### With options
+The generated schema will be written to `schema/gatsbySchema.graphql`.
+```js
+// gatsby-config.js
+  ...
+  plugins: [
+    {
+      resolve: `gatsby-plugin-schema-export`,
+      options: {
+        dest: `schemas/gatsbySchema.graphql`,
+      },
+    },
+     ...
+  ],
+```
+
+## Usage
+The generated schema will be written to `generated/schema.graphql` unless the `dest` option is set.
+

--- a/packages/npm/gatsby-plugin-schema-export/package.json
+++ b/packages/npm/gatsby-plugin-schema-export/package.json
@@ -8,5 +8,12 @@
   "private": false,
   "peerDependencies": {
     "gatsby": "^2.24.67"
-  }
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "graphql",
+    "schema",
+    "export"
+  ]
 }


### PR DESCRIPTION
## Package(s) involved
npm/gatsby-plugin-schema-export

## Description of changes
make gatsby-plugin-schema-export visible in Gatsby plugin library and add README for usage

## Motivation and context
Make it available to more folks and document a bit.
