### PR TITLE
feat(gutenberg): add shared gutenberg module

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/composer.json
+++ b/packages/composer/amazeelabs/silverback_gutenberg/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "amazeelabs/silverback_gutenberg",
+  "type": "drupal-module",
+  "version": "1.0.0",
+  "description": "Adjusts Gutenberg for Amazee Labs needs.",
+  "homepage": "https://github.com/AmazeeLabs/silverback-mono/tree/development/packages/composer/amazeelabs/silverback_gutenberg#readme",
+  "license": "GPL-2.0+"
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/css/gutenberg-tweaks.css
+++ b/packages/composer/amazeelabs/silverback_gutenberg/css/gutenberg-tweaks.css
@@ -1,0 +1,17 @@
+/* There is no other way to disable the columns amount slider. */
+.components-range-control {
+  display: none;
+}
+
+/* Hide the Upload button as it skips the media edit form (which may cause
+required fields to be left blank). Users still can upload new files via the
+media dialog. */
+.block-editor-media-placeholder .components-form-file-upload {
+  display: none;
+}
+
+/* Hide the "Welcome to Gutenberg" overlay, since it is annoying and messes
+with cypress tests.*/
+.components-modal__screen-overlay {
+  display: none !important;
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/js/base.js
+++ b/packages/composer/amazeelabs/silverback_gutenberg/js/base.js
@@ -1,0 +1,24 @@
+var silverbackGutenbergUtils = {
+  sanitizeText: function (text) {
+    return (
+      text
+        // When copying text from Word, HTML comments are escaped. So we get this:
+        // ...<br>&lt;!-- /* Font Definitions */ @font-face {...} --&gt;<br>...
+        // Unescape them back.
+        .replace("&lt;!--", "<!--")
+        .replace("--&gt;", "-->")
+        // Now clean all HTML tags.
+        .replace(/(<([^>]+)>)/gi, "")
+    );
+  },
+
+  setPlainTextAttribute: function (props, name, text) {
+    const sanitizedText = silverbackGutenbergUtils.sanitizeText(text);
+    props.setAttributes({
+      [name]: sanitizedText,
+    });
+    if (text !== sanitizedText) {
+      props.setState({ rerender: Date.now() });
+    }
+  },
+};

--- a/packages/composer/amazeelabs/silverback_gutenberg/js/gutenberg-tweaks.js
+++ b/packages/composer/amazeelabs/silverback_gutenberg/js/gutenberg-tweaks.js
@@ -1,0 +1,66 @@
+drupalSettings.gutenberg._listeners.init.push(
+  // For all block types:
+  function () {
+    var blockTypes = wp.blocks.getBlockTypes();
+    for (var i = 0; i < blockTypes.length; i++) {
+      if (!blockTypes[i].supports) {
+        blockTypes[i].supports = {};
+      }
+      // Disable "Additional CSS class(es)" section.
+      blockTypes[i].supports.customClassName = false;
+      // Disable align options.
+      blockTypes[i].supports.align = false;
+    }
+  },
+
+  // Workaround for https://github.com/WordPress/gutenberg/issues/19815
+  function () {
+    var coreColumnsAllowed =
+      drupalSettings.editor.formats.gutenberg.editorSettings.allowedBlocks[
+        "core/columns"
+      ];
+    var coreImageAllowed =
+      drupalSettings.editor.formats.gutenberg.editorSettings.allowedBlocks[
+        "core/image"
+      ];
+    if (coreColumnsAllowed && !coreImageAllowed) {
+      var coreColumnsBlock = wp.blocks.getBlockType("core/columns");
+      // Remove core/image from the example.
+      coreColumnsBlock.example.innerBlocks[0].innerBlocks.splice(1, 1);
+    }
+  },
+
+  // Remove most of the columns options.
+  function () {
+    var coreColumnsBlock = wp.blocks.getBlockType("core/columns");
+    coreColumnsBlock.supports.inserter = false;
+    coreColumnsBlock.supports.align = false;
+    coreColumnsBlock.supports.__experimentalColor = false;
+  },
+
+  // We never want some of the format options.
+  function () {
+    wp.richText.unregisterFormatType("core/image");
+    wp.richText.unregisterFormatType("core/text-color");
+  },
+
+  // We don't want table styles.
+  function () {
+    wp.blocks.unregisterBlockStyle("core/table", "regular");
+    wp.blocks.unregisterBlockStyle("core/table", "stripes");
+  },
+
+  // Disable "HTML anchor" for all blocks except for the custom heading.
+  function () {
+    var blockTypes = wp.blocks.getBlockTypes();
+    for (var i = 0; i < blockTypes.length; i++) {
+      if (!blockTypes[i].supports) {
+        blockTypes[i].supports = {};
+      }
+
+      if (blockTypes[i].name !== "custom/heading") {
+        blockTypes[i].supports.anchor = false;
+      }
+    }
+  }
+);

--- a/packages/composer/amazeelabs/silverback_gutenberg/package.json
+++ b/packages/composer/amazeelabs/silverback_gutenberg/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@-amazeelabs/silverback_gutenberg",
+  "version": "1.0.0",
+  "author": "Amazee Labs <development@amazeelabs.com>",
+  "publishConfig": {
+    "access": "public",
+    "registry": "http://localhost:4873",
+    "repository": "git@github.com:AmazeeLabs/silverback_gutenberg.git",
+    "branch": "main"
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
@@ -1,0 +1,49 @@
+<?php
+
+function hook_silverback_gutenberg_link_processor_block_attributes_alter(
+  array &$attributes,
+  string $blockName,
+  callable $processUrlCallback
+) {
+  if ($blockName === 'custom/my-block' && isset($attributes['urls'])) {
+    foreach ($attributes['urls'] as $key => $url) {
+      $attributes['urls'][$key] = $processUrlCallback($url);
+    }
+  }
+}
+
+function hook_silverback_gutenberg_link_processor_inbound_link_alter(
+  \DOMElement $link,
+  \Drupal\silverback_gutenberg\LinkProcessor $linkProcessor
+) {
+  // No idea.
+}
+
+function hook_silverback_gutenberg_link_processor_outbound_link_alter(
+  \DOMElement $link,
+  \Drupal\Core\Language\LanguageInterface $language,
+  \Drupal\silverback_gutenberg\LinkProcessor $linkProcessor
+) {
+  $url = $link->getAttribute('href');
+  if ($url && $linkProcessor->isExternal($url)) {
+    $link->setAttribute('target', '_blank');
+    $link->setAttribute('rel', 'noreferrer');
+  }
+}
+
+function hook_silverback_gutenberg_link_processor_inbound_url_alter(
+  string &$url,
+  \Drupal\silverback_gutenberg\LinkProcessor $linkProcessor
+) {
+  // No idea.
+}
+
+function hook_silverback_gutenberg_link_processor_outbound_url_alter(
+  string &$url,
+  \Drupal\Core\Language\LanguageInterface $language,
+  \Drupal\silverback_gutenberg\LinkProcessor $linkProcessor
+) {
+  if (preg_match('#^/media/([0-9]+)/edit$#', $url, $matches)) {
+    // For example, turn $url into a direct file link.
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.info.yml
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.info.yml
@@ -1,0 +1,9 @@
+name: Silverback Gutenberg
+type: module
+description: 'Adjusts Gutenberg for Amazee Labs needs.'
+package: Silverback
+core: 8.x
+core_version_requirement: ^8 || ^9
+
+dependencies:
+  - gutenberg:gutenberg (>=8.x-2.0-beta2)

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.libraries.yml
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.libraries.yml
@@ -1,0 +1,13 @@
+tweaks:
+  js:
+    js/gutenberg-tweaks.js: {  }
+  css:
+    theme:
+      css/gutenberg-tweaks.css: { }
+  dependencies:
+    - core/drupalSettings
+
+base:
+  version: VERSION
+  js:
+    js/base.js: {}

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
@@ -1,0 +1,75 @@
+<?php
+
+use Drupal\Core\Asset\AttachedAssetsInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\node\NodeInterface;
+use Drupal\silverback_gutenberg\Utils;
+
+/**
+ * Implements hook_js_settings_alter().
+ */
+function silverback_gutenberg_js_settings_alter(array &$settings, AttachedAssetsInterface $assets) {
+  if (isset($settings['gutenberg'])) {
+    if (!isset($settings['gutenberg']['theme-support'])) {
+      $settings['gutenberg']['theme-support'] = [];
+    }
+    $settings['gutenberg']['theme-support'] = [
+
+        // Disable text colors.
+        'colors' => [],
+        'disableCustomColors' => TRUE,
+
+        // Disable typography.
+        'fontSizes' => [],
+        'disableCustomFontSizes' => TRUE,
+        '__experimentalDisableCustomLineHeight' => TRUE,
+        '__experimentalDisableDropCap' => TRUE,
+
+      ] + $settings['gutenberg']['theme-support'];
+  }
+}
+
+/**
+ * Implements hook_library_info_alter().
+ */
+function silverback_gutenberg_library_info_alter(&$libraries, $extension) {
+  if ($extension === 'gutenberg') {
+    $libraries['edit-node']['dependencies'][] = 'silverback_gutenberg/tweaks';
+  }
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function silverback_gutenberg_form_node_form_alter(&$form, FormStateInterface $form_state) {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $form_state->getFormObject()->getEntity();
+  foreach (Utils::getGutenbergFields($node) as $field) {
+      if (is_string($form[$field]['widget'][0]['#default_value'])) {
+        $form[$field]['widget'][0]['#default_value'] =
+          Utils::linkProcessor()->processLinks(
+            $form[$field]['widget'][0]['#default_value'],
+            'outbound',
+            \Drupal::languageManager()->getLanguage(
+              $form['langcode']['widget'][0]['value']['#default_value']
+            )
+          );
+      }
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function silverback_gutenberg_node_presave(NodeInterface $node) {
+  foreach (Utils::getGutenbergFields($node) as $field) {
+    $field = $node->get($field);
+    if (is_string($field->value)) {
+      $field->value = Utils::linkProcessor()->processLinks(
+        $field->value,
+        'inbound'
+      );
+    }
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.services.yml
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.services.yml
@@ -1,0 +1,4 @@
+services:
+  Drupal\silverback_gutenberg\LinkProcessor:
+    class: Drupal\silverback_gutenberg\LinkProcessor
+    arguments: ['@path_alias.manager', '@config.factory', '@request_stack', '@module_handler']

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Drupal\silverback_gutenberg;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\StreamWrapper\PublicStream;
+use Drupal\Core\Url;
+use Drupal\path_alias\AliasManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class LinkProcessor {
+
+  protected AliasManagerInterface $pathAliasManager;
+  protected ConfigFactoryInterface $configFactory;
+  protected ModuleHandlerInterface $moduleHandler;
+  protected string $currentHost;
+  protected string $currentPort;
+
+  public function __construct(
+    AliasManagerInterface $pathAliasManager,
+    ConfigFactoryInterface $configFactory,
+    RequestStack $requestStack,
+    ModuleHandlerInterface $moduleHandler
+  ) {
+    $this->pathAliasManager = $pathAliasManager;
+    $this->configFactory = $configFactory;
+    $this->moduleHandler = $moduleHandler;
+    $this->currentHost = $requestStack->getCurrentRequest()->getHost();
+    $this->currentPort = $requestStack->getCurrentRequest()->getPort();
+  }
+
+  public function processLinks(string $html, string $direction, LanguageInterface $language = NULL) {
+    if (!in_array($direction, ['inbound', 'outbound'], TRUE)) {
+      throw new \Exception('Unknown direction: "' . $direction . '".');
+    }
+    if ($direction === 'outbound' && !$language) {
+      throw new \Exception('$language is required for "outbound" direction.');
+    }
+
+    $document = Html::load($html);
+
+    foreach ($document->getElementsByTagName('a') as $link) {
+      $this->processLink($link, $direction, $language);
+    }
+
+    $xpath = new \DOMXpath($document);
+    $comments = $xpath->query('//comment()');
+    /** @var \DOMComment $comment */
+    foreach ($comments as $comment) {
+      if (preg_match('/^(\s*wp:)(\S+)(\s*)({.*})(\s*\/\s*)$/s', $comment->textContent, $matches)) {
+        $blockName = $matches[2];
+        $json = $matches[4];
+        $attributes = json_decode($json, TRUE);
+        $callback = fn(string $url) => $this->processUrl($url, $direction, $language);
+        $this->moduleHandler->alter(
+          'silverback_gutenberg_link_processor_block_attributes',
+          $attributes,
+          $blockName,
+          $callback
+        );
+        $jsonNew = json_encode($attributes);
+        if ($jsonNew !== $json) {
+          $comment->textContent = $matches[1] . $blockName . $matches[3] . $jsonNew . $matches[5];
+        }
+      }
+    }
+
+    $processed = Html::serialize($document);
+
+    // This entity kills Gutenberg.
+    $processed = str_replace('&#13;', "\r", $processed);
+
+    return $processed;
+  }
+
+  public function isExternal(string $url): bool {
+    $parts = parse_url($url);
+    if (!isset($parts['host'])) {
+      return FALSE;
+    }
+    if (
+      $parts['host'] !== $this->currentHost &&
+      (
+        !isset($parts['port']) ||
+        ($parts['port'] != $this->currentPort)
+      )
+    ) {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  public function isAsset(string $url): bool {
+    $parts = parse_url($url);
+    if (empty($parts['path'])) {
+      return FALSE;
+    }
+    if ($this->isExternal($url)) {
+      // We have no reliable way to check if an external URL is an asset.
+      return FALSE;
+    }
+    if (strpos($parts['path'], '/' . PublicStream::basePath() . '/') === 0) {
+      return TRUE;
+    }
+    if (strpos($parts['path'], '/system/files') !== FALSE) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  protected function cleanUrl(string $url): string {
+    if ($this->isExternal($url)) {
+      return $url;
+    }
+    $parts = parse_url($url);
+    unset($parts['scheme'], $parts['host'], $parts['port'], $parts['user'], $parts['pass']);
+    return $this->buildUrl($parts);
+  }
+
+  protected function processLink(\DOMElement $link, string $direction, LanguageInterface $language = NULL) {
+    if ($direction === 'outbound' && !$language) {
+      throw new \Exception('$language is required for "outbound" direction.');
+    }
+
+    $href = $link->getAttribute('href');
+    if ($href) {
+      if (!$this->isExternal($href)) {
+        $href = $this->cleanUrl($href);
+      }
+
+      $link->setAttribute('href', $this->processUrl($href, $direction, $language));
+    }
+
+    if ($direction === 'inbound') {
+      $this->moduleHandler->alter('silverback_gutenberg_link_processor_inbound_link', $link, $this);
+    }
+    if ($direction === 'outbound') {
+      $this->moduleHandler->alter('silverback_gutenberg_link_processor_outbound_link', $link, $language, $this);
+    }
+
+  }
+
+  protected function processUrl(string $url, string $direction, LanguageInterface $language = NULL): string {
+    if ($direction === 'outbound' && !$language) {
+      throw new \Exception('$language is required for "outbound" direction.');
+    }
+
+    $parts = parse_url($url);
+
+    if (empty($parts['path'])) {
+
+      // Corrupted URL.
+      return $url;
+    }
+
+    if ($direction === 'inbound') {
+      $path = $this->pathAliasManager->getPathByAlias($parts['path']);
+      if ($path === $parts['path']) {
+        // Try to strip the language prefix.
+        $prefixes = $this->configFactory
+          ->get('language.negotiation')
+          ->get('url.prefixes');
+        $pathLangcode = null;
+        foreach ($prefixes as $langcode => $prefix) {
+          if ('/' . $prefix === $parts['path']) {
+            $withoutPrefix = '/';
+            break;
+          }
+          elseif (strpos($parts['path'], '/' . $prefix . '/') === 0) {
+            $pathLangcode = $langcode;
+            $withoutPrefix = substr($parts['path'], strlen($prefix) + 1);
+            break;
+          }
+        }
+        if (!empty($withoutPrefix)) {
+          $path = $this->pathAliasManager->getPathByAlias($withoutPrefix, $pathLangcode);
+        }
+      }
+      if ($path !== $parts['path']) {
+        $parts['path'] = $path;
+      }
+    }
+
+    if ($direction === 'outbound') {
+      if ((strpos($parts['path'], '/') !== 0) && (strpos($parts['path'], '#') !== 0) && (strpos($parts['path'], '?') !== 0)) {
+        /* @see \Drupal\Core\Url::fromUserInput  */
+        $parts['path'] = '/' . $parts['path'];
+      }
+      $pathAlias = Url::fromUserInput($parts['path'])
+        ->setAbsolute(FALSE)
+        ->setOption('language', $language)
+        ->toString(TRUE)
+        ->getGeneratedUrl();
+      if ($pathAlias !== $parts['path']) {
+        $parts['path'] = $pathAlias;
+      }
+    }
+
+    $url = $this->buildUrl($parts);
+
+    if ($direction === 'inbound') {
+      $this->moduleHandler->alter('silverback_gutenberg_link_processor_inbound_url', $url, $this);
+    }
+    if ($direction === 'outbound') {
+      $this->moduleHandler->alter('silverback_gutenberg_link_processor_outbound_url', $url, $language, $this);
+    }
+
+    return $url;
+  }
+
+  protected function buildUrl(array $parts): string {
+    return (isset($parts['scheme']) ? "{$parts['scheme']}:" : '') .
+      ((isset($parts['user']) || isset($parts['host'])) ? '//' : '') .
+      (isset($parts['user']) ? "{$parts['user']}" : '') .
+      (isset($parts['pass']) ? ":{$parts['pass']}" : '') .
+      (isset($parts['user']) ? '@' : '') .
+      (isset($parts['host']) ? "{$parts['host']}" : '') .
+      (isset($parts['port']) ? ":{$parts['port']}" : '') .
+      (isset($parts['path']) ? "{$parts['path']}" : '') .
+      (isset($parts['query']) ? "?{$parts['query']}" : '') .
+      (isset($parts['fragment']) ? "#{$parts['fragment']}" : '');
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Service/MediaService.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Service/MediaService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\Service;
+
+use Drupal\gutenberg\Service\MediaService as Original;
+use Drupal\media_library\MediaLibraryState;
+
+class MediaService extends Original {
+
+  public function renderDialog(array $media_types) {
+    // Instead of guessing media types as the parent method does, use given
+    // media types as media type IDs. So the blocks have full control over
+    // allowed media types.
+    // This behavior is proposed here:
+    // https://www.drupal.org/project/gutenberg/issues/3107837#comment-14119332
+    $allowed_media_type_ids = $media_types;
+
+    $buildUi = $this->builder->buildUi(
+      MediaLibraryState::create('gutenberg.media_library.opener', array_unique($allowed_media_type_ids), reset($allowed_media_type_ids), 1)
+    );
+    $this->moduleHandler->alter('gutenberg_media_library_view', $buildUi);
+    return $this->renderer->render($buildUi);
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/SilverbackGutenbergServiceProvider.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/SilverbackGutenbergServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\silverback_gutenberg;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\silverback_gutenberg\Service\MediaService;
+
+class SilverbackGutenbergServiceProvider extends ServiceProviderBase {
+  public function alter(ContainerBuilder $container) {
+    if ($container->has('gutenberg.media_service')) {
+      $definition = $container->getDefinition('gutenberg.media_service');
+      $definition->setClass(MediaService::class);
+    }
+    if ($container->has('webform.message_manager')) {
+      $definition = $container->getDefinition('webform.message_manager');
+      $definition->setClass('Drupal\silverback_gutenberg\WebformMessageManager');
+    }
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Utils.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Utils.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\silverback_gutenberg;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\gutenberg\Controller\UtilsController;
+
+class Utils {
+
+  public static function getGutenbergFields(EntityInterface $entity): array {
+    if (!_gutenberg_is_gutenberg_enabled($entity)) {
+      return [];
+    }
+    if ($entity instanceof FieldableEntityInterface) {
+      $textFields = UtilsController::getEntityTextFields($entity);
+      if (empty($textFields)) {
+        return [];
+      }
+      // At the moment Gutenberg uses the first text field.
+      return [$textFields[0]];
+    }
+    return [];
+  }
+
+  public static function linkProcessor(): LinkProcessor {
+    return \Drupal::service(LinkProcessor::class);
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/WebformMessageManager.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/WebformMessageManager.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\silverback_gutenberg;
+
+use Drupal\webform\WebformMessageManager as Original;
+
+class WebformMessageManager extends Original {
+
+  public function build($key) {
+    $build = parent::build($key);
+
+    if (isset($build['#markup'])) {
+      /** @var \Drupal\silverback_gutenberg\LinkProcessor $linkProcessor */
+      $linkProcessor = \Drupal::service(LinkProcessor::class);
+
+      // Ensure that the redirect links point to correct URLs.
+      $build['#markup'] = $linkProcessor->processLinks($build['#markup'], 'inbound');
+      $build['#markup'] = $linkProcessor->processLinks(
+        $build['#markup'],
+        'outbound',
+        \Drupal::languageManager()->getCurrentLanguage()
+      );
+      $build['#cache']['max-age'] = 0;
+    }
+
+    return $build;
+  }
+
+}


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback_gutenberg`

## Description of changes

Added shared Gutenberg code.

TODO:
- polish hooks (e.g. provide `$originalUrl` as context)
- create recipe for a drupal module containing custom gutenberg blocks
- add a readme
- add tests
- integrate with silverback-drupal/silverback-gatsby

## Motivation and context

We want Gutenberg on other projects.

## How has this been tested?

It was tested with existing tests on the existing project. Also manually.
