### PR TITLE
ESLint: catch forgotten `test.only` occurrences

### DIFF
--- a/apps/silverback-gatsby/cypress/integration/gatsby-clear.ts
+++ b/apps/silverback-gatsby/cypress/integration/gatsby-clear.ts
@@ -2,7 +2,7 @@ import { drupalNodeOpUrl, previewUrl } from './constants';
 import { waitForGatsby } from './wait-for-gatsby';
 
 describe('Test gatsby-source-silverback', () => {
-  it.only('clears stored nodes when necessary', () => {
+  it('clears stored nodes when necessary', () => {
     cy.request('POST', drupalNodeOpUrl, {
       op: 'create',
       node: {

--- a/packages/npm/@amazeelabs/eslint-config/index.js
+++ b/packages/npm/@amazeelabs/eslint-config/index.js
@@ -48,6 +48,7 @@ module.exports = {
     "deprecate",
     "simple-import-sort",
     "import",
+    "no-only-tests",
     ...(isReactProject ? [
       "react",
       "react-hooks",
@@ -61,6 +62,7 @@ module.exports = {
     "import/first": "error",
     "import/newline-after-import": "error",
     "import/no-duplicates": "error",
+    "no-only-tests/no-only-tests": "error",
     ...(isReactProject ? {
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",

--- a/packages/npm/@amazeelabs/eslint-config/package.json
+++ b/packages/npm/@amazeelabs/eslint-config/package.json
@@ -12,6 +12,7 @@
     "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-deprecate": "^0.7.0",
     "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-promise": "^5.0.0",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12024,6 +12024,11 @@ eslint-plugin-jsx-a11y@^6.0.3, eslint-plugin-jsx-a11y@^6.4.1:
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
+eslint-plugin-no-only-tests@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz#19f6c9620bda02b9b9221b436c5f070e42628d76"
+  integrity sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==
+
 eslint-plugin-prettier@^2.6.2:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz#b4312dcf2c1d965379d7f9d5b5f8aaadc6a45904"


### PR DESCRIPTION
It is recommended to use `test.only` to debug a particular Playwright test. If we forget such a thing in the code, the rest of the tests will be skipped.