### PR TITLE
feat: avoid ajax call when tab is not active

### DIFF
--- a/packages/composer/drupal/gatsby_build_monitor/js/state.js
+++ b/packages/composer/drupal/gatsby_build_monitor/js/state.js
@@ -1,5 +1,8 @@
 (function ($) {
   function getState() {
+    if (document.hidden) {
+      return;
+    }
     $.ajax({
       type: "post",
       url: Drupal.url("gatsby-build-monitor/get-state"),


### PR DESCRIPTION
## Package(s) involved
drupal/gatsby_build_monitor

## Description of changes
Only refresh the status on the toolbar when the browser tab is active

## Motivation and context
Reduce the load on requests made to the Drupal backend

## How has this been tested?
Just locally
