### PR TITLE
feat(silverback-cli): follow `drush deploy` behavior

### DIFF
--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
@@ -81,10 +81,12 @@ EOD
 
     if ($installFromCache) {
       $this->executeProcess([$drush, 'updb', '-y', '--cache-clear=0'], $output);
+      $this->executeProcess([$drush, 'cr'], $output);
       if ($configExists && !$noConfigImport) {
         $this->executeProcess([$drush, 'cim', '-y'], $output);
+        $this->executeProcess([$drush, 'cr'], $output);
       }
-      $this->executeProcess([$drush, 'cr'], $output);
+      $this->executeProcess([$drush, 'deploy:hook', '-y'], $output);
     }
     else {
       if ($zipCacheExists) {


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback-cli`

## Description of changes

Make `silverback setup` execute `hook_deploy_NAME`.

## Motivation and context

Drush 10.3.0+ provides [deploy](https://www.drush.org/latest/deploycommand/) command which can be really useful on projects. I suggest that we don't use the command directly, but copy its behavior leaving the `--no-config-import` option (used for [checking for uncommitted config changes](https://github.com/AmazeeLabs/silverback-mono/blob/16dcd2c7dcd7d38bdefe2b7e039929c3a06b9b42/.github/workflows/test.yml#L87)).

## How has this been tested?

With existing tests.
