### PR TITLE
silverback_cdn_redirect: fix bad redirect cache

### DIFF
--- a/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
@@ -56,6 +56,12 @@ class CdnRedirectController extends ControllerBase {
       return new Response('Circular redirect', 500);
     }
 
-    return new TrustedRedirectResponse($location, $responseCode);
+    $response = new TrustedRedirectResponse($location, $responseCode);
+    // Vary the cache by the full URL. Otherwise it can happen that real backend
+    // request /node/123 leads to frontend https://frontend.site/alias
+    // because the redirect was already cached for /cdn-redirect/node/123
+    // request.
+    $response->getCacheableMetadata()->addCacheContexts(['url']);
+    return $response;
   }
 }


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback_cdn_redirect`

## Description of changes

Fixed caching of the redirect response.

## How has this been tested?

On a project where we found the bug.
