### PR TITLE
Declare compatibility with webform 6.

### DIFF
--- a/packages/composer/drupal/webform_jsonschema/composer.json
+++ b/packages/composer/drupal/webform_jsonschema/composer.json
@@ -11,6 +11,6 @@
     "source": "http://cgit.drupalcode.org/webform_jsonschema"
   },
   "require": {
-    "drupal/webform": "^5"
+    "drupal/webform": "^5 || ^6"
   }
 }


### PR DESCRIPTION
## Package(s) involved
drupal/webform_jsonschema

## Description of changes
Declare webform 6 compatibility

## Motivation and context
The module only declares to be compatible with webform 5 but also with Drupal 9. Webform 5 is not compatible with Drupal 9 so the module can't be installed in Drupal 9.

## How has this been tested?
Bring the module to the project committed as a custom module and tested it manually along with webform 6.
