### PR TITLE
Cypress module env

### DIFF
--- a/packages/composer/drupal/cypress/cypress.module
+++ b/packages/composer/drupal/cypress/cypress.module
@@ -6,7 +6,8 @@
  * @return bool
  */
 function cypress_enabled() {
-  return \Drupal::getContainer()->getParameter('cypress.enabled');
+  return \Drupal::getContainer()->getParameter('cypress.enabled')
+    || getenv('ENABLE_INSECURE_CYPRESS_TESTING_FEATURES');
 }
 
 /**

--- a/packages/npm/cypress-screenplay/commands.ts
+++ b/packages/npm/cypress-screenplay/commands.ts
@@ -1,39 +1,41 @@
-import { Actor, Question, Task } from './index';
+import { Actor, Question, Task as ScreenPlayTask } from './index';
 
 let _actor = new Actor();
 
-export declare namespace Cypress {
-  interface Chainable<Subject> {
-    /**
-     * Initiate with a different actor.
-     *
-     * Allows to set a customized actor with specialised abilities.
-     *
-     * @param actor
-     */
-    initiateActor(actor: Actor): Chainable<void>;
+declare global {
+  namespace Cypress {
+    interface Chainable<Subject> {
+      /**
+       * Initiate with a different actor.
+       *
+       * Allows to set a customized actor with specialised abilities.
+       *
+       * @param actor
+       */
+      initiateActor(actor: Actor): Chainable<void>;
 
-    /**
-     * Perform a given task.
-     *
-     * @param task
-     *   The task implementation.
-     * @param param
-     *   The tasks parameter.
-     */
-    perform<P>(task: Task<P>, param: P): Chainable<void>;
+      /**
+       * Perform a given task.
+       *
+       * @param task
+       *   The task implementation.
+       * @param param
+       *   The tasks parameter.
+       */
+      perform<P>(task: ScreenPlayTask<P>, param: P): Chainable<void>;
 
-    /**
-     * Ask a question.
-     *
-     * The questions result will be returned as a chainable.
-     *
-     * @param question
-     *   The question implementation.
-     * @param param
-     *   Question parameter.
-     */
-    ask<P, R>(question: Question<P, R>, param: P): Chainable<R>;
+      /**
+       * Ask a question.
+       *
+       * The questions result will be returned as a chainable.
+       *
+       * @param question
+       *   The question implementation.
+       * @param param
+       *   Question parameter.
+       */
+      ask<P, R>(question: Question<P, R>, param: P): Chainable<R>;
+    }
   }
 }
 
@@ -41,9 +43,12 @@ Cypress.Commands.add('initiateActor', (actor: Actor) => {
   _actor = actor;
 });
 
-Cypress.Commands.add('perform', (task: Task<any>, param: any = undefined) => {
-  _actor.perform(task, param);
-});
+Cypress.Commands.add(
+  'perform',
+  (task: ScreenPlayTask<any>, param: any = undefined) => {
+    _actor.perform(task, param);
+  },
+);
 
 Cypress.Commands.add(
   'ask',

--- a/packages/npm/cypress-screenplay/index.ts
+++ b/packages/npm/cypress-screenplay/index.ts
@@ -1,3 +1,5 @@
+import './commands';
+
 export { Actor } from './src/actor';
 export { TaskInteraction, Task } from './src/task';
 export { QuestionInteraction, Question } from './src/question';


### PR DESCRIPTION
## Package(s) involved
`drupal/cypress`

## Description of changes
Allow enabling the insecure cypress module features by passing an environment variable to the PHP process. This makes it easier to run rests from the outside when using the `silverback-cli`.
