### PR TITLE
build: clear root lockfile before installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "commit": "yarn git-cz",
     "test": "yarn lerna run prepublish --since --include-dependencies && yarn lerna run test --since --stream --concurrency=1",
     "git-registry": "yarn verdaccio -c config.yml",
+    "preinstall": "rm -f yarn.lock",
     "postinstall": "lerna bootstrap && lerna run prepare"
   },
   "devDependencies": {


### PR DESCRIPTION
I ran into problems with multiple versions of `react`, caused by outdated versions of `react` in the root lock file. Deleting the lock file and reinstalling fixed it. Should we just always clear it when running `yarn` since its ephemeral anyway?
