### PR TITLE
fix(gatsby): return translation list for untranslated entities

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -1,3 +1,10 @@
+# Directive for the "EntityFeed" plugin.
+directive @entity(
+  type: String!
+  bundle: String
+  access: Boolean
+) on OBJECT
+
 # Directive for the "MenuFeed" plugin.
 directive @menu(
   """
@@ -18,12 +25,6 @@ directive @menu(
   level does not require a full rebuild of every page.
   """
   max_level: Int
-) on OBJECT
-
-# Directive for the "EntityFeed" plugin.
-directive @entity(
-  type: String!
-  bundle: String
 ) on OBJECT
 
 schema {
@@ -99,6 +100,14 @@ type MainMenu @menu(menu_id: "main", item_type: "MenuItem")
 
 type FirstLevelMainMenu @menu(menu_id: "main", item_type: "MenuItem", max_level: 1)
 
+type Feed {
+  typeName: String!
+  translatable: Boolean!
+  singleFieldName: String!
+  listFieldName: String!
+  changes(lastBuild: Int, currentBuild: Int): [String!]!
+}
+
 extend type Query {
   drupalBuildId: Int!
   drupalFeedInfo: [Feed!]!
@@ -108,7 +117,7 @@ extend type Query {
   loadImage(id: String!): Image
   queryImages(offset: Int!, limit: Int!): [Image!]!
 }
-extend type Image implements TranslatableFeedItem {
+extend type Image {
   id: String!
   drupalId: String!
   defaultTranslation: Boolean!
@@ -120,7 +129,7 @@ extend type Query {
   loadTag(id: String!): Tag
   queryTags(offset: Int!, limit: Int!): [Tag!]!
 }
-extend type Tag implements FeedItem {
+extend type Tag {
   id: String!
   drupalId: String!
 }
@@ -129,7 +138,7 @@ extend type Query {
   loadPage(id: String!): Page
   queryPages(offset: Int!, limit: Int!): [Page!]!
 }
-extend type Page implements TranslatableFeedItem {
+extend type Page {
   id: String!
   drupalId: String!
   defaultTranslation: Boolean!
@@ -141,7 +150,7 @@ extend type Query {
   loadGutenbergPage(id: String!): GutenbergPage
   queryGutenbergPages(offset: Int!, limit: Int!): [GutenbergPage!]!
 }
-extend type GutenbergPage implements TranslatableFeedItem {
+extend type GutenbergPage {
   id: String!
   drupalId: String!
   defaultTranslation: Boolean!
@@ -153,7 +162,7 @@ extend type Query {
   loadArticle(id: String!): Article
   queryArticles(offset: Int!, limit: Int!): [Article!]!
 }
-extend type Article implements TranslatableFeedItem {
+extend type Article {
   id: String!
   drupalId: String!
   defaultTranslation: Boolean!
@@ -165,7 +174,7 @@ extend type Query {
   loadMainMenu(id: String!): MainMenu
   queryMainMenus(offset: Int!, limit: Int!): [MainMenu!]!
 }
-extend type MainMenu implements TranslatableFeedItem {
+extend type MainMenu {
   id: String!
   drupalId: String!
   defaultTranslation: Boolean!
@@ -183,7 +192,7 @@ extend type Query {
   loadFirstLevelMainMenu(id: String!): FirstLevelMainMenu
   queryFirstLevelMainMenus(offset: Int!, limit: Int!): [FirstLevelMainMenu!]!
 }
-extend type FirstLevelMainMenu implements TranslatableFeedItem {
+extend type FirstLevelMainMenu {
   id: String!
   drupalId: String!
   defaultTranslation: Boolean!

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
@@ -180,7 +180,9 @@ class EntityFeed extends FeedBase implements ContainerFactoryPluginInterface {
    * {@inheritDoc}
    */
   public function resolveTranslations(): ResolverInterface {
-    return $this->builder->produce('entity_translations')
-      ->map('entity', $this->builder->fromParent());
+    return $this->builder->defaultValue(
+      $this->builder->produce('entity_translations')->map('entity', $this->builder->fromParent()),
+      $this->builder->callback(fn ($value) => [$value])
+    );
   }
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/queries/translatable.gql
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/queries/translatable.gql
@@ -1,5 +1,5 @@
-query {
-  loadPage(id: "1:en") {
+query ($id: String!) {
+  loadPage(id: $id) {
     title
   }
   queryPages(limit: 10, offset: 0) {

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
@@ -42,7 +42,7 @@ class EntityFeedTest extends EntityFeedTestBase {
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheContexts(['user.node_grants:view', 'static:language:en']);
     $metadata->addCacheTags(['node:1', 'node_list']);
-    $this->assertResults($query, [], [
+    $this->assertResults($query, ['id' => '1:en'], [
       'loadPage' => [
         'title' => 'Test',
       ],
@@ -61,4 +61,69 @@ class EntityFeedTest extends EntityFeedTestBase {
       ],
     ], $metadata);
   }
+
+  public function testLanguageNotApplicable() {
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Test',
+      'langcode' => 'zxx',
+    ]);
+    $node->save();
+
+    $query = $this->getQueryFromFile('translatable.gql');
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheContexts(['user.node_grants:view']);
+    $metadata->addCacheTags(['node:1', 'node_list']);
+    $this->assertResults($query, ['id' => '1:zxx'], [
+      'loadPage' => [
+        'title' => 'Test',
+      ],
+      'queryPages' => [
+        [
+          'id' => '1:zxx',
+          'drupalId' => '1',
+          'translations' => [
+            [
+              'defaultTranslation' => true,
+              'langcode' => 'zxx',
+              'title' => 'Test',
+            ],
+          ],
+        ],
+      ],
+    ], $metadata);
+  }
+
+  public function testLanguageNotSpecified() {
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Test',
+      'langcode' => 'und',
+    ]);
+    $node->save();
+
+    $query = $this->getQueryFromFile('translatable.gql');
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheContexts(['user.node_grants:view']);
+    $metadata->addCacheTags(['node:1', 'node_list']);
+    $this->assertResults($query, ['id' => '1:und'], [
+      'loadPage' => [
+        'title' => 'Test',
+      ],
+      'queryPages' => [
+        [
+          'id' => '1:und',
+          'drupalId' => '1',
+          'translations' => [
+            [
+              'defaultTranslation' => true,
+              'langcode' => 'und',
+              'title' => 'Test',
+            ],
+          ],
+        ],
+      ],
+    ], $metadata);
+  }
+
 }


### PR DESCRIPTION
If the language is not specified und not applicable,
the translations field returns the source language
as a single item.

## Package(s) involved
<!-- type the name of the package(s) involved in this pull request -->

## Description of changes
<!-- a brief summary of your code changes -->

## Motivation and context
<!-- why is this PR necessary? is someone experiencing bugs or is a new feature being implemented? -->

## Related Issue(s)
<!-- make sure you link with either an `#issue-number` or directly with `[link-text](url)` -->

## How has this been tested?
<!-- locally? written tests? -->
