### PR TITLE
chore: no additional waiting for gatsby

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback-cypress/src/commands.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback-cypress/src/commands.ts
@@ -62,8 +62,6 @@ Cypress.Commands.add(
 
       const checkBuildId = (gatsbyBuildId: number) => {
         if (gatsbyBuildId === drupalBuildId) {
-          // Give Gatsby additional time.
-          cy.wait(1000);
           return;
         }
         if (Date.now() > start + waitOptions.timeout) {


### PR DESCRIPTION
We don't need this `cy.wait` anymore. It was required because of a bug fixed in https://github.com/AmazeeLabs/silverback-mono/pull/747/commits/d9c8eb07273daaa1bbf9bea9078edeb16cdd111f