### PR TITLE
Jest preset configure

### DIFF
--- a/packages/npm/@amazeelabs/jest-preset-react/README.md
+++ b/packages/npm/@amazeelabs/jest-preset-react/README.md
@@ -1,0 +1,4 @@
+After installing/updating, run:
+```
+node_modules/.bin/jest-preset-configure react
+```

--- a/packages/npm/@amazeelabs/jest-preset-react/package.json
+++ b/packages/npm/@amazeelabs/jest-preset-react/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@amazeelabs/jest-preset-react": "^1.0.1",
+    "@amazeelabs/jest-preset": "^1.0.1",
     "@testing-library/react": "^11.0.4"
   }
 }

--- a/packages/npm/@amazeelabs/jest-preset/README.md
+++ b/packages/npm/@amazeelabs/jest-preset/README.md
@@ -1,0 +1,4 @@
+After installing/updating, run:
+```
+node_modules/.bin/jest-preset-configure
+```

--- a/packages/npm/@amazeelabs/jest-preset/config/configure.js
+++ b/packages/npm/@amazeelabs/jest-preset/config/configure.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('fs');
+const readline = require('readline');
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+rl.question(`Please make sure you ran this command from your project root!
+This command will add/adjust files in your project root. Please use VCS to track changes.
+Ready? (y/n): `, function (answer) {
+  if (answer.trim() === 'y') {
+    tasks.copyFiles();
+    tasks.adjustFiles();
+    console.log('Done! Please check the changes.');
+  } else {
+    console.log('See you next time.');
+  }
+  rl.close();
+});
+
+const data = {
+  paths: {
+    projectRoot: process.env.PWD,
+    files: path.join(__dirname, 'files'),
+  },
+  kind: process.argv[2], // e.g. "react"
+};
+
+const tasks = {
+  copyFiles: () => {
+    for (const file of fs.readdirSync(data.paths.files)) {
+      const scr = path.join(data.paths.files, file);
+      const dest = path.join(data.paths.projectRoot, file);
+      fs.copyFileSync(scr, dest);
+      if (data.kind) {
+        utils.adjustKind(dest);
+      }
+    }
+  },
+
+  adjustFiles: () => {
+    utils.adjustPackageJson(path.join(data.paths.projectRoot, 'package.json'));
+  },
+};
+
+const utils = {
+  adjustPackageJson: (filepath) => {
+    const contents = fs.readFileSync(filepath, 'utf8');
+    const json = JSON.parse(contents);
+    if (!json.scripts) {
+      json.scripts = {};
+    }
+    json.scripts['test:ci'] = 'jest';
+    json.scripts['test:watch'] = 'jest --watch';
+    json.scripts['test'] = 'is-ci test:ci test:watch';
+    fs.writeFileSync(filepath, JSON.stringify(json, null, 2));
+  },
+
+  adjustKind: (filepath) => {
+    const contents = fs.readFileSync(filepath, 'utf8');
+    const updated = contents.replace(
+      '@amazeelabs/jest-preset',
+      '@amazeelabs/jest-preset-' + data.kind
+    ).replace(
+      '@amazeelabs/eslint-config',
+      '@amazeelabs/eslint-config-' + data.kind
+    );
+    fs.writeFileSync(filepath, updated);
+  }
+};

--- a/packages/npm/@amazeelabs/jest-preset/config/files/.eslintrc.js
+++ b/packages/npm/@amazeelabs/jest-preset/config/files/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@amazeelabs/eslint-config'],
+};

--- a/packages/npm/@amazeelabs/jest-preset/config/files/.huskyrc
+++ b/packages/npm/@amazeelabs/jest-preset/config/files/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "lint-staged"
+  }
+}

--- a/packages/npm/@amazeelabs/jest-preset/config/files/.lintstagedrc
+++ b/packages/npm/@amazeelabs/jest-preset/config/files/.lintstagedrc
@@ -1,0 +1,8 @@
+{
+  "*.+(js|ts|tsx)": [
+    "jest --findRelatedTests"
+  ],
+  "*.+(js|ts|tsx|md|mdx|yml)": [
+    "prettier --write --ignore-path .gitignore"
+  ]
+}

--- a/packages/npm/@amazeelabs/jest-preset/config/files/.prettierrc
+++ b/packages/npm/@amazeelabs/jest-preset/config/files/.prettierrc
@@ -1,0 +1,1 @@
+"@amazeelabs/prettier-config"

--- a/packages/npm/@amazeelabs/jest-preset/config/files/jest.config.js
+++ b/packages/npm/@amazeelabs/jest-preset/config/files/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: '@amazeelabs/jest-preset',
+};

--- a/packages/npm/@amazeelabs/jest-preset/package.json
+++ b/packages/npm/@amazeelabs/jest-preset/package.json
@@ -9,6 +9,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "bin": {
+    "jest-preset-configure": "config/configure.js"
+  },
   "dependencies": {
     "@types/jest": "^26.0.14",
     "is-ci-cli": "^2.1.2",


### PR DESCRIPTION
Closes #328

As it was already discussed with Philipp in Slack, there were two major issues preventing the process automation:
1. Yarn does not display output from postinstall scripts. There is no way to tell to user that files were updated. There is an open [bug](https://github.com/yarnpkg/yarn/issues/5476), but I guess they did it on a purpose of spam protection. Because the bug is opened for two years and no one cares.
2. When npm is used, it's really hard to distinguish between `npm install` and `npm install package` commands. It's possible, but very tricky.

So it's implemented in a semi-automated way:
```
yarn add @amazeelabs/jest-preset
node_modules/.bin/jest-preset-configure
```
or
```
yarn add @amazeelabs/jest-preset-react
node_modules/.bin/jest-preset-configure react
```