### PR TITLE
LinkProcessor: better URL flags

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
@@ -27,7 +27,7 @@ function hook_silverback_gutenberg_link_processor_outbound_link_alter(
   \Drupal\silverback_gutenberg\LinkProcessor $linkProcessor
 ) {
   $url = $link->getAttribute('href');
-  if ($url && $linkProcessor->isExternal($url)) {
+  if ($url && !$linkProcessor->linksToCurrentHost()) {
     $link->setAttribute('target', '_blank');
     $link->setAttribute('rel', 'noreferrer');
   }


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback_gutenberg`

## Description of changes

Changed `LinkProcessor` methods:
- introduced `linksToCurrentHost`
- introduced `hasSchemeOrHost`
- deprecated `isExternal` (`hasSchemeOrHost` should be used instead)

## Motivation and context

Given: our website is hosted at `https://my.com`.

| URL                 | isAbsolute (theoretical) | hasSchemeOrHost | linksToCurrentHost |
|----------------------|------------|-----------------|--------------------|
| `/foo/bar`           | ❌          | ❌               | ✅                  |
| `https://my.com/foo` | ✅          | ✅               | ✅                  |
| `//my.com/foo`       | ❌          | ✅               | ✅                  |
| `//other.com/foo`    | ❌          | ✅               | ❌                  |
| `mailto:bob@my.com`  | ✅          | ✅               | ❌                  |

Here we see that only the first URL is "true" relative. And the last two ones might need `target="_blank"` attribute on the link.

While `isAbsolute` does not help at all.

## How has this been tested?

Unit tests.
