### PR TITLE
fix: do not process urls with schemes

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
@@ -78,6 +78,9 @@ class LinkProcessor {
 
   public function isExternal(string $url): bool {
     $parts = parse_url($url);
+    if (isset($parts['scheme'])) {
+      return TRUE;
+    }
     if (!isset($parts['host'])) {
       return FALSE;
     }

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
@@ -150,6 +150,19 @@ class LinkProcessorTest extends KernelTestBase {
           ],
         ],
       ],
+      'mailto' => [
+        'inbound' => [
+          ['mailto:someone@example.site' => 'mailto:someone@example.site'],
+        ],
+        'outbound' => [
+          [
+            'mailto:someone@example.site' => [
+              'en' => 'mailto:someone@example.site',
+              'de' => 'mailto:someone@example.site',
+            ]
+          ]
+        ],
+      ],
     ];
 
     foreach ($cases as $name => $directions) {


### PR DESCRIPTION
## Package(s) involved
`silverback_gutenberg`

## Description of changes
When processing the urls from the Gutenberg editor, only specific schemes (currently http and https) are considered. Other urls, like mailto, telephone, etc, should stay exactly how they are.

## How has this been tested?
Manual, locally.
