### PR TITLE
chore(packages): fixes eslint-config and jest-preset version conflicts

### DIFF
--- a/packages/npm/@amazeelabs/recipes/package.json
+++ b/packages/npm/@amazeelabs/recipes/package.json
@@ -12,8 +12,6 @@
     "amazee-recipes": "./dist/index.js"
   },
   "dependencies": {
-    "@amazeelabs/eslint-config": "^1.3.1",
-    "@amazeelabs/jest-preset": "^1.3.3",
     "@amazeelabs/prettier-config": "^1.1.0",
     "@amazeelabs/scaffold": "^1.3.2",
     "chalk": "^4.1.0",
@@ -26,8 +24,8 @@
     "update-notifier": "^5.1.0"
   },
   "devDependencies": {
-    "@amazeelabs/eslint-config": "^1.3.0",
-    "@amazeelabs/jest-preset": "^1.3.1",
+    "@amazeelabs/eslint-config": "^1.3.1",
+    "@amazeelabs/jest-preset": "^1.3.3",
     "@amazeelabs/prettier-config": "^1.1.0",
     "@types/chalk": "^2.2.0",
     "@types/deasync": "^0.1.1",

--- a/packages/npm/@amazeelabs/scaffold/files/package.json
+++ b/packages/npm/@amazeelabs/scaffold/files/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@amazeelabs/jest-preset": "^1.2.0",
-    "@amazeelabs/eslint-config": "^1.3.0",
+    "@amazeelabs/eslint-config": "^1.3.1",
     "@amazeelabs/prettier-config": "^1.1.0",
     "@types/jest": "^26.0.20",
     "jest": "^27.0.0",

--- a/packages/npm/@amazeelabs/scaffold/package.json
+++ b/packages/npm/@amazeelabs/scaffold/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@amazeelabs/eslint-config": "^1.3.1",
     "@amazeelabs/prettier-config": "^1.1.0",
     "chalk": "^4.1.0",
     "esm": "^3.2.25"
@@ -25,7 +24,7 @@
     "watch": "jest --watch"
   },
   "devDependencies": {
-    "@amazeelabs/eslint-config": "^1.3.0",
+    "@amazeelabs/eslint-config": "^1.3.1",
     "@amazeelabs/jest-preset": "^1.3.3",
     "@amazeelabs/prettier-config": "^1.1.0",
     "@types/chalk": "^2.2.0",


### PR DESCRIPTION
Fixes issue 
```
warning package.json: "dependencies" has dependency "@amazeelabs/eslint-config" with range "^1.3.1" that collides with a dependency in "devDependencies" of the same name with version "^1.3.0"
warning package.json: "dependencies" has dependency "@amazeelabs/jest-preset" with range "^1.3.3" that collides with a dependency in "devDependencies" of the same name with version "^1.3.1"
```
