### PR TITLE
docs: add "taxonomy_entity_index" to the list of Drupal modules

### DIFF
--- a/apps/silverback-website/docs/drupal/modules.mdx
+++ b/apps/silverback-website/docs/drupal/modules.mdx
@@ -86,6 +86,12 @@ not affected by destructive cropping.
 ### [Cypress & Test session](https://www.drupal.org/project/cypress)
 Write end2end Cypress tests and easily run integration tests against Drupal.
 
+### [Taxonomy Entity Index](https://www.drupal.org/project/taxonomy_entity_index)
+Run taxonomy-depth queries using index tables against all entities (Drupal core
+only supports published nodes out of the box). Useful when using taxonomy
+hierarchies for organising content in the backend (and potentially a lot of other
+use cases).
+
 ## Prohibited modules
 Don't even bother to start a discussion.
 


### PR DESCRIPTION
## Package(s) involved
Drupal documentation.

## Description of changes
Add the `taxonomy_entity_index` module to the list of recommended Drupal modules.

## Motivation and context
Drupal Core supports taxonomy-hierarchy queries ("tagged with X or children of X") for published nodes only. With this module it can also be used on other entities (e.g. media) and unpublished content. That makes taxonomies a viable tool for structuring content in administration backends.

## Related Issue(s)
<!-- make sure you link with either an `#issue-number` or directly with `[link-text](url)` -->

## How has this been tested?
<!-- locally? written tests? -->
