### PR TITLE
feat(gatsby): nullify inaccessible entities instead of failing

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/silverback_gatsby_example.module
+++ b/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/silverback_gatsby_example.module
@@ -1,0 +1,16 @@
+<?php
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Implements hook_entity_access().
+ */
+function silverback_gatsby_example_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {
+  // If the entity is labeled "Access denied", we block access. This way we
+  // simulate unpredictable access scenarios in tests.
+  if ($entity->label() === 'Access denied') {
+    return AccessResult::forbidden();
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/ListEntities.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/ListEntities.php
@@ -3,6 +3,7 @@
 namespace Drupal\silverback_gatsby\Plugin\GraphQL\DataProducer;
 
 use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * @DataProducer(
@@ -58,11 +59,12 @@ class ListEntities extends EntityQueryBase {
       $metadata->addCacheableDependency($entity);
     }
 
-    if ($access) {
-      $this->checkAccess($entities);
-    }
-
-    return $entities;
+    return $access
+      ? array_map(
+        fn (EntityInterface $entity) => $entity->access('view') ? $entity : null,
+        $entities
+      )
+      : $entities;
   }
 
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
@@ -148,7 +148,7 @@ class SilverbackGatsbySchemaExtension extends SdlSchemaExtensionPluginBase
     $schema = [
       "extend type Query {",
       "  $singleFieldName(id: String!): $typeName",
-      "  $listFieldName(offset: Int!, limit: Int!): [$typeName!]!",
+      "  $listFieldName(offset: Int!, limit: Int!): [$typeName]!",
     ];
 
     $schema [] = "}";

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
@@ -126,4 +126,25 @@ class EntityFeedTest extends EntityFeedTestBase {
     ], $metadata);
   }
 
+  public function testAccessDenied() {
+    $node = Node::create([
+      'type' => 'page',
+      // A custom entity access hook in silverback_gatsby_example will make
+      // entities with this label inaccessible.
+      'title' => 'Access denied',
+    ]);
+    $node->save();
+
+    $query = $this->getQueryFromFile('translatable.gql');
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheContexts(['user.node_grants:view']);
+    $metadata->addCacheTags(['node:1', 'node_list']);
+    $this->assertResults($query, ['id' => '1:en'], [
+      'loadPage' => null,
+      'queryPages' => [
+        null
+      ],
+    ], $metadata);
+  }
+
 }


### PR DESCRIPTION
## Package(s) involved
* `silverback_gatsby`

## Description of changes
Instead of failing completely, the `list_entities` data producer simply returns a `null` item if an entity is not accessible by the current user.

## Motivation and context
In case of more complex permission models, the build completely failed if the entity query returned an entity that is not accessible. Now it won't fail, but just emit an empty item that is ignored by the source plugin.

## Related Issue(s)
#688 

## How has this been tested?
With a unit test and the integration tests in `silverback-gatsby` should still pass.
