### PR TITLE
feature(gatsby): allow consuming components to override link parameters

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/gatsby.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/gatsby.test.tsx
@@ -22,6 +22,7 @@ jest.mock(
     navigate: (to: string) => gatsbyNav(to),
   }),
 );
+beforeEach(jest.resetAllMocks);
 
 describe('buildLink', () => {
   it('can build a link from segments and query parameters', () => {
@@ -35,6 +36,36 @@ describe('buildLink', () => {
     expect(screen.getByRole('link').getAttribute('data-gatsby')).toBeTruthy();
     expect(screen.getByRole('link').getAttribute('href')).toEqual(
       '/foo/bar?a=b',
+    );
+  });
+
+  it('allows the consumer to set query parameters', () => {
+    const Link = buildLink({
+      href: '/foo',
+    });
+    render(<Link query={{ a: 'b' }}>Test</Link>);
+    expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo?a=b');
+  });
+
+  it('allows the consumer to set a query fragment', () => {
+    const Link = buildLink({
+      href: '/foo',
+    });
+    render(<Link fragment="bar">Test</Link>);
+    expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo#bar');
+  });
+
+  it('allows the consumer to set query parameters and fragments', () => {
+    const Link = buildLink({
+      href: '/foo',
+    });
+    render(
+      <Link query={{ a: 'b' }} fragment="bar">
+        Test
+      </Link>,
+    );
+    expect(screen.getByRole('link').getAttribute('href')).toEqual(
+      '/foo?a=b#bar',
     );
   });
 
@@ -72,5 +103,12 @@ describe('buildLink', () => {
     Link.navigate();
     expect(gatsbyNav).toHaveBeenCalledTimes(1);
     expect(gatsbyNav).toHaveBeenCalledWith('#test');
+  });
+
+  it('exposes Gatsby navigate that allows to override query and fragments', () => {
+    const Link = buildLink({ href: '/foo', query: { a: 'b' } });
+    Link.navigate({ query: { a: 'c' }, fragment: 'bar' });
+    expect(gatsbyNav).toHaveBeenCalledTimes(1);
+    expect(gatsbyNav).toHaveBeenCalledWith('/foo?a=c#bar');
   });
 });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
@@ -25,6 +25,45 @@ describe('buildLink', () => {
     );
   });
 
+  it('allows the consumer to set query parameters', () => {
+    const Link = buildLink({
+      href: '/foo',
+    });
+    render(<Link query={{ a: 'b' }}>Test</Link>);
+    expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo?a=b');
+  });
+
+  it('allows the consumer to override query parameters', () => {
+    const Link = buildLink({
+      href: '/foo',
+      query: { a: 'b' },
+    });
+    render(<Link query={{ a: 'c' }}>Test</Link>);
+    expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo?a=c');
+  });
+
+  it('allows the consumer to set a query fragment', () => {
+    const Link = buildLink({
+      href: '/foo',
+    });
+    render(<Link fragment="bar">Test</Link>);
+    expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo#bar');
+  });
+
+  it('allows the consumer to set query parameters and fragments', () => {
+    const Link = buildLink({
+      href: '/foo',
+    });
+    render(
+      <Link query={{ a: 'b' }} fragment="bar">
+        Test
+      </Link>,
+    );
+    expect(screen.getByRole('link').getAttribute('href')).toEqual(
+      '/foo?a=b#bar',
+    );
+  });
+
   it('renders a simple link', () => {
     const Link = buildLink({ href: '#test' });
     render(<Link>test</Link>);
@@ -70,6 +109,13 @@ describe('buildLink', () => {
     Link.navigate();
     expect(action).toHaveBeenCalledTimes(1);
     expect(action).toHaveBeenCalledWith('#test');
+  });
+
+  it('exposes a navigate function that logs a storybook action and allows to override queries and fragments', () => {
+    const Link = buildLink({ href: '/foo', query: { a: 'b' } });
+    Link.navigate({ query: { a: 'c' }, fragment: 'bar' });
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(action).toHaveBeenCalledWith('/foo?a=c#bar');
   });
 });
 

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/utils.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/utils.test.tsx
@@ -212,4 +212,9 @@ describe('buildUrl', () => {
       '/first/second/third',
     );
   });
