### PR TITLE
chore: run deploy hooks when updating cache

### DIFF
--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
@@ -73,6 +73,7 @@ EOD
         '--account-pass',
         getenv('SB_ADMIN_PASS'),
       ]), $output);
+      $this->executeProcess([$drush, 'deploy:hook', '-y'], $output);
     }
 
     if (!$this->fileSystem->exists($private)) {


### PR DESCRIPTION
This is a follow up for https://github.com/AmazeeLabs/silverback-mono/pull/677

When we run `drush si`, Drupal marks all existing `hook_post_update_NAME` functions as executed. However, this does not happen for `hook_deploy_NAME` functions.

`drush deploy:hook-skip` will be introduced in https://github.com/drush-ops/drush/pull/4739, but for now it's also fine if we just run deploy hooks after `drush si`.

## Package(s) involved
`composer/amazeelabs/silverback-cli`

## How has this been tested?
Locally on a project.