### PR TITLE
Add prettier for PHP

### DIFF
--- a/packages/composer/amazeelabs/silverback-cli/.prettierrc
+++ b/packages/composer/amazeelabs/silverback-cli/.prettierrc
@@ -1,0 +1,1 @@
+"@amazeelabs/prettier-config"

--- a/packages/composer/amazeelabs/silverback-cli/package.json
+++ b/packages/composer/amazeelabs/silverback-cli/package.json
@@ -11,5 +11,11 @@
     "registry": "http://localhost:4873",
     "repository": "git@github.com:AmazeeLabs/silverback-cli.git",
     "branch": "master"
+  },
+  "devDependencies": {
+    "@amazeelabs/prettier-config": "^1.1.0"
+  },
+  "dependencies": {
+    "prettier": "^2.2.1"
   }
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
@@ -8,32 +8,48 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Setup extends SilverbackCommand {
-
   protected function configure(): void {
     parent::configure();
     $zipCache = self::zipCache();
     $this->setName('setup');
     $this->setDescription('Install a site.');
-    $this->setHelp(<<<EOD
-If --profile option is passed:
-  - A new installation will be made using Drush site-install command (with --existing-config flag if case if Drupal configuration already exists in config/sync dir).
-  - $zipCache will be created or updated.
-Otherwise:
-  - $zipCache will be used to restore the site.
-  - The following Drush commands will be fired: updatedb, config-import, cache-rebuild.
-EOD
+    $this->setHelp(
+      <<<EOD
+                              If --profile option is passed:
+                                - A new installation will be made using Drush site-install command (with --existing-config flag if case if Drupal configuration already exists in config/sync dir).
+                                - $zipCache will be created or updated.
+                              Otherwise:
+                                - $zipCache will be used to restore the site.
+                                - The following Drush commands will be fired: updatedb, config-import, cache-rebuild.
+                              EOD
+      ,
     );
-    $this->addOption('profile', 'p', InputOption::VALUE_OPTIONAL, 'A Drupal profile to use for a new installation.');
-    $this->addOption('no-config-import', NULL, InputOption::VALUE_NONE, 'Disable configuration import during a cached installation. Useful for testing module updates.');
+    $this->addOption(
+      'profile',
+      'p',
+      InputOption::VALUE_OPTIONAL,
+      'A Drupal profile to use for a new installation.',
+    );
+    $this->addOption(
+      'no-config-import',
+      null,
+      InputOption::VALUE_NONE,
+      'Disable configuration import during a cached installation. Useful for testing module updates.',
+    );
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output): int {
+  protected function execute(
+    InputInterface $input,
+    OutputInterface $output
+  ): int {
     parent::execute($input, $output);
     $profile = $input->getOption('profile');
     $noConfigImport = $input->getOption('no-config-import');
 
     if ($profile && $noConfigImport) {
-      $output->writeln("<error>Options --profile and --no-config-import cannot be used together.</>");
+      $output->writeln(
+        '<error>Options --profile and --no-config-import cannot be used together.</>',
+      );
       return 1;
     }
 
@@ -48,7 +64,9 @@ EOD
     $zipCacheExists = $this->fileSystem->exists($zipCache);
 
     if (!$zipCacheExists && !$profile) {
-      $output->writeln("<error>No $zipCache found. Please pass --profile to make a new Drupal installation.</>");
+      $output->writeln(
+        "<error>No $zipCache found. Please pass --profile to make a new Drupal installation.</>",
+      );
       return 1;
     }
 
@@ -59,20 +77,26 @@ EOD
       $output->writeln("<info>Restoring from $zipCache...</>");
       $cache = $zippy->open($zipCache);
       $cache->extract('web/sites/default');
-    }
-    else {
-      $output->writeln('<info>Installing from scratch' . ($configExists ? ' using existing config' : '') . '.</>');
-      $this->executeProcess(array_filter([
-        $drush,
-        'si',
-        '-y',
-        $profile,
-        $configExists ? '--existing-config' : '',
-        '--account-name',
-        getenv('SB_ADMIN_USER'),
-        '--account-pass',
-        getenv('SB_ADMIN_PASS'),
-      ]), $output);
+    } else {
+      $output->writeln(
+        '<info>Installing from scratch' .
+          ($configExists ? ' using existing config' : '') .
+          '.</>',
+      );
+      $this->executeProcess(
+        array_filter([
+          $drush,
+          'si',
+          '-y',
+          $profile,
+          $configExists ? '--existing-config' : '',
+          '--account-name',
+          getenv('SB_ADMIN_USER'),
+          '--account-pass',
+          getenv('SB_ADMIN_PASS'),
+        ]),
+        $output,
+      );
     }
 
     if (!$this->fileSystem->exists($private)) {
@@ -85,24 +109,21 @@ EOD
         $this->executeProcess([$drush, 'cim', '-y'], $output);
       }
       $this->executeProcess([$drush, 'cr'], $output);
-    }
-    else {
+    } else {
       if ($zipCacheExists) {
         $output->writeln("<info>Updating $zipCache...</>");
         $this->fileSystem->remove($zipCache);
-      }
-      else {
+      } else {
         $output->writeln("<info>Creating $zipCache...</>");
       }
-      $zippy->create($zipCache, ['files' => $public], TRUE);
+      $zippy->create($zipCache, ['files' => $public], true);
     }
 
-    $output->writeln("<info>Setup complete.</>");
+    $output->writeln('<info>Setup complete.</>');
     return 0;
   }
 
   public static function zipCache(): string {
     return 'install-cache.zip';
   }
-
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SilverbackCommand.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SilverbackCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class SilverbackCommand extends Command {
-
   /**
    * @var \Symfony\Component\Filesystem\Filesystem
    */
@@ -35,9 +34,11 @@ class SilverbackCommand extends Command {
   }
 
   protected function executeProcess(array $command, OutputInterface $output) {
-    $process = new Process($command, getcwd(), NULL, NULL, NULL);
+    $process = new Process($command, getcwd(), null, null, null);
     $process->start();
-    $output->writeln('<comment>Executing command: ' . $process->getCommandLine() . '</>');
+    $output->writeln(
+      '<comment>Executing command: ' . $process->getCommandLine() . '</>',
+    );
     foreach ($process as $type => $line) {
       $output->write($line);
     }
@@ -60,7 +61,9 @@ class SilverbackCommand extends Command {
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     if (!file_exists('composer.json')) {
-      $output->writeln('<error>composer.json not found. Please run this command from composer based Drupal installations root directory.</>');
+      $output->writeln(
+        '<error>composer.json not found. Please run this command from composer based Drupal installations root directory.</>',
+      );
       exit(1);
     }
     // TODO: scan upwards and detect root directory?
@@ -73,11 +76,19 @@ class SilverbackCommand extends Command {
     }
     $finder = new Finder();
     $finder->files()->in($source);
-    $finder->ignoreDotFiles(FALSE);
+    $finder->ignoreDotFiles(false);
     foreach ($finder as $file) {
       $this->fileSystem->copy(
-        rtrim($source, '/') . '/' . $file->getRelativePath() . '/' . $file->getFilename(),
-        rtrim($destination) . '/' . $file->getRelativePath() . '/' . $file->getFilename()
+        rtrim($source, '/') .
+          '/' .
+          $file->getRelativePath() .
+          '/' .
+          $file->getFilename(),
+        rtrim($destination) .
+          '/' .
+          $file->getRelativePath() .
+          '/' .
+          $file->getFilename(),
       );
     }
   }
@@ -86,7 +97,7 @@ class SilverbackCommand extends Command {
     if ($this->fileSystem->exists($source)) {
       $finder = new Finder();
       $finder->files()->in($source);
-      $finder->ignoreDotFiles(FALSE);
+      $finder->ignoreDotFiles(false);
       foreach ($finder as $file) {
         $this->fileSystem->remove($file->getPathname());
       }
@@ -114,14 +125,21 @@ class SilverbackCommand extends Command {
     return md5(serialize($files));
   }
 
-  protected function confirm(InputInterface $input, OutputInterface $output, string $question) {
+  protected function confirm(
+    InputInterface $input,
+    OutputInterface $output,
+    string $question
+  ) {
     if ($input->getOption('yes')) {
       $output->writeln("<question>$question</question>yes");
       return true;
     }
     /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
     $helper = $this->getHelper('question');
-    return $helper->ask($input, $output, new ConfirmationQuestion("<question>$question</question>", true));
+    return $helper->ask(
+      $input,
+      $output,
+      new ConfirmationQuestion("<question>$question</question>", true),
+    );
   }
-
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotBase.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotBase.php
@@ -6,13 +6,17 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 
 class SnapshotBase extends SilverbackCommand {
-
   /**
    * {@inheritDoc}
    */
   protected function configure() {
     parent::configure();
-    $this->addArgument('name', InputArgument::OPTIONAL, 'The snapshot name.', 'default');
+    $this->addArgument(
+      'name',
+      InputArgument::OPTIONAL,
+      'The snapshot name.',
+      'default',
+    );
   }
 
   /**
@@ -26,5 +30,4 @@ class SnapshotBase extends SilverbackCommand {
     $name = $input->getArgument('name');
     return "$this->rootDirectory/.silverback-snapshots/$name";
   }
-
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotCreate.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotCreate.php
@@ -6,7 +6,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SnapshotCreate extends SnapshotBase {
-
   /**
    * {@inheritDoc}
    */
@@ -26,7 +25,13 @@ class SnapshotCreate extends SnapshotBase {
     $path = $this->getSnapshotStorageDirectory($input);
 
     if ($this->fileSystem->exists($path)) {
-      if (!$this->confirm($input, $output, 'The snapshot already exists. Override it?')) {
+      if (
+        !$this->confirm(
+          $input,
+          $output,
+          'The snapshot already exists. Override it?',
+        )
+      ) {
         return 1;
       }
       $this->fileSystem->remove($path);
@@ -35,5 +40,4 @@ class SnapshotCreate extends SnapshotBase {
     $this->copyDir('web/sites/default/files', $path);
     $output->writeln("</info>The snapshot has been saved to $path.</>");
   }
-
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotRestore.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotRestore.php
@@ -6,7 +6,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SnapshotRestore extends SnapshotBase {
-
   /**
    * {@inheritDoc}
    */
@@ -33,7 +32,8 @@ class SnapshotRestore extends SnapshotBase {
     $this->fileSystem->chmod('web/sites/default', 0755);
     $this->fileSystem->remove('web/sites/default/files');
     $this->copyDir($snapshotDirectory, 'web/sites/default/files');
-    $output->writeln("<info>The snapshot has been restored from $snapshotDirectory.</>");
+    $output->writeln(
+      "<info>The snapshot has been restored from $snapshotDirectory.</>",
+    );
   }
-
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Teardown.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Teardown.php
@@ -6,7 +6,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Teardown extends SilverbackCommand {
-
   protected function configure() {
     parent::configure();
     $this->setName('teardown');
@@ -18,7 +17,6 @@ class Teardown extends SilverbackCommand {
     if ($this->fileSystem->exists('web/sites/default/files')) {
       $this->cleanDir('web/sites/default/files');
     }
-    $output->writeln("<info>Deleted the current site.</>");
+    $output->writeln('<info>Deleted the current site.</>');
   }
-
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/SilverbackCli.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/SilverbackCli.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Filesystem\Filesystem;
 
 class SilverbackCli extends Application {
-
   public function __construct($name = 'silverback', $version = '0.1') {
     parent::__construct($name, $version);
     $fileSystem = new Filesystem();
@@ -19,5 +18,4 @@ class SilverbackCli extends Application {
     $this->add(new SnapshotCreate($fileSystem));
     $this->add(new SnapshotRestore($fileSystem));
   }
-
 }

--- a/packages/npm/@amazeelabs/prettier-config/index.js
+++ b/packages/npm/@amazeelabs/prettier-config/index.js
@@ -1,6 +1,10 @@
 module.exports = {
   singleQuote: true,
   trailingComma: "all",
-  proseWrap: "always"
+  proseWrap: "always",
+  phpVersion: "7.4",
+  trailingCommaPHP: true,
+  braceStyle: "1tbs",
+  tabWidth: 2
 };
 

--- a/packages/npm/@amazeelabs/prettier-config/package.json
+++ b/packages/npm/@amazeelabs/prettier-config/package.json
@@ -11,5 +11,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@prettier/plugin-php": "^0.16.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3605,6 +3605,15 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
+"@prettier/plugin-php@^0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@prettier/plugin-php/-/plugin-php-0.16.2.tgz#11f124f84a3daec40f672987a0b9887d479d61a9"
+  integrity sha512-0pqK5hIDTSy07O55sJu86sxqfLHlzoDYn64GyNVhft9unc/7UCQui/s2gpTTwfTpU26YHUDEqL8CT8p5Rl3s6Q==
+  dependencies:
+    linguist-languages "^7.5.1"
+    mem "^8.0.0"
+    php-parser "3.0.2"
+
 "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -16454,6 +16463,11 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linguist-languages@^7.5.1:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.13.0.tgz#9f533f3753861755c7414d57211e0df48bf6c113"
+  integrity sha512-n1X6l+YYbEDtXE9tDr8nYZAgeuKw+qBFvYGzIGltw3Z3oJwS+4vyVtFG5UFa71kvmPWMS3RT/yB95RWzD7MrVQ==
+
 lint-staged@^10.4.0, lint-staged@^10.5.1, lint-staged@^10.5.4:
   version "10.5.4"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.5.4.tgz#cd153b5f0987d2371fc1d2847a409a2fe705b665"
@@ -19735,6 +19749,11 @@ phin@^2.9.1:
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/phin/-/phin-2.9.3.tgz#f9b6ac10a035636fb65dfc576aaaa17b8743125c"
   integrity sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==
+
+php-parser@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.0.2.tgz#a86dbbc110e57378cba71ab4cd9b0d18f3872ac3"
+  integrity sha512-a7y1+odEGsceLDLpu7oNyspZ0pK8FMWJOoim4/yd82AtnEZNLdCLZ67arnOQZ9K0lHJiSp4/7lVUpGELVxE14w==
 
 physical-cpu-count@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Package(s) involved
* `@amazeelabs/prettier-config`
* `amazee/silverback-cli` (as the first lab rat)

## Description of changes
Add and configure the official php plugin for prettier (https://github.com/prettier/plugin-php). Reformatted source code for `silverback-cli` to test it.

## Motivation and context
I love prettier, and I hate formatting php files.
It's not 100% Drupal standard, but the joy of nicely formatted php on save outweighs that for me.

