### PR TITLE
Gatsby: Receive build notifications from Gatsby Cloud

### DIFF
--- a/apps/silverback-drupal/package.json
+++ b/apps/silverback-drupal/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@-amazeelabs/silverback-cli": "^2.6.0",
     "@-amazeelabs/silverback_gatsby": "^1.2.1",
-    "@-drupal/cypress": "^2.3.10"
+    "@-drupal/cypress": "^2.3.10",
+    "@-drupal/gatsby_build_monitor": "^1.1.1"
   }
 }

--- a/apps/silverback-gatsby/cypress/integration/build-status.ts
+++ b/apps/silverback-gatsby/cypress/integration/build-status.ts
@@ -6,7 +6,7 @@ describe('Test Gatsby Build Monitor integration', () => {
     cy.get('#edit-name').type('admin');
     cy.get('#edit-pass').type('admin');
     cy.get('#edit-submit').click();
-    cy.contains('a', 'Gatsby is ready');
+    cy.contains('a', 'Website is ready');
 
     cy.visit(`${drupalUrl}/node/add/page`);
     cy.get('#edit-title-0-value').type('New page');
@@ -16,10 +16,10 @@ describe('Test Gatsby Build Monitor integration', () => {
 
     // Give it few seconds to receive the status.
     cy.wait(3_000);
-    cy.contains('a', 'Gatsby is building');
+    cy.contains('a', 'Website is building');
 
     cy.wait(rebuildDelay);
-    cy.contains('a', 'Gatsby is ready');
+    cy.contains('a', 'Website is ready');
 
     cy.visit(`${drupalUrl}/admin/reports/gatsby-build-logs`);
     cy.get('.view-gatsby-build-monitor-logs table td').should(

--- a/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.module
+++ b/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.module
@@ -14,13 +14,24 @@ function gatsby_build_monitor_toolbar() {
 
   switch (_gatsby_build_monitor_state()) {
     case 'idle':
-      $state = t('Gatsby is ready');
+      $state = t('Website is ready');
       break;
     case 'building':
-      $state = t('Gatsby is building');
+      $state = t('Website is building');
+      break;
+    case 'failure':
+      $state = t('Website build failed');
       break;
     default:
-      $state = t('Gatsby status is unknown');
+      $state = t('Website status is unknown');
+  }
+
+  $attributes = [
+    'class' => ['gatsby-build-monitor-state'],
+  ];
+  $timestamp = \Drupal::state()->get('gatsby_build_monitor.state_updated');
+  if ($timestamp) {
+    $attributes['title'] = \Drupal::service('date.formatter')->format($timestamp, 'custom', 'Y-m-d H:i:s');
   }
 
   return [
@@ -30,9 +41,7 @@ function gatsby_build_monitor_toolbar() {
         '#type' => 'link',
         '#title' => $state,
         '#url' => $url,
-        '#attributes' => [
-          'class' => ['gatsby-build-monitor-state'],
-        ],
+        '#attributes' => $attributes,
         '#cache' => [
           'max-age' => 0,
         ],
@@ -49,14 +58,15 @@ function gatsby_build_monitor_toolbar() {
  * Sets or returns Gatsby rebuild state.
  *
  * @param string|null $state
- *   Values: "idle" or "building".
+ *   Values: "idle" (means success), "building" or "failure".
  *
  * @return void|string
- *   Values: "idle", "building" or "unknown".
+ *   Values: "idle" (means success), "building", "failure" or "unknown".
  */
 function _gatsby_build_monitor_state($state = NULL) {
   if ($state === NULL) {
     return \Drupal::state()->get('gatsby_build_monitor.state') ?? 'unknown';
   }
   \Drupal::state()->set('gatsby_build_monitor.state', $state);
+  \Drupal::state()->set('gatsby_build_monitor.state_updated', \Drupal::time()->getRequestTime());
 }

--- a/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.routing.yml
+++ b/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.routing.yml
@@ -15,3 +15,13 @@ gatsby_build_monitor.get_state:
   methods: ['POST']
   requirements:
     _permission: 'access gatsby build status'
+
+gatsby_build_monitor.gatsby_notifications:
+  path: '/gatsby-build-monitor/gatsby-cloud-notifications/{token}/{state}'
+  defaults:
+    _controller: '\Drupal\gatsby_build_monitor\Controller::gatsbyCloudNotifications'
+  methods: ['POST']
+  requirements:
+    # The token is checked in the controller.
+    _access: 'TRUE'
+    state: '^(build-success|build-failure|deploy-success|deploy-failure)$'

--- a/packages/composer/drupal/gatsby_build_monitor/js/state.js
+++ b/packages/composer/drupal/gatsby_build_monitor/js/state.js
@@ -3,24 +3,36 @@
     $.ajax({
       type: "post",
       url: Drupal.url("gatsby-build-monitor/get-state"),
-      success: function (state) {
+      success: function (data) {
         var text;
-        switch (state) {
+        switch (data.state) {
           case "idle":
-            text = Drupal.t("Gatsby is ready");
+            text = Drupal.t("Website is ready");
             break;
           case "building":
-            text = Drupal.t("Gatsby is building");
+            text = Drupal.t("Website is building");
+            break;
+          case "failure":
+            text = Drupal.t("Website build failed");
             break;
           default:
-            text = Drupal.t("Gatsby status is unknown");
+            text = Drupal.t("Website status is unknown");
         }
-        $(".gatsby-build-monitor-state").text(text);
+        var $state = $(".gatsby-build-monitor-state");
+        $state.text(text);
+        if (data.timestamp) {
+          $state.attr(
+            "title",
+            new Date(data.timestamp * 1000).toLocaleString()
+          );
+        } else {
+          $state.removeAttr("title");
+        }
       },
       error: function () {
-        $(".gatsby-build-monitor-state").text(
-          Drupal.t("Gatsby status is unknown")
-        );
+        var $state = $(".gatsby-build-monitor-state");
+        $state.text(Drupal.t("Website status is unknown"));
+        $state.removeAttr("title");
       },
     });
   }


### PR DESCRIPTION
## Package(s) involved

drupal/gatsby_build_monitor

## Description of changes

- Receive build notifications from Gatsby Cloud
- Change the wording in UI ("Gatsby" to "Website")
- Add a new state: "failure"

## How has this been tested?
Locally. The old mode (receive status updates from gatsby-plugin-build-monitor) is still covered with tests.
