### PR TITLE
Avoid eslint using configs from parent dirs

### DIFF
--- a/packages/npm/@amazeelabs/scaffold/files/.eslintrc.js
+++ b/packages/npm/@amazeelabs/scaffold/files/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
   extends: ['@amazeelabs/eslint-config'],
+  root: true,
 };


### PR DESCRIPTION
https://eslint.org/docs/2.0.0/user-guide/configuring
> By default, ESLint will look for configuration files in all parent folders up to the root
> directory.

We don't want this to happen.
