### PR TITLE
react-framework-bridge: add rel=noreferrer to external links by default

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
@@ -46,6 +46,7 @@ export function buildLink<Query = {}>({
       <a
         className={className}
         target={target || '_blank'}
+        rel={props.rel || (isRelative(uri) ? undefined : 'noreferrer')}
         href={uri}
         {...props}
       >


### PR DESCRIPTION
## Package(s) involved

- `npm/@amazeelabs/react-framework-bridge`

## Description of changes

`buildLink`: if `rel` prop is not set and the link is external, set `rel` to `noreferrer`.

## Motivation and context

As it is recommended at https://web.dev/external-anchors-use-rel-noopener

## How has this been tested?

It was not.