### PR TITLE
feat(cdn-redirect): add missing translation redirect

### DIFF
--- a/packages/composer/amazeelabs/silverback_cdn_redirect/config/install/silverback_cdn_redirect.settings.yml
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/config/install/silverback_cdn_redirect.settings.yml
@@ -2,3 +2,4 @@ base_url: ''
 404_path: ''
 should_prefix_404_path: false
 netlify_password: ''
+missing_translation_redirect_entity_types: []

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/config/schema/silverback_cdn_redirect.schema.yml
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/config/schema/silverback_cdn_redirect.schema.yml
@@ -14,3 +14,9 @@ silverback_cdn_redirect.settings:
     netlify_password:
       type: string
       label: 'The global password for Netlify.'
+    missing_translation_redirect_entity_types:
+      type: sequence
+      label: 'Entity type IDs for which the missing translation redirect should be performed.'
+      sequence:
+        type: string
+        label: 'Entity type ID'

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.install
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.install
@@ -17,3 +17,13 @@ function silverback_cdn_redirect_update_8001() {
 
   $config->save(TRUE);
 }
+
+/**
+ * Add missing_translation_redirect_entity_types config option.
+ */
+function silverback_cdn_redirect_update_8002() {
+  \Drupal::configFactory()
+    ->getEditable('silverback_cdn_redirect.settings')
+    ->set('missing_translation_redirect_entity_types', [])
+    ->save(TRUE);
+}

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.services.yml
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.services.yml
@@ -3,3 +3,8 @@ services:
     class: Drupal\silverback_cdn_redirect\EventSubscriber\CdnRedirectRouteSubscriber
     tags:
       - { name: event_subscriber }
+  silverback_cdn_redirect.missing_translation_redirect_subscriber:
+    class: Drupal\silverback_cdn_redirect\EventSubscriber\MissingTranslationRedirectSubscriber
+    arguments: [ '@language_manager', '@current_route_match', '@config.factory']
+    tags:
+      - { name: event_subscriber }

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/src/EventSubscriber/MissingTranslationRedirectSubscriber.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/src/EventSubscriber/MissingTranslationRedirectSubscriber.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\silverback_cdn_redirect\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Url;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class MissingTranslationRedirectSubscriber implements EventSubscriberInterface {
+
+  protected LanguageManagerInterface $languageManager;
+
+  protected RouteMatchInterface $routeMatch;
+
+  /**
+   * @var string[]
+   */
+  protected array $entityTypes;
+
+  public function __construct(LanguageManagerInterface $language_manager, RouteMatchInterface $route_match, ConfigFactoryInterface $configFactory) {
+    $this->languageManager = $language_manager;
+    $this->routeMatch = $route_match;
+    $this->entityTypes = $configFactory
+      ->get('silverback_cdn_redirect.settings')
+      ->get('missing_translation_redirect_entity_types') ?: [];
+  }
+
+  public static function getSubscribedEvents() {
+    return [
+      KernelEvents::REQUEST => [
+        // We need this subscriber to run after the router_listener service
+        // (which has priority 32) so that the parameters are set into the
+        // request.
+        ['onKernelRequest', 30],
+      ]
+    ];
+  }
+
+  public function onKernelRequest(RequestEvent $event) {
+    // In case the user tries to access an entity in a different language than
+    // the current content one, we perform a redirect using the actual language
+    // of the entity from the route. This means that the language of the
+    // interface will most probably change as well.
+    foreach ($this->entityTypes as $entityType) {
+      $routeName = 'entity.' . $entityType . '.canonical';
+      if ($this->routeMatch->getRouteName() !== $routeName) {
+        continue;
+      }
+
+      $entity = $this->routeMatch->getCurrentRouteMatch()->getParameter($entityType);
+      $requestedLanguageId = $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
+      if ($entity->language()->getId() === $requestedLanguageId) {
+        return;
+      }
+
+      $url = Url::fromRoute(
+        $routeName,
+        [
+          $entityType => $entity->id(),
+        ],
+        [
+          'language' => $entity->language(),
+          'query' => [
+            'show_warning' => 'content_language_not_available',
+            'original_language' => $requestedLanguageId,
+          ] + $event->getRequest()->query->all(),
+        ]
+      );
+      $response = new TrustedRedirectResponse($url->toString());
+
+      // Add the necessary cache contexts to the response, as redirect
+      // responses are cached as well.
+      $response->getCacheableMetadata()
+        ->addCacheContexts([
+          'languages:language_content',
+          'url.query_args',
+        ])
+        ->addCacheableDependency($entity);
+
+      $event->setResponse($response);
+      return;
+    }
+  }
+}


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback_cdn_redirect`

## Description of changes

Added a redirect to the source entity language if a non existing entity translation was requested.

It is disabled by default. Can be enabled like this:
```
drush cset silverback_cdn_redirect.settings missing_translation_redirect_entity_types '["node", "commerce_product"]' --input-format=yaml
```

## How has this been tested?

Locally on a project.
