### PR TITLE
fix: move silverback-playwright to dev dependencies

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/package.json
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@amazeelabs/prettier-config": "^1.1.0",
-    "@amazeelabs/scaffold": "^1.3.8",
-    "@amazeelabs/silverback-playwright": "^1.3.0"
+    "@amazeelabs/scaffold": "^1.3.8"
   },
   "devDependencies": {
     "@amazeelabs/eslint-config": "^1.4.0",
     "@amazeelabs/jest-preset": "^1.3.1",
     "@amazeelabs/prettier-config": "^1.1.0",
+    "@amazeelabs/silverback-playwright": "^1.3.0",
     "@types/jest": "^27.0.0",
     "eslint": "^7.25.0",
     "gatsby": "^3.7.2",


### PR DESCRIPTION
It was in dependencies because of a Yarn bug. `yarn add @amazeelabs/silverback-playwright@^1.3.0 --dev` adds the package to `dependencies`.