### PR TITLE
Bring back composer-patches plugin to silverback-cli

### DIFF
--- a/packages/composer/amazeelabs/silverback-cli/composer.json
+++ b/packages/composer/amazeelabs/silverback-cli/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "ext-zip": "*",
         "alchemy/zippy": "dev-master",
+        "cweagans/composer-patches": "^1.7.0",
         "drush/drush": "^10.3.6",
         "vlucas/phpdotenv": "^5.2",
         "ext-json": "*"


### PR DESCRIPTION
Because even our own apps rely on the fact that silverback-cli is served with it.