### PR TITLE
fix(gatsby): properly handle null in gatsby result lists

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-sourcing-config.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-sourcing-config.ts
@@ -24,7 +24,10 @@ type TranslatableListResultItem = UntranslatableListResultItem & {
   translations: Array<ListResultItem>;
 };
 
-type ListResultItem = UntranslatableListResultItem | TranslatableListResultItem;
+type ListResultItem =
+  | UntranslatableListResultItem
+  | TranslatableListResultItem
+  | null;
 
 type ITranslatablePaginationAdapter = IPaginationAdapter<
   ListResultItem[],
@@ -44,7 +47,7 @@ export const createSourcingConfig = async (
     item: ListResultItem,
   ): item is TranslatableListResultItem =>
     drupalNodes.filter(
-      (def) => def.type === item.remoteTypeName && def.translatable,
+      (def) => def.type === item?.remoteTypeName && def.translatable,
     ).length > 0;
   // Instruct gatsby-graphql-source-toolkit how to fetch content from Drupal.
   // The LIST_ queries are used to fetch the content when there is no cache. The


### PR DESCRIPTION
Was introduced with: https://github.com/AmazeeLabs/silverback-mono/pull/689

## Package(s) involved
`gatsby-source-silverback`

## Description of changes
#689 introduced possible null entries in Gatsby result lists, but this part of the plugin was not prepared for that yet.
