### PR TITLE
chore(deps): update alchemy/zippy to 1.0

### DIFF
--- a/packages/composer/drupal/cypress/composer.json
+++ b/packages/composer/drupal/cypress/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "ext-json": "*",
-    "alchemy/zippy": "dev-master",
+    "alchemy/zippy": "^1.0.0",
     "drupal/test_session": "^1.0.0",
     "drush/drush": "^10.3.5"
   },


### PR DESCRIPTION
## Package(s) involved
`alchemy/zippy` in `/packages/composer/drupal/cypress`

## Description of changes
Update the `alchemy/zippy` to the stable 1.0 release.

## Motivation and context
Pinning `alchemy/zippy` to dev-master can cause unresolvable dependency clashes with other packages.

## Related Issue(s)
[Your requirements could not be resolved to an installable set of packages.](https://www.drupal.org/project/cypress/issues/3179307)

## How has this been tested?
locally
