### PR TITLE
feat(recipes): allow dynamic file names for file blocks

### DIFF
--- a/packages/npm/@amazeelabs/recipes/helpers/files.ts
+++ b/packages/npm/@amazeelabs/recipes/helpers/files.ts
@@ -48,13 +48,14 @@ export const file = (
 };
 
 export const __writeFile = (source: string, target: string) => {
-  const targetPath = path.resolve(process.cwd(), target);
+  const targetName = renderString(target, _vars);
+  const targetPath = path.resolve(process.cwd(), targetName);
   const sourcePath = path.resolve(__dirname, '../files', source);
   if (fs.existsSync(target)) {
     fs.rmSync(targetPath);
   }
   const content = renderString(fs.readFileSync(sourcePath).toString(), _vars);
   fs.writeFileSync(targetPath, content);
-  log.info(`updated ${chalk.cyan(target)}`);
-  log.silly(`contents of ${chalk.cyan(target)}:\n${content}\n`);
+  log.info(`updated ${chalk.cyan(targetName)}`);
+  log.silly(`contents of ${chalk.cyan(targetName)}:\n${content}\n`);
 };

--- a/packages/npm/@amazeelabs/recipes/recipes/create-monorepo.ts.md
+++ b/packages/npm/@amazeelabs/recipes/recipes/create-monorepo.ts.md
@@ -180,7 +180,7 @@ $$.vars({
 ```
 
 ```markdown
-<!-- |-> README.md -->
+|-> README.md
 
 # {{projectName}}
 


### PR DESCRIPTION
## Package(s) involved
`@amazeelabs/recipes`

## Description of changes
Allow dynamic file names for template file blocks.

```php
<?php
// |-> {{module}}.module
...
```
