### PR TITLE
Variable existence check is introduced in Conditions class to avoid notice errors

### DIFF
--- a/packages/composer/drupal/webform_jsonschema/src/Conditions.php
+++ b/packages/composer/drupal/webform_jsonschema/src/Conditions.php
@@ -117,7 +117,7 @@ class Conditions {
     $value = reset($triggerArray);
     $trigger = key($triggerArray);
 
-    if ($schema['properties'][$dependencyKey]['type'] === 'boolean' && $trigger === 'filled') {
+    if ($schema['properties'][$dependencyKey]['type'] ?? NULL === 'boolean' && $trigger === 'filled') {
       // The issue with the checkboxes is:
       // - JSON Schema dependencies react to the presence of the field value.
       // - When a checkbox appears on a form, it's value is undefined.
@@ -154,7 +154,7 @@ class Conditions {
           return $definition['enum'][0];
         }, $schema['properties'][$dependencyKey]['anyOf']);
       }
-      if ($schema['properties'][$dependencyKey]['type'] === 'boolean') {
+      if ($schema['properties'][$dependencyKey]['type'] ?? NULL === 'boolean') {
         // Boolean field.
         $possibleValues = [TRUE, FALSE];
       }


### PR DESCRIPTION
## Package(s) involved
Package `drupal/webform_jsonschema` is affected.

## Description of changes
`Conditions::prepareDependencySchema()` method contains `if` statements where existence of variables is not checked. This causes PHP notice errors to be issued and automated tests fail due to non-0 code returns.

## Related Issue(s)
Original report is posted on drupal.org - https://www.drupal.org/project/webform_jsonschema/issues/3225332

## How has this been tested?
This has been manually tested by running the tests and not experiencing notice errors.
