### PR TITLE
Managed forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,3 +134,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn lerna publish -y
+
+      - name: Update forks
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: node forks.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,6 @@ jobs:
         run: yarn lerna publish -y
 
       - name: Update forks
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node forks.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .npmrc
+.forks-tmp

--- a/apps/silverback-website/docs/drupal/patching.mdx
+++ b/apps/silverback-website/docs/drupal/patching.mdx
@@ -1,0 +1,74 @@
+# Patching modules
+
+Patching or forking contributed modules is discouraged, but sometimes it can not
+be avoided. To mitigate the negative effects, we at least try to keep all
+patches in a central place instead of scattering them across projects, so we can
+test them once to roll them out everywhere.
+
+## Should I patch?
+
+General rule:
+
+> A patch is only valid, when it is contributed to the origin package and has a
+realistic chance to be merged into upstream.
+
+## Consider all alternatives
+
+Drupal has a lot of levers to adjust contributed code aside from patching or
+forking it.
+
+1. *Replace service classes:* Since most of the business logic has been moved
+into services by now, the Drupal dependency injection container makes it easy to
+replace parts of it by inserting a [custom service provider].
+2. *Alter hook execution:* [`hook_module_implements_alter`][hook_module_implements_alter]
+allows to us to adjust execution of hook implementations. This way we can
+remove, replace and reorder hooks provided by core and contributed modules.
+3. *Theme overrides:* Kind of obvious, but a derived admin theme helps with
+polishing some rough patches.
+4. *Library overrides:* Drupal's library system allows themes to selectively
+remove or replace [Javascript or CSS assets][libraries-override].
+
+[hook_module_implements_alter]: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_module_implements_alter/9.1.x
+[custom service provider]: https://www.drupal.org/docs/drupal-apis/services-and-dependency-injection/altering-existing-services-providing-dynamic
+[libraries-override]: https://www.drupal.org/docs/theming-drupal/adding-stylesheets-css-and-javascript-js-to-a-drupal-theme#override-extend
+
+## I really need to patch
+
+1. If it's your own patch, make sure it's uploaded to the issue and has the
+maintainers' attention.
+2. Add the module and the patch to [`silverback-drupal`][silverback-drupal]
+3. Add Cypress integration tests for what the patch is supposed to fix.
+4. Create a new GitHub repository in the `AmazeeLabs` namespace with the modules
+name, but prefixed with `fork-`. E.g.: `https://github.com/AmazeeLabs/fork-gutenberg`
+5. Add the path to the module patched by composer and the repository url to
+[`forks.json`][forks].
+6. Open a pull request that contains the reasoning why we need this patch, and
+a link to the drupal.org issue.
+7. When the pull request is merged, the patched version of the module will be
+pushed to the repository you provided. Add a new packagist project for that
+repository.
+8. Add the patched module to your project using `composer require AmazeeLabs/fork-[module]`.
+
+[silverback-drupal]: https://github.com/AmazeeLabs/silverback-mono/tree/development/apps/silverback-drupal
+[forks]: https://github.com/AmazeeLabs/silverback-mono/blob/managed-forks/forks.json
+
+
+## What happens then?
+
+The silverback repository as well as all client projects use [renovate] to
+update dependencies automatically. Whenever the upstream version of the module
+changes, the release process will automatically attempt to re-apply the patch
+and run your test against it.
+
+If the re-application is successful, silverback will automatically push and
+update to the `fork-*` repository, and the client projects will receive it on
+their next [renovate]-run.
+
+If it fails, the patch needs to be re-rolled and committed to
+`silverback-drupal`. From there the automatic process kicks in again and
+distributes it to all projects that depend on the patched module.
+
+[renovate]: https://github.com/renovatebot/renovate
+
+> A patch is still a liability, and it is high priority to keep the amount
+> of patches to a minimum and actively try to merge them into upstream.

--- a/forks.js
+++ b/forks.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const forks = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'forks.json')).toString());
+const tmpDir = path.resolve(__dirname, '.forks-tmp');
+
+if (fs.existsSync(tmpDir)) {
+  execSync(`rm -rf ${tmpDir}`);
+}
+
+fs.mkdirSync(tmpDir);
+
+process.chdir(tmpDir);
+
+forks.map(fork => {
+  const dir = new URL(fork.repository).pathname.substr(1);
+  execSync(`mkdir -p AmazeeLabs`);
+  execSync(`mkdir -p tmp/AmazeeLabs`);
+  execSync(`git clone ${fork.repository} tmp/${dir}`);
+  execSync(`cp -R ../${fork.path} ${dir}`);
+  execSync(`rm -rf ${dir}/.git`);
+  execSync(`cp -R tmp/${dir}/.git ${dir}/.git`)
+  process.chdir(path.resolve(tmpDir, dir));
+  const result = execSync(`git status --porcelain`).toString();
+  console.log(result);
+  if (result.trim().length > 0) {
+    execSync(`git add -f *`);
+    fs.readdirSync(path.resolve(tmpDir, dir)).map(file => {
+      if (file.substr(0, 1) === '.') {
+        execSync(`git add -f ${file}`);
+      }
+    })
+    execSync(`git commit -m "chore: updated fork"`);
+    execSync(`git push`);
+  }
+  process.chdir(tmpDir);
+});

