### PR TITLE
Fix silverback-website builds

### DIFF
--- a/apps/silverback-website/package.json
+++ b/apps/silverback-website/package.json
@@ -60,7 +60,7 @@
     "clean": "gatsby clean",
     "update-schema": "GATSBY_UPDATE_SCHEMA_SNAPSHOT=true gatsby build",
     "codegen": "graphql-codegen --config codegen.yml",
-    "test:ci": "jest && yarn build",
+    "test:ci": "jest && yarn codegen && yarn tsc && yarn build",
     "test:watch": "jest --watch",
     "test": "is-ci test:ci test:watch",
     "storybook": "start-storybook -p 6006",

--- a/apps/silverback-website/package.json
+++ b/apps/silverback-website/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@amazeelabs/eslint-config-react": "^1.0.7",
-    "@amazeelabs/gatsby-theme-core": "^0.4.0",
     "@amazeelabs/jest-preset-react": "^1.1.1",
     "@amazeelabs/prettier-config": "^1.1.0",
     "@graphql-codegen/cli": "1.19.2",

--- a/apps/silverback-website/package.json
+++ b/apps/silverback-website/package.json
@@ -61,7 +61,7 @@
     "clean": "gatsby clean",
     "update-schema": "GATSBY_UPDATE_SCHEMA_SNAPSHOT=true gatsby build",
     "codegen": "graphql-codegen --config codegen.yml",
-    "test:ci": "jest",
+    "test:ci": "jest && yarn build",
     "test:watch": "jest --watch",
     "test": "is-ci test:ci test:watch",
     "storybook": "start-storybook -p 6006",

--- a/packages/npm/@amazeelabs/gatsby-theme-core/package.json
+++ b/packages/npm/@amazeelabs/gatsby-theme-core/package.json
@@ -44,6 +44,7 @@
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint --fix \"**/*.{js,jsx,ts,tsx}\"",
     "prepare": "tsc -p ./",
+    "postinstall": "yarn prepare",
     "test": "is-ci test:ci test:watch",
     "test:ci": "jest",
     "test:watch": "jest --watch"

--- a/packages/npm/@amazeelabs/react-di/package.json
+++ b/packages/npm/@amazeelabs/react-di/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "postinstall": "yarn build",
     "prepublish": "tsc",
     "test:ci": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Problem
TypeScript and Webpack fail to resolve `@amazeelabs/gatsby-theme-core` and `@amazeelabs/react-di` when they are not compiled.

## Solution
Compile the mentioned packages during the monorepo initialization.

## Solution which did not work
https://github.com/microsoft/TypeScript/issues/21423 suggest a workaround:
```ts
// index.ts in root of each package
export * from './src/index'
```

It helps TypeScript, but does not work for webpack.