### PR TITLE
Do not run composer install in yarn postinstall

### DIFF
--- a/apps/silverback-drupal-graphql-v3/package.json
+++ b/apps/silverback-drupal-graphql-v3/package.json
@@ -3,9 +3,6 @@
   "version": "1.3.12",
   "private": true,
   "license": "MIT",
-  "scripts": {
-    "prepare": "composer install -vvv"
-  },
   "dependencies": {
     "@-amazeelabs/silverback-cli": "^2.0.1"
   }

--- a/apps/silverback-drupal/package.json
+++ b/apps/silverback-drupal/package.json
@@ -4,8 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "prepare": "composer install -vvv",
-    "test": "bash vendor/bin/silverback-test"
+    "test": "composer install && bash vendor/bin/silverback-test"
   },
   "dependencies": {
     "@-amazeelabs/silverback-cli": "^2.0.1",

--- a/apps/silverback-gatsby/test.sh
+++ b/apps/silverback-gatsby/test.sh
@@ -17,6 +17,7 @@ function setup_drupal {
   cd ../silverback-drupal-graphql-v3
   source .envrc
 
+  composer install
   vendor/bin/silverback teardown
   vendor/bin/silverback setup
   vendor/bin/drush -y content-sync:import

--- a/apps/silverback-website/docs/drupal/gatsby.mdx
+++ b/apps/silverback-website/docs/drupal/gatsby.mdx
@@ -92,6 +92,7 @@ Prepare (run from the silverback-mono root):
 ```shell
 cd apps/silverback-drupal-graphql-v3
 direnv allow
+composer install
 silverback setup
 drush -y cim
 drush -y content-sync:import # Ignore the errors.

--- a/packages/composer/drupal/cypress/package.json
+++ b/packages/composer/drupal/cypress/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.14",
   "description": "Cypress E2E testing for Drupal.",
   "scripts": {
-    "test": "cd ../../../../apps/silverback-drupal && vendor/bin/phpstan analyse --configuration=web/modules/contrib/cypress/phpstan.neon"
+    "test": "cd ../../../../apps/silverback-drupal && composer install && vendor/bin/phpstan analyse --configuration=web/modules/contrib/cypress/phpstan.neon"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
We had an issue with alchemy/zippy composer package. Our guess that the error was caused by the fact
that lerna runs all commands in parallel by default. Look like a `composer install` in
`apps/silverback-drupal` starts to clone the package to cache and another `composer install` running
in parallel from `apps/silverback-drupal-graphql-v3` thinks that the package is already cloned and
tried to checkout a specific reference.

Here is the error:

```
Executing command (/home/runner/work/silverback-mono/silverback-mono/apps/silverback-drupal-graphql-v3/vendor/alchemy/zippy): git checkout 'c79815c422b2754f922810ce029b231dea91ea32' -- && git reset --hard 'c79815c422b2754f922810ce029b231dea91ea32' --
    c79815c422b2754f922810ce029b231dea91ea32 is gone (history was rewritten?)
Failed: [RuntimeException] Failed to execute git checkout 'c79815c422b2754f922810ce029b231dea91ea32' -- && git reset --hard 'c79815c422b2754f922810ce029b231dea91ea32' --

fatal: reference is not a tree: c79815c422b2754f922810ce029b231dea91ea32

    Install of alchemy/zippy failed
```