+  it('attaches a fragment', () => {
+    expect(
+      buildUrl(['https://fake.url/', 'a', 'b'], undefined, undefined, 'foo'),
+    ).toStrictEqual(`https://fake.url/a/b#foo`);
+  });
 });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import type { Image, Link, LinkProps } from './types';
 import {
   buildHtmlBuilder,
-  buildUrl,
+  buildUrlBuilder,
   isInternalTarget,
   isRelative,
 } from './utils';
@@ -20,12 +20,15 @@ export const buildLink = ({
 }: Omit<GatsbyLinkProps<any>, 'className' | 'activeClassName' | 'to'> & {
   href?: string;
 } & Pick<LinkProps, 'segments' | 'query' | 'queryOptions'>): Link => {
-  const uri = segments ? buildUrl(segments, query, queryOptions) : href;
+  const buildUrl = buildUrlBuilder(segments || [href], query, queryOptions);
   const Element: Link = function LinkBuilder({
     className,
     activeClassName,
     children,
+    query: queryOverride,
+    fragment,
   }) {
+    const uri = buildUrl(queryOverride, fragment);
     return uri && isInternalTarget(target) && isRelative(uri) ? (
       // @ts-ignore GatsbyLink comply with type
       <GatsbyLink
@@ -49,7 +52,10 @@ export const buildLink = ({
     );
   };
 
-  Element.navigate = () => href && navigate(href, props);
+  Element.navigate = (opts) => {
+    const uri = buildUrl(opts?.query, opts?.fragment);
+    navigate(uri, props);
+  };
 
   return Element;
 };

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import React from 'react';
 
 import { Image, ImageProps, Link, LinkProps } from './types';
-import { buildHtmlBuilder, buildUrl } from './utils';
+import { buildHtmlBuilder, buildUrlBuilder } from './utils';
 
 export const buildLink = ({
   href,
@@ -11,12 +11,16 @@ export const buildLink = ({
   queryOptions,
   ...props
 }: LinkProps): Link => {
-  const target = segments ? buildUrl(segments, query, queryOptions) : href;
+  const buildUrl = buildUrlBuilder(segments || [href], query, queryOptions);
+
   const Element: Link = function MockLink({
     className,
     activeClassName,
+    query: queryOverride,
+    fragment,
     children,
   }) {
+    const target = buildUrl(queryOverride, fragment);
     return (
       <a
         href={target}
@@ -35,7 +39,10 @@ export const buildLink = ({
       </a>
     );
   };
-  Element.navigate = () => action('navigate to')(target);
+  Element.navigate = (opts) => {
+    const target = buildUrl(opts?.query, opts?.fragment);
+    action('navigate to')(target);
+  };
   return Element;
 };
 

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
@@ -29,7 +29,14 @@ export type ImageBuilder = (props: ImageProps) => Image;
 export type Link = React.FC<{
   className?: string;
   activeClassName?: string;
-}> & { navigate: () => void };
+  query?: { [key: string]: string };
+  fragment?: string;
+}> & {
+  navigate: (opts?: {
+    query?: { [key: string]: string };
+    fragment?: string;
+  }) => void;
+};
 
 export type LinkProps = Omit<
   React.DetailedHTMLProps<

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils.tsx
@@ -129,6 +129,7 @@ export const buildUrl = (
   segments: NonNullable<LinkProps['segments']>,
   query?: LinkProps['query'],
   queryOptions?: LinkProps['queryOptions'],
+  fragment?: string,
 ) => {
   const url = segments.filter(isTruthy).map(stripSlashes).join('/');
 
@@ -137,5 +138,22 @@ export const buildUrl = (
     ...queryOptions,
   });
 
-  return [url, queryString].filter(isTruthy).join('?');
+  return [[url, queryString].filter(isTruthy).join('?'), fragment]
+    .filter(isTruthy)
+    .join('#');
 };
+
+export const buildUrlBuilder =
+  (
+    segments: NonNullable<LinkProps['segments']>,
+    query?: LinkProps['query'],
+    queryOptions?: LinkProps['queryOptions'],
+    fragment?: string,
+  ) =>
+  (queryOverride?: { [key: string]: string }, fragmentOverride?: string) =>
+    buildUrl(
+      segments,
+      { ...(query || {}), ...(queryOverride || {}) },
+      queryOptions,
+      fragmentOverride || fragment,
+    );


### PR DESCRIPTION
## Package(s) involved
* `@amazeelabs/react-framework-bridge`

## Description of changes
Allow consumers of `Link` elements created with `buildLink` to override query and fragment of the url.

## How has this been tested?
With Jest unit tests.
