### PR TITLE
Coalescing operator expression is wrapped in parentheses in Condition class

### DIFF
--- a/packages/composer/drupal/webform_jsonschema/src/Conditions.php
+++ b/packages/composer/drupal/webform_jsonschema/src/Conditions.php
@@ -117,7 +117,7 @@ class Conditions {
     $value = reset($triggerArray);
     $trigger = key($triggerArray);
 
-    if ($schema['properties'][$dependencyKey]['type'] ?? NULL === 'boolean' && $trigger === 'filled') {
+    if (($schema['properties'][$dependencyKey]['type'] ?? NULL) === 'boolean' && $trigger === 'filled') {
       // The issue with the checkboxes is:
       // - JSON Schema dependencies react to the presence of the field value.
       // - When a checkbox appears on a form, it's value is undefined.
@@ -154,7 +154,7 @@ class Conditions {
           return $definition['enum'][0];
         }, $schema['properties'][$dependencyKey]['anyOf']);
       }
-      if ($schema['properties'][$dependencyKey]['type'] ?? NULL === 'boolean') {
+      if (($schema['properties'][$dependencyKey]['type'] ?? NULL) === 'boolean') {
         // Boolean field.
         $possibleValues = [TRUE, FALSE];
       }


### PR DESCRIPTION
This is a follow-up PR to https://github.com/AmazeeLabs/silverback-mono/pull/765.

## Package(s) involved
Package `drupal/webform_jsonschema` is affected.

## Description of changes
The coalescing operator `??` needs to be wrapped in parentheses in order to work with comparison. Here's the code to check the behaviour:

```php
<?php

$schema['properties']['name']['type'] = 'string';

if ($schema['properties']['name']['type'] ?? NULL === 'boolean') {
  print_r('Element type is not a boolean.');
}

if (($schema['properties']['name']['type'] ?? NULL) === 'boolean') {
  print_r('This should never print.');
}
```

The proposed resolution involves wrapping coalescing operator expressing in parentheses so that comparison yields correct results:

```php
if (($schema['properties'][$dependencyKey]['type'] ?? NULL) === 'boolean' && $trigger === 'filled') {
// ...
}

if (($schema['properties'][$dependencyKey]['type'] ?? NULL) === 'boolean') {
// ...
}
```

## Related Issue(s)
Original report is posted on drupal.org - https://www.drupal.org/project/webform_jsonschema/issues/3225332

## How has this been tested?
This change has been manually tested.
