### PR TITLE
feat(gatsby): export full definition of composable schema

### DIFF
--- a/apps/silverback-drupal/package.json
+++ b/apps/silverback-drupal/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "prepare": "if php -v && [[ -z $LAGOON ]]; then composer install && yarn setup; fi",
+    "prepare": "if php -v && [[ -z $LAGOON ]]; then composer install && yarn setup && drush sgse; fi",
     "start": "source .envrc && cd web && php -S 127.0.0.1:8888 .ht.router.php",
     "setup": "source .envrc && silverback setup",
     "clear": "source .envrc && drush cr",

--- a/apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/graphql/.gitignore
+++ b/apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/graphql/.gitignore
@@ -1,0 +1,1 @@
+*.composed.graphqls

--- a/packages/composer/amazeelabs/silverback_gatsby/composer.json
+++ b/packages/composer/amazeelabs/silverback_gatsby/composer.json
@@ -4,5 +4,12 @@
   "version": "1.0.0",
   "description": "Bridge module between Gatsby and Drupal.",
   "homepage": "https://silverback.netlify.app",
-  "license": "GPL-2.0+"
+  "license": "GPL-2.0+",
+  "extra": {
+    "drush": {
+      "services": {
+        "drush.services.yml": "^10"
+      }
+    }
+  }
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/drush.services.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/drush.services.yml
@@ -1,0 +1,8 @@
+services:
+  silverback_gatsby.commands:
+    class: \Drupal\silverback_gatsby\Commands\SilverbackGatsbyCommands
+    arguments:
+      - '@entity_type.manager'
+      - '@plugin.manager.graphql.schema'
+    tags:
+      - { name: drush.command }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Commands/SilverbackGatsbyCommands.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Commands/SilverbackGatsbyCommands.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Commands;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\silverback_gatsby\GraphQL\ComposableSchema;
+use Drush\Commands\DrushCommands;
+
+/**
+ * A Drush commandfile.
+ *
+ * In addition to this file, you need a drush.services.yml
+ * in root of your module, and a composer.json file that provides the name
+ * of the services file to use.
+ *
+ * See these files for an example of injecting Drupal services:
+ *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
+ *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ */
+class SilverbackGatsbyCommands extends DrushCommands {
+
+  protected EntityTypeManagerInterface $entityTypeManager;
+  protected PluginManagerInterface $schemaPluginManager;
+
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, PluginManagerInterface $schemaPluginManager) {
+    parent::__construct();
+    $this->entityTypeManager = $entityTypeManager;
+    $this->schemaPluginManager = $schemaPluginManager;
+  }
+
+  /**
+   * Export composable schema definitions.
+   *
+   * @command silverback-gatsby:schema-export
+   * @aliases sgse
+   */
+  public function schemaExport() {
+    $servers = $this->entityTypeManager->getStorage('graphql_server')->loadMultiple();
+    foreach ($servers as $server) {
+      /** @var $server \Drupal\graphql\Entity\Server */
+      $config = $server->get('schema_configuration');
+      /** @var \Drupal\graphql\Plugin\SchemaPluginInterface $schema */
+      $schema = $this->schemaPluginManager->createInstance($server->schema, $config[$server->schema]);
+      if (!$schema instanceof ComposableSchema) {
+        continue;
+      }
+      $definition = $schema->getPluginDefinition();
+      $path = drupal_get_path('module', $definition['provider']) . '/graphql/' . $server->id() . '.composed.graphqls';
+      $this->logger->success(dt('Writing definition of %id to %path', [
+        '%id' => $server->id(),
+        '%path' => $path,
+      ]));
+      file_put_contents($path, $schema->getSchemaDefinition());
+    }
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GraphQL/ComposableSchema.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GraphQL/ComposableSchema.php
@@ -39,7 +39,7 @@ class ComposableSchema extends OriginalComposableSchema {
   /**
    * {@inheritDoc}
    */
-  protected function getSchemaDefinition() {
+  public function getSchemaDefinition() {
     $extensions = parent::getExtensions();
 
     // Get all extensions and prepend any defined directives to the schema.
@@ -63,6 +63,7 @@ class ComposableSchema extends OriginalComposableSchema {
     }
 
     $schema[] = file_get_contents($file);
+
     return implode("\n", $schema);
   }
 }


### PR DESCRIPTION
## Package(s) involved
* `silverback_gatsby`

## Description of changes
Add a drush command that will export the full definition of a dynamically composed schema.

## Motivation and context
`graphql-codegen` needs the full schema to generate code for frontend libraries that communicate directly with this API and should not rely on Drupal running to do some basic type checking.