--- a/forks.js
+++ b/forks.js
@@ -4,35 +4,59 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
-const forks = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'forks.json')).toString());
 const tmpDir = path.resolve(__dirname, '.forks-tmp');
 
+// Make sure there is an empty temp directory for managing forks.
 if (fs.existsSync(tmpDir)) {
   execSync(`rm -rf ${tmpDir}`);
 }
-
 fs.mkdirSync(tmpDir);
 
 process.chdir(tmpDir);
+
+// Read forks information from `forks.json`.
+const forks = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'forks.json')).toString());
 
 forks.map(fork => {
   const dir = new URL(fork.repository).pathname.substr(1);
   execSync(`mkdir -p AmazeeLabs`);
   execSync(`mkdir -p tmp/AmazeeLabs`);
+  // Clone the fork to get it's .git directory.
   execSync(`git clone ${fork.repository} tmp/${dir}`);
+  // Copy the patched version of the target package.
   execSync(`cp -R ../${fork.path} ${dir}`);
+  // Remove the original .git directory and replace it with the one from the
+  // fork.
   execSync(`rm -rf ${dir}/.git`);
+  // Apply the git history of the fork to the patched package.
   execSync(`cp -R tmp/${dir}/.git ${dir}/.git`)
+
   process.chdir(path.resolve(tmpDir, dir));
+  // Bail out if the directory does not contain a composer package.
+  if (!fs.existsSync('composer.json')) {
+    console.warn(`${fork.path} is not a composer package`);
+    return;
+  }
+
+  // Change the composer package name.
+  const composerJson = JSON.parse(fs.readFileSync('composer.json').toString());
+  composerJson.name = dir.toLocaleLowerCase();
+  fs.writeFileSync('composer.json', JSON.stringify(composerJson, null, 2));
+
+  // Check if there are changes, else we don't have to commit anything.
   const result = execSync(`git status --porcelain`).toString();
   console.log(result);
+
   if (result.trim().length > 0) {
+    // Stage all changes.
     execSync(`git add -f *`);
     fs.readdirSync(path.resolve(tmpDir, dir)).map(file => {
       if (file.substr(0, 1) === '.') {
         execSync(`git add -f ${file}`);
       }
     })
+
+    // Commit and push to the target repository.
     execSync(`git commit -m "chore: updated fork"`);
     execSync(`git push`);
   }

--- a/forks.json
+++ b/forks.json
@@ -1,0 +1,6 @@
+[
+  {
+    "path": "apps/silverback-drupal/web/modules/contrib/gutenberg",
+    "repository": "https://github.com/AmazeeLabs/fork-gutenberg"
+  }
+]


### PR DESCRIPTION
## Description of changes
Added a workflow to managed patched packages. There is a central `forks.json` that maintains a path within silverback-mono with another repository. On release, whatever is in this path (in the first example the patched version of drupal/gutenberg) is pushed to the repository. Other projects then can simply apply the patched version directly and will receive updates throught renovatebot.

## Motivation and context
We want to centrally manage patches and patched versions of Drupal modules, so patches don't have to be maintained on every project separately.

## Proposed workflow

When a Drupal module has to be patched, it is added (along with the patches) to `silverback-drupal` and ideally covered with some tests. We also create a separate repository, prefixed with `fork-` (like https://github.com/AmazeeLabs/fork-gutenberg). Then the path of the patched module in `silverback-drupal` as well as the repository are added to `forks.json`. From there CI takes over and will push a new commit whenever our fork changes somehow. Either because the base package was updated by renovate, or the applied patches change. The fork then can simply be published under the `amazeelabs` namespace on packagist. Client projects can require the module via `composer require amazeelabs/fork-gutenberg` and receive updates from there.


## How does it work?

1. `silverback-drupal` requires a module and applies patches (standard composer workflow)
2. the release process of this repository clones the "target repository" and commits all content from within the module (which has already been patched)
3. the target repository is automatically updated, and therefore the packagist mirror
4. client projects only require the mirror (e.g. `amazeelabs/fork-gutenberg`)

Related issue: #200 