### PR TITLE
feat(gatsby): automatically open external link in "_blank"

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
@@ -38,7 +38,12 @@ export const buildLink = ({
         {children}
       </GatsbyLink>
     ) : (
-      <a className={className} target={target} href={uri} {...props}>
+      <a
+        className={className}
+        target={target || '_blank'}
+        href={uri}
+        {...props}
+      >
         {children}
       </a>
     );


### PR DESCRIPTION
## Package(s) involved
* `@amazeelabs/react-framework-bridge`

## Description of changes
By default, external Gatsby links are opened in a new browser window or tab.

## Motivation and context
This is a requirement in 98% of all projects.
