### PR TITLE
Disable auto-refresh by default on non-lagoon environments

### DIFF
--- a/apps/silverback-drupal/.envrc
+++ b/apps/silverback-drupal/.envrc
@@ -14,3 +14,9 @@ fi
 
 # Load everything defined in .env
 set -o allexport; source .env; set +o allexport
+
+# Special case for drupal/gatsby_build_monitor package.
+if [ "$TEST_SESSION_ENABLED" == "true" ]; then
+  # This env var should be set only if we are running Playwright tests.
+  export GATSBY_BUILD_MONITOR_AUTO_REFRESH=true
+fi

--- a/packages/composer/drupal/gatsby_build_monitor/README.md
+++ b/packages/composer/drupal/gatsby_build_monitor/README.md
@@ -1,6 +1,8 @@
 # Gatsby Build Monitor
 
-Receives status from [gatsby-plugin-build-monitor](https://www.npmjs.com/package/gatsby-plugin-build-monitor) and displays it in the Toolbar.
+Receives status from
+[gatsby-plugin-build-monitor](https://www.npmjs.com/package/gatsby-plugin-build-monitor)
+and displays it in the Toolbar.
 
 ## Setup
 
@@ -27,15 +29,15 @@ drush cset gatsby_build_monitor.settings site_url '{the-url}'
 ## To disable Toolbar auto-refresh
 
 ```js
-window.localStorage.setItem("gatsby_build_monitor_disable", "1");
+window.localStorage.setItem('gatsby_build_monitor_disable', '1');
 ```
 
 To enable it back
 
 ```js
-window.localStorage.removeItem("gatsby_build_monitor_disable");
+window.localStorage.removeItem('gatsby_build_monitor_disable');
 ```
 
-## Tests
-
-For now there is just an [integration test](https://github.com/AmazeeLabs/silverback-mono/tree/development/apps/silverback-gatsby/cypress/integration/build-status.ts) in `silverback-gatsby` project.
+Also, the auto-refresh is disabled on non-Lagoon environments by default. If you
+want it enabled, set `GATSBY_BUILD_MONITOR_AUTO_REFRESH` environment variable to
+`true`.

--- a/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.module
+++ b/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.module
@@ -48,6 +48,12 @@ function gatsby_build_monitor_toolbar() {
       ],
       '#attached' => [
         'library' => ['gatsby_build_monitor/state'],
+        'drupalSettings' => [
+          'gatsbyBuildMonitor' => [
+            'autoRefresh' => getenv('LAGOON') ||
+              getenv('GATSBY_BUILD_MONITOR_AUTO_REFRESH') === 'true',
+          ],
+        ],
       ],
       '#weight' => 1000,
     ],

--- a/packages/composer/drupal/gatsby_build_monitor/js/state.js
+++ b/packages/composer/drupal/gatsby_build_monitor/js/state.js
@@ -1,5 +1,5 @@
-/* global jQuery, Drupal */
-(function ($) {
+/* global jQuery, Drupal, drupalSettings */
+(function ($, Drupal, drupalSettings) {
   function getState() {
     if (document.hidden) {
       return;
@@ -40,7 +40,10 @@
       },
     });
   }
-  if (!window.localStorage.getItem('gatsby_build_monitor_disable')) {
+  if (
+    !window.localStorage.getItem('gatsby_build_monitor_disable') &&
+    drupalSettings.gatsbyBuildMonitor.autoRefresh
+  ) {
     setInterval(getState, 2000);
   }
-})(jQuery);
+})(jQuery, Drupal, drupalSettings);


### PR DESCRIPTION
## Package(s) involved

- `composer/drupal/gatsby_build_monitor`

## Related Issue(s)

Closes https://github.com/AmazeeLabs/silverback-mono/issues/799

## How has this been tested?

After the change the tests failed as expected. Once the env var was restored, the tests are green again.
