### PR TITLE
silverback_iframe: exclude some links from processing

### DIFF
--- a/packages/composer/amazeelabs/silverback_iframe_theme/iframeCommand.js
+++ b/packages/composer/amazeelabs/silverback_iframe_theme/iframeCommand.js
@@ -98,6 +98,20 @@
       if (!href) {
         return true;
       }
+
+      // Exclude some links.
+      if (
+        // Drupal a11y links.
+        $this.hasClass("visually-hidden") ||
+        // Commerce checkout "Edit" links.
+        $this.closest(".checkout-pane-review").length ||
+        // Multistep form navigation links.
+        $this.closest(".form-actions").length
+      ) {
+        return true;
+      }
+
+      // Process links.
       // 1. Remove "iframe=true" from the URL.
       href = removeIframeFromUrl(href);
       // 2. Use parent frame base URL for relative links.

--- a/packages/tests/silverback-iframe/package.json
+++ b/packages/tests/silverback-iframe/package.json
@@ -9,7 +9,6 @@
     "@-amazeelabs/silverback_iframe": "^1.1.1",
     "@-amazeelabs/silverback_iframe_theme": "^1.1.0",
     "@amazeelabs/eslint-config": "^1.3.2",
-    "@amazeelabs/jest-preset": "^1.3.5",
     "@amazeelabs/prettier-config": "^1.1.0",
     "@amazeelabs/scaffold": "^1.3.7",
     "@amazeelabs/silverback-iframe": "^1.1.1",


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback_iframe_theme`

## Motivation and context

The link processing code broke Commerce Checkout links.

Commerce links are not AJAX, so I had to exclude links based on classes.

## Related Issue(s)

https://github.com/AmazeeLabs/silverback-mono/issues/787

## How has this been tested?

Locally on a project. Automated testing would need Commerce which I don't want to add to `silverback-drupal`.
