### PR TITLE
Gatsby: Integrate silverback_gatsby with gatsby_build_monitor

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTrigger.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTrigger.php
@@ -52,6 +52,13 @@ class GatsbyUpdateTrigger implements GatsbyUpdateTriggerInterface {
             ],
             'json' => ['buildId' => $id],
           ]);
+          if (
+            \Drupal::moduleHandler()->moduleExists('gatsby_build_monitor') &&
+            // This detects the "build" webhook.
+            strpos($url, '/data_source/publish/') !== FALSE
+          ) {
+            _gatsby_build_monitor_state('building');
+          }
         } catch (RequestException $exc) {
           $this->messenger->addError('Could not send build notification to server "' . $server . '".');
           $this->messenger->addError($exc->getMessage());


### PR DESCRIPTION
## Package(s) involved

- composer/amazeelabs/silverback_gatsby
- composer/drupal/gatsby_build_monitor

## Description of changes

`silverback_gatsby` now updates the `gatsby_build_monitor` status when triggering a Gatsby build.

## How has this been tested?
Not tested.
