### PR TITLE
fix(gatsby): properly update gatsby on menu item deletion

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
@@ -9,23 +9,11 @@ function _silverback_gatsby_entity_event(EntityInterface $entity) {
   \Drupal::service('silverback_gatsby.update_handler')->handle(EntityFeed::class, $entity);
 }
 
-function _silverback_gatsby_menu_event(EntityInterface $entity) {
-  \Drupal::service('silverback_gatsby.update_handler')->handle(MenuFeed::class, $entity);
-}
-
-/**
- * Implements hook_entity_presave().
- */
-function silverback_gatsby_entity_presave(EntityInterface $entity) {
-  _silverback_gatsby_menu_event($entity);
-}
-
 /**
  * Implements hook_entity_create().
  */
 function silverback_gatsby_entity_insert(EntityInterface $entity) {
   _silverback_gatsby_entity_event($entity);
-  _silverback_gatsby_menu_event($entity);
 }
 
 /**
@@ -33,7 +21,6 @@ function silverback_gatsby_entity_insert(EntityInterface $entity) {
  */
 function silverback_gatsby_entity_update(EntityInterface $entity) {
   _silverback_gatsby_entity_event($entity);
-  _silverback_gatsby_menu_event($entity);
 }
 
 /**
@@ -41,5 +28,4 @@ function silverback_gatsby_entity_update(EntityInterface $entity) {
  */
 function silverback_gatsby_entity_delete(EntityInterface $entity) {
   _silverback_gatsby_entity_event($entity);
-  _silverback_gatsby_menu_event($entity);
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.services.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.services.yml
@@ -19,3 +19,9 @@ services:
   silverback_gatsby.update_handler:
     class: Drupal\silverback_gatsby\GatsbyUpdateHandler
     arguments: ['@entity_type.manager', '@silverback_gatsby.update_tracker']
+
+  silverback_gatsby.menu_tree_storage:
+    class: Drupal\silverback_gatsby\MenuTreeStorageDecorator
+    decorates: menu.tree_storage
+    public: false
+    arguments: ['@silverback_gatsby.menu_tree_storage.inner', '@silverback_gatsby.update_handler']

--- a/packages/composer/amazeelabs/silverback_gatsby/src/MenuTreeStorageDecorator.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/MenuTreeStorageDecorator.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Drupal\silverback_gatsby;
+
+use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\Core\Menu\MenuTreeStorageInterface;
+use Drupal\silverback_gatsby\Plugin\Gatsby\Feed\MenuFeed;
+
+/**
+ * Decorates the menu tree storage and sends updates to Gatsby on modifications.
+ */
+class MenuTreeStorageDecorator implements MenuTreeStorageInterface {
+
+  /**
+   * @var \Drupal\Core\Menu\MenuTreeStorageInterface
+   */
+  protected MenuTreeStorageInterface $subject;
+
+  /**
+   * @var \Drupal\silverback_gatsby\GatsbyUpdateHandler
+   */
+  protected GatsbyUpdateHandler $updateHandler;
+
+  /**
+   * @param \Drupal\Core\Menu\MenuTreeStorageInterface $subject
+   *   The decorated menu tree storage service.
+   * @param \Drupal\silverback_gatsby\GatsbyUpdateHandler $updateHandler
+   *   A Gatsby update handler to send events to.
+   */
+  public function __construct(
+    MenuTreeStorageInterface $subject,
+    GatsbyUpdateHandler $updateHandler
+  ) {
+    $this->subject = $subject;
+    $this->updateHandler = $updateHandler;
+  }
+
+  /**
+   * Send updates after updating a menu item.
+   * {@inheritDoc}
+   */
+  public function save(array $definition) {
+    // Emit change events before save to detect if the menu item moved out of
+    // a certain level range.
+    $this->updateHandler->handle(MenuFeed::class, $definition['id']);
+    $this->subject->save($definition);
+    // Emit change events after save to update the range it is now in.
+    $this->updateHandler->handle(MenuFeed::class, $definition['id']);
+  }
+
+  /**
+   * Send updates before deleting a menu item.
+   * {@inheritDoc}
+   */
+  public function delete($id) {
+    // Delete update handler has to run before the actual delete operation,
+    // because afterwards its position in the tree is lost, and it's not possible
+    // to determine which layers are affected.
+    $this->updateHandler->handle(MenuFeed::class, $id);
+    $this->subject->delete($id);
+  }
+
+  // ======================================================================
+  // Untouched public interface.
+  // ======================================================================
+
+  public function maxDepth() {
+    return $this->subject->maxDepth();
+  }
+
+  public function resetDefinitions() {
+    return $this->subject->resetDefinitions();
+  }
+
+  public function rebuild(array $definitions) {
+    return $this->subject->rebuild($definitions);
+  }
+
+  public function load($id) {
+    return $this->subject->load($id);
+  }
+
+  public function loadMultiple(array $ids) {
+    return $this->subject->loadMultiple($ids);
+  }
+
+  public function loadByProperties(array $properties) {
+    return $this->subject->loadByProperties($properties);
+  }
+
+  public function loadByRoute(
+    $route_name,
+    array $route_parameters = [],
+    $menu_name = NULL
+  ) {
+    return $this->subject->loadByRoute($route_name, $route_parameters, $menu_name);
+  }
+
+  public function loadTreeData($menu_name, MenuTreeParameters $parameters) {
+    return $this->subject->loadTreeData($menu_name, $parameters);
+  }
+
+  public function loadAllChildren($id, $max_relative_depth = NULL) {
+    return $this->subject->loadAllChildren($id, $max_relative_depth);
+  }
+
+  public function getAllChildIds($id) {
+    return $this->subject->getAllChildIds($id);
+  }
+
+  public function loadSubtreeData($id, $max_relative_depth = NULL) {
+    return $this->subject->loadSubtreeData($id, $max_relative_depth);
+  }
+
+  public function getRootPathIds($id) {
+    return $this->subject->getRootPathIds($id);
+  }
+
+  public function getExpanded($menu_name, array $parents) {
+    return $this->subject->getExpanded($menu_name, $parents);
+  }
+
+  public function getSubtreeHeight($id) {
+    return $this->subject->getSubtreeHeight($id);
+  }
+
+  public function menuNameInUse($menu_name) {
+    return $this->subject->menuNameInUse($menu_name);
+  }
+
+  public function getMenuNames() {
+    return $this->subject->getMenuNames();
+  }
+
+  public function countMenuLinks($menu_name = NULL) {
+    return $this->subject->countMenuLinks($menu_name);
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
@@ -123,21 +123,18 @@ class MenuFeed extends FeedBase implements ContainerFactoryPluginInterface {
    * {@inheritDoc}
    */
   public function getUpdateIds($context) : array {
-    if ($context instanceof MenuLinkContentInterface) {
-      $params = new MenuTreeParameters();
-      if ($this->max_level > 0) {
-        $params->maxDepth = $this->max_level;
-      }
-      $tree = $this->menuLinkTree->load($this->menu_id, $params);
-      $items = GatsbyMenuLinks::flatten($tree, -1);
-
-      $ids = [$context->getPluginId()];
-      $match = count(array_filter($items, function (MenuLinkTreeElement $item) use ($ids) {
-        return in_array($item->link->getPluginId(), $ids);
-      })) > 0;
-      return $match ? [$context->getMenuName()] : [];
+    $params = new MenuTreeParameters();
+    if ($this->max_level > 0) {
+      $params->maxDepth = $this->max_level;
     }
-    return [];
+    $tree = $this->menuLinkTree->load($this->menu_id, $params);
+    $items = GatsbyMenuLinks::flatten($tree, -1);
+
+    $ids = [$context];
+    $match = count(array_filter($items, function (MenuLinkTreeElement $item) use ($ids) {
+      return in_array($item->link->getPluginId(), $ids);
+    })) > 0;
+    return $match ? [$this->menu_id] : [];
   }
 
   /**

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/MenuFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/MenuFeedTest.php
@@ -320,4 +320,22 @@ class MenuFeedTest extends GraphQLTestBase {
       new GatsbyUpdate('VisibleMainMenu', 'main'),
     ], $diff);
   }
+
+  public function testDeletedMenuItem() {
+    $foo = $this->createMenuItem('Foo', 'internal:/foo');
+
+    $tracker = $this->container->get('silverback_gatsby.update_tracker');
+
+    // Change
+    $tracker->clear();
+    $latest = $tracker->latestBuild($this->server->id());
+    $foo->delete();
+    $current = $tracker->latestBuild($this->server->id());
+
+    $diff = $tracker->diff($latest, $current, $this->server->id());
+    $this->assertEquals([
+      new GatsbyUpdate('MainMenu', 'main'),
+      new GatsbyUpdate('VisibleMainMenu', 'main'),
+    ], $diff);
+  }
 }


### PR DESCRIPTION

## Package(s) involved
* `silverback_gatsby`

## Description of changes
Switched Gatsby notifications to occur on tree modification instead
menu content entities. The latter did not work correctly because the
position in the menu is lost on delete, and it's not possible to
determine the level anymore.

## Motivation and context
* Menu items did not disappear when deleted
* Menu items from another source than content menu items also trigger updates now.

## Related Issue(s)
#760 

## How has this been tested?
* unit tests in `silverback_gatsby`
* manually tested in the `silverback-drupal`/`silverback-gatsby` test install.
