### PR TITLE
Gatsby fails when translations are deleted

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
@@ -127,7 +127,7 @@ class EntityFeed extends FeedBase implements ContainerFactoryPluginInterface {
    * {@inheritDoc}
    */
   public function resolveItem(ResolverInterface $id, ?ResolverInterface $langcode = null): ResolverInterface {
-    $resolver = $this->builder->produce('entity_load')
+    $resolver = $this->builder->produce('fetch_entity')
       ->map('type', $this->builder->fromValue($this->type))
       ->map('bundles', $this->builder->fromValue([$this->bundle]))
       ->map('access', $this->builder->fromValue($this->access))

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use GraphQL\Deferred;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * TODO: Add an option to upstream "entity_load" to return null on missing
+ *       translation and remove this plugin.
+ *
+ * Loads a single entity.
+ *
+ * @DataProducer(
+ *   id = "fetch_entity",
+ *   name = @Translation("Fetch entity"),
+ *   description = @Translation("Loads a single entity."),
+ *   produces = @ContextDefinition("entity",
+ *     label = @Translation("Entity")
+ *   ),
+ *   consumes = {
+ *     "type" = @ContextDefinition("string",
+ *       label = @Translation("Entity type")
+ *     ),
+ *     "id" = @ContextDefinition("string",
+ *       label = @Translation("Identifier"),
+ *       required = FALSE
+ *     ),
+ *     "language" = @ContextDefinition("string",
+ *       label = @Translation("Entity language"),
+ *       required = FALSE
+ *     ),
+ *     "bundles" = @ContextDefinition("string",
+ *       label = @Translation("Entity bundle(s)"),
+ *       multiple = TRUE,
+ *       required = FALSE
+ *     ),
+ *     "access" = @ContextDefinition("boolean",
+ *       label = @Translation("Check access"),
+ *       required = FALSE,
+ *       default_value = TRUE
+ *     ),
+ *     "access_user" = @ContextDefinition("entity:user",
+ *       label = @Translation("User"),
+ *       required = FALSE,
+ *       default_value = NULL
+ *     ),
+ *     "access_operation" = @ContextDefinition("string",
+ *       label = @Translation("Operation"),
+ *       required = FALSE,
+ *       default_value = "view"
+ *     )
+ *   }
+ * )
+ */
+class FetchEntity extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity repository service.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * The entity buffer service.
+   *
+   * @var \Drupal\graphql\GraphQL\Buffers\EntityBuffer
+   */
+  protected $entityBuffer;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @codeCoverageIgnore
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('entity.repository'),
+      $container->get('graphql.buffer.entity')
+    );
+  }
+
+  /**
+   * EntityLoad constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration array.
+   * @param string $pluginId
+   *   The plugin id.
+   * @param array $pluginDefinition
+   *   The plugin definition array.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entityRepository
+   *   The entity repository service.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $entityBuffer
+   *   The entity buffer service.
+   *
+   * @codeCoverageIgnore
+   */
+  public function __construct(
+    array $configuration,
+    $pluginId,
+    array $pluginDefinition,
+    EntityTypeManagerInterface $entityTypeManager,
+    EntityRepositoryInterface $entityRepository,
+    EntityBuffer $entityBuffer
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityRepository = $entityRepository;
+    $this->entityBuffer = $entityBuffer;
+  }
+
+  /**
+   * Resolver.
+   *
+   * @param string $type
+   * @param string $id
+   * @param string|null $language
+   * @param array|null $bundles
+   * @param bool|null $access
+   * @param \Drupal\Core\Session\AccountInterface|null $accessUser
+   * @param string|null $accessOperation
+   * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
+   *
+   * @return \GraphQL\Deferred
+   */
+  public function resolve($type, $id, ?string $language, ?array $bundles, ?bool $access, ?AccountInterface $accessUser, ?string $accessOperation, FieldContext $context) {
+    $resolver = $this->entityBuffer->add($type, $id);
+
+    return new Deferred(function () use ($type, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {
+      if (!$entity = $resolver()) {
+        // If there is no entity with this id, add the list cache tags so that
+        // the cache entry is purged whenever a new entity of this type is
+        // saved.
+        $type = $this->entityTypeManager->getDefinition($type);
+        /** @var \Drupal\Core\Entity\EntityTypeInterface $type */
+        $tags = $type->getListCacheTags();
+        $context->addCacheTags($tags);
+        return NULL;
+      }
+
+      $context->addCacheableDependency($entity);
+      if (isset($bundles) && !in_array($entity->bundle(), $bundles)) {
+        // If the entity is not among the allowed bundles, don't return it.
+        return NULL;
+      }
+
+
+      // Get the correct translation.
+      if (isset($language) && $language !== $entity->language()->getId() && $entity instanceof TranslatableInterface) {
+        if (!$entity->hasTranslation($language)) {
+          return NULL;
+        }
+        $entity = $entity->getTranslation($language);
+        $entity->addCacheContexts(["static:language:{$language}"]);
+      }
+
+      // Check if the passed user (or current user if none is passed) has access
+      // to the entity, if not return NULL.
+      if ($access) {
+        /** @var \Drupal\Core\Access\AccessResultInterface $accessResult */
+        $accessResult = $entity->access($accessOperation, $accessUser, TRUE);
+        $context->addCacheableDependency($accessResult);
+        if (!$accessResult->isAllowed()) {
+          return NULL;
+        }
+      }
+
+      return $entity;
+    });
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
@@ -147,4 +147,37 @@ class EntityFeedTest extends EntityFeedTestBase {
     ], $metadata);
   }
 
+  public function testDeletedTranslation() {
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'English',
+    ]);
+    $node->save();
+    $node->addTranslation('de', ['title' => 'German'])->save();
+    $node->removeTranslation('de');
+    $node->save();
+
+    $query = $this->getQueryFromFile('translatable.gql');
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheContexts(['user.node_grants:view', 'static:language:en']);
+    $metadata->addCacheTags(['node:1', 'node_list']);
+    $this->assertResults($query, ['id' => '1:de'], [
+      'loadPage' => null,
+      'queryPages' => [
+        [
+
+          'id' => '1:en',
+          'drupalId' => '1',
+          'translations' => [
+            [
+              'defaultTranslation' => true,
+              'langcode' => 'en',
+              'title' => 'English',
+            ],
+          ],
+        ],
+      ],
+    ], $metadata);
+  }
+
 }


### PR DESCRIPTION
## Package(s) involved
`silverback_gatsby`

## Description of changes
Add a local version of the `entity_load` data producer that returns `null` for a missing translation.

## Motivation and context
When a translation is deleted, Gatsby attempts to fetch it and _would_ delete it if it returns `null`. But the `entity_load` data producer from the upstream GraphQL module throws an exception in that case. The local replacement returns simply `null` and Gatsby will properly delete the translation from the data store.

## How has this been tested?
Unit test in `silverback_gatsby`.
