### PR TITLE
--force should not ignore existing config

### DIFF
--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
@@ -44,7 +44,7 @@ class Setup extends SilverbackCommand {
       $this->fileSystem->remove('install-cache.zip');
     }
 
-    $configExists = $this->fileSystem->exists('config/sync/core.extension.yml') && !$input->getOption('force');
+    $configExists = $this->fileSystem->exists('config/sync/core.extension.yml');
 
     if (!$this->fileSystem->exists($this->cacheDir . '/' . $hash) || $input->getOption('force')) {
       $zippy = Zippy::load();


### PR DESCRIPTION
From the `--force` flag help:
> Force installation.

The actual action was: Force installation and ignore the existing config.