### PR TITLE
fix(gatsby): display 404 page instead of redirecting to it

### DIFF
--- a/packages/composer/amazeelabs/silverback_cdn_redirect/config/install/silverback_cdn_redirect.settings.yml
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/config/install/silverback_cdn_redirect.settings.yml
@@ -1,3 +1,4 @@
 base_url: ''
-fallback_path: ''
-prefix_fallback_path: false
+404_path: ''
+should_prefix_404_path: false
+netlify_password: ''

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/config/schema/silverback_cdn_redirect.schema.yml
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/config/schema/silverback_cdn_redirect.schema.yml
@@ -5,9 +5,12 @@ silverback_cdn_redirect.settings:
     base_url:
       type: string
       label: 'Base URL of the frontend. Must have no trailing slash.'
-    fallback_path:
+    404_path:
       type: string
-      label: 'A path to fallback to in case if no redirect is found. Must start from a slash.'
-    prefix_fallback_path:
+      label: 'A path to 404 page in case if no redirect is found. Must start from a slash.'
+    should_prefix_404_path:
       type: boolean
-      label: 'Whether to add the language prefix to the fallback path.'
+      label: 'Whether to add the language prefix to the 404 path.'
+    netlify_password:
+      type: string
+      label: 'The global password for Netlify.'

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.install
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.install
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Rename config properties.
+ */
+function silverback_cdn_redirect_update_8001() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('silverback_cdn_redirect.settings');
+
+  $config->set('404_path', $config->get('fallback_path'));
+  $config->clear('fallback_path');
+
+  $config->set('should_prefix_404_path', $config->get('prefix_fallback_path'));
+  $config->clear('prefix_fallback_path');
+
+  $config->set('netlify_password', '');
+
+  $config->save(TRUE);
+}


### PR DESCRIPTION
Closes https://github.com/AmazeeLabs/silverback-mono/issues/753

## Package(s) involved

- `composer/amazeelabs/silverback_cdn_redirect`

## Description of changes

Previous behavior: `GET /non-exiting-page` => 302 redirect to Gatsby's `/404` (with 200 status code in the end)

New behavior: `GET /non-exiting-page` => 404 response with the contents of Gatsby's `/404` page

## How has this been tested?
Tested locally targeting the module to:
- local Gatsby
- public Netlify site
- password protected Netlify site
