### PR TITLE
feat(cypress-screenplay): allow tasks to return promises

### DIFF
--- a/packages/npm/cypress-screenplay/cypress/integration/screenplay.spec.js
+++ b/packages/npm/cypress-screenplay/cypress/integration/screenplay.spec.js
@@ -1,4 +1,8 @@
-import { readListItems, visitTestPage } from '../support/interactions';
+import {
+  readListItems,
+  visitTestPage,
+  appendToList,
+} from '../support/interactions';
 
 describe('Screenplay', () => {
   it('executes tasks and questions', () => {
@@ -7,5 +11,12 @@ describe('Screenplay', () => {
       .should('contain', 'A')
       .should('contain', 'B')
       .should('contain', 'C');
+    cy.window().then((win) => {
+      cy.perform(appendToList, {
+        text: 'D',
+        list: win.document.getElementsByTagName('ul').item(0),
+      });
+      cy.ask(readListItems).should('contain', 'D');
+    });
   });
 });

--- a/packages/npm/cypress-screenplay/cypress/support/interactions.js
+++ b/packages/npm/cypress-screenplay/cypress/support/interactions.js
@@ -14,3 +14,14 @@ export const readListItems = createCypressQuestion((cy, _, assert) => {
     ),
   );
 });
+
+export const appendToList = createCypressTask((cy, { text, list }) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const item = document.createElement('li');
+      item.textContent = text;
+      list.appendChild(item);
+      resolve(undefined);
+    }, 3000);
+  });
+});

--- a/packages/npm/cypress-screenplay/index.ts
+++ b/packages/npm/cypress-screenplay/index.ts
@@ -130,7 +130,7 @@ export const Then: StepDefinition = (expression, implementation) => {
 Cypress.Commands.add(
   'perform',
   (task: ScreenPlayTask<any>, param: any = undefined) => {
-    _actor.perform(task, param);
+    return cy.wrap(_actor.perform(task, param), { log: false });
   },
 );
 
@@ -141,6 +141,7 @@ Cypress.Commands.add(
       new Cypress.Promise((resolve) => {
         _actor.ask(question, param, resolve);
       }),
+      { log: false },
     );
   },
 );

--- a/packages/npm/cypress-screenplay/src/actor.ts
+++ b/packages/npm/cypress-screenplay/src/actor.ts
@@ -12,10 +12,9 @@ export interface AbilityFactory<T> {
 
 export type AbilityType<T> = T extends AbilityFactory<infer FA> ? FA : T;
 
-function hasOwnProperty<X extends any, Y extends PropertyKey>(
+function hasThenProperty<X extends any>(
   obj: X,
-  prop: Y,
-): obj is X & Record<Y, unknown> {
+): obj is X & Record<'then', unknown> {
   // @ts-ignore
   return !!obj.then;
 }
@@ -25,7 +24,7 @@ function isPromise<T extends any>(
 ): value is Promise<any> {
   return (
     typeof value === 'object' &&
-    hasOwnProperty(value, 'then') &&
+    hasThenProperty(value) &&
     typeof value.then === 'function'
   );
 }

--- a/packages/npm/cypress-screenplay/src/actor.ts
+++ b/packages/npm/cypress-screenplay/src/actor.ts
@@ -150,8 +150,8 @@ export class Actor {
   public async perform<P>(task: Task<P>, param: P): Promise<Actor> {
     const result = this.prepare(task).invoke(param);
     if (isPromise(result)) {
-      return new Promise((resolve) => {
-        return result.then(() => resolve(this));
+      return new Promise((resolve, reject) => {
+        result.then(() => resolve(this)).catch(reject);
       });
     } else {
       return new Promise((resolve) => {

--- a/packages/npm/cypress-screenplay/src/task.ts
+++ b/packages/npm/cypress-screenplay/src/task.ts
@@ -4,7 +4,7 @@ import { AbilityType, Actor, isAbilityFactory } from './actor';
  * Type definition for task interactions.
  */
 export interface TaskInteraction<P> {
-  invoke(param: P): void;
+  invoke(param: P): void | Promise<void>;
 }
 
 /**
@@ -18,7 +18,7 @@ export type Task<P> = TaskType<P> | TaskType<P>[];
 export type TaskProcedure<A extends object, P> = (
   ability: AbilityType<A>,
   param: P,
-) => void;
+) => void | Promise<void>;
 
 /**
  * Shorthand for creating tasks using a specific ability.
@@ -47,8 +47,8 @@ export function createTask<A extends object, P>(
       this.actor = actor;
       this.ability = actor.ability(ability);
     }
-    invoke(param: P): void {
-      procedure(
+    invoke(param: P): void | Promise<void> {
+      return procedure(
         isAbilityFactory(this.ability) ? this.ability.create() : this.ability,
         param,
       );


### PR DESCRIPTION
## Package(s) involved
cypress-screenplay

## Description of changes
Allow tasks to return promises and make the test runner wait for them to resolve.

## Motivation and context
Some tasks have to invoke multiple asynchronous operations.

## How has this been tested?
Unit and integration tests within cypress screenplay.
