### PR TITLE
Make Renovate update all dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,4 +37,5 @@
   rangeStrategy: "replace",
   groupName: "all",
   schedule: ["before 5am on monday"],
+  lockFileMaintenance: { enabled: true },
 }


### PR DESCRIPTION
... even the ones which are not directly listed in `package.json` or `composer.json` files.

Current issue: The official Drupal composer template does not include `drupal/core` in `composer.json`. So Renovate does not update Drupal core 😛 