### PR TITLE
Improve `LinkProcessor`

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -87,11 +87,11 @@ type BlockHtml {
 
 type BlockImage {
   caption: String!
-  image: Image!
+  image: Image
 }
 
 type BlockTeaser {
-  image: Image!
+  image: Image
   title: String!
   subtitle: String!
   url: String!

--- a/apps/silverback-drupal/web/modules/custom/gutenberg_custom_blocks/gutenberg_custom_blocks.module
+++ b/apps/silverback-drupal/web/modules/custom/gutenberg_custom_blocks/gutenberg_custom_blocks.module
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Implements hook_silverback_gutenberg_link_processor_block_attrs_alter().
+ */
+function gutenberg_custom_blocks_silverback_gutenberg_link_processor_block_attrs_alter(array &$attributes, array $context) {
+  if ($context['blockName'] === 'custom/teaser' && isset($attributes['url'])) {
+    $attributes['url'] = $context['processUrlCallback']($attributes['url']);
+  }
+}

--- a/apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/graphql/silverback_gatsby_test.graphqls
+++ b/apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/graphql/silverback_gatsby_test.graphqls
@@ -58,11 +58,11 @@ type BlockHtml {
 
 type BlockImage {
   caption: String!
-  image: Image!
+  image: Image
 }
 
 type BlockTeaser {
-  image: Image!
+  image: Image
   title: String!
   subtitle: String!
   url: String!

--- a/apps/silverback-gatsby/generated/schema.graphql
+++ b/apps/silverback-gatsby/generated/schema.graphql
@@ -6426,11 +6426,11 @@ type DrupalBlockHtml {
 
 type DrupalBlockImage {
   caption: String!
-  image: DrupalImage!
+  image: DrupalImage
 }
 
 type DrupalBlockTeaser {
-  image: DrupalImage!
+  image: DrupalImage
   title: String!
   subtitle: String!
   url: String!

--- a/apps/silverback-gatsby/src/components/content-blocks/image.tsx
+++ b/apps/silverback-gatsby/src/components/content-blocks/image.tsx
@@ -6,9 +6,9 @@ export const BlockImage: React.FC<BlockImageFragment> = ({
   image,
 }) => (
   <div className="border-solid border-4">
-    {image.localImage?.childImageSharp?.fixed && (
+    {image?.localImage?.childImageSharp?.fixed && (
       <Image fixed={image.localImage.childImageSharp.fixed} />
     )}
-    <div>{caption}</div>
+    <div dangerouslySetInnerHTML={{ __html: caption }} />
   </div>
 );

--- a/apps/silverback-gatsby/src/components/content-blocks/teaser.tsx
+++ b/apps/silverback-gatsby/src/components/content-blocks/teaser.tsx
@@ -9,7 +9,7 @@ export const BlockTeaser: React.FC<BlockTeaserFragment> = ({
 }) => (
   <div className="border-solid border-4">
     <a href={url}>
-      {image.localImage?.childImageSharp?.fixed && (
+      {image?.localImage?.childImageSharp?.fixed && (
         <Image fixed={image.localImage.childImageSharp.fixed} />
       )}
       <h2>{title}</h2>

--- a/apps/silverback-gatsby/src/templates/gutenberg-page.tsx
+++ b/apps/silverback-gatsby/src/templates/gutenberg-page.tsx
@@ -76,7 +76,7 @@ const GutenbergPage: React.FC<
         </tr>
         <tr>
           <Row>{page.title}</Row>
-          <Row>
+          <Row className="gutenberg-body">
             {page.body.map((block) => {
               switch (block.__typename) {
                 case 'DrupalBlockHtml':

--- a/apps/silverback-gatsby/src/util/Row.tsx
+++ b/apps/silverback-gatsby/src/util/Row.tsx
@@ -1,5 +1,9 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 
-export const Row: React.FC = ({ children }) => (
-  <td className="border-solid border-4">{children}</td>
+type Props = PropsWithChildren<{
+  className?: string;
+}>;
+
+export const Row = ({ children, className }: Props) => (
+  <td className={`border-solid border-4 ${className}`}>{children}</td>
 );

--- a/packages/composer/amazeelabs/silverback_gutenberg/.eslintrc.js
+++ b/packages/composer/amazeelabs/silverback_gutenberg/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ['@amazeelabs/eslint-config'],
+  root: true,
+};

--- a/packages/composer/amazeelabs/silverback_gutenberg/.gitignore
+++ b/packages/composer/amazeelabs/silverback_gutenberg/.gitignore
@@ -1,7 +1,0 @@
-### MANAGED BY @amazeelabs/scaffold - START
-.eslintrc.js
-.jest-runner-eslintrc
-.lintstagedrc
-.prettierrc
-jest.config.js
-### MANAGED BY @amazeelabs/scaffold - END

--- a/packages/composer/amazeelabs/silverback_gutenberg/.gitignore
+++ b/packages/composer/amazeelabs/silverback_gutenberg/.gitignore
@@ -1,0 +1,7 @@
+### MANAGED BY @amazeelabs/scaffold - START
+.eslintrc.js
+.jest-runner-eslintrc
+.lintstagedrc
+.prettierrc
+jest.config.js
+### MANAGED BY @amazeelabs/scaffold - END

--- a/packages/composer/amazeelabs/silverback_gutenberg/.jest-runner-eslintrc
+++ b/packages/composer/amazeelabs/silverback_gutenberg/.jest-runner-eslintrc
@@ -1,0 +1,5 @@
+{
+  "cliOptions": {
+    "ignorePath": "./.gitignore"
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/.lintstagedrc
+++ b/packages/composer/amazeelabs/silverback_gutenberg/.lintstagedrc
@@ -1,8 +1,9 @@
 {
   "*.+(js|ts|tsx)": [
-    "jest --findRelatedTests"
+    "jest --findRelatedTests",
+    "eslint --fix"
   ],
   "*.+(js|ts|tsx|md|mdx|yml)": [
-    "prettier --write --ignore-path .gitignore"
+    "prettier --write"
   ]
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/.lintstagedrc
+++ b/packages/composer/amazeelabs/silverback_gutenberg/.lintstagedrc
@@ -1,0 +1,8 @@
+{
+  "*.+(js|ts|tsx)": [
+    "jest --findRelatedTests"
+  ],
+  "*.+(js|ts|tsx|md|mdx|yml)": [
+    "prettier --write --ignore-path .gitignore"
+  ]
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/.npmignore
+++ b/packages/composer/amazeelabs/silverback_gutenberg/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/composer/amazeelabs/silverback_gutenberg/.prettierrc
+++ b/packages/composer/amazeelabs/silverback_gutenberg/.prettierrc
@@ -1,0 +1,1 @@
+"@amazeelabs/prettier-config"

--- a/packages/composer/amazeelabs/silverback_gutenberg/README.md
+++ b/packages/composer/amazeelabs/silverback_gutenberg/README.md
@@ -1,1 +1,27 @@
-# TBD
+# Silverback Gutenberg
+
+Helps integrating Drupal's [Gutenberg module](https://www.drupal.org/project/gutenberg) into Silverback projects.
+
+## LinkProcessor
+
+The main idea is that all links added to a Gutenberg page are
+
+- kept in internal format (e.g. `/node/123`) when saved to Drupal database
+- processed to language-prefixed aliased form (e.g. `/en/my-page`) when
+  - they are displayed in Gutenberg editor
+  - they are sent out via GraphQL
+
+This helps to
+
+- always display fresh path aliases
+- be sure that the language prefix is correct
+- update link URLs when translating content (e.g. `/en/my-page` will become `/fr/ma-page` automatically because it's `/node/123` under the hood)
+- keep track of entity usage (TBD)
+
+### Implementation
+
+The module does most of the things automatically. Yet there are few things developers should take care of.
+
+First, custom Gutenberg blocks which store links in block attributes should implement `hook_silverback_gutenberg_link_processor_block_attributes_alter`. See [`silverback_gutenberg.api.php`](./silverback_gutenberg.api.php) for an example.
+
+Next, GraphQL resolvers which parse Gutenberg code should call `LinkProcessor::processLinks` before parsing the blocks. See [`DataProducer/Gutenberg.php`](../../../../apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/src/Plugin/GraphQL/DataProducer/Gutenberg.php) for an example.

--- a/packages/composer/amazeelabs/silverback_gutenberg/README.md
+++ b/packages/composer/amazeelabs/silverback_gutenberg/README.md
@@ -22,6 +22,6 @@ This helps to
 
 The module does most of the things automatically. Yet there are few things developers should take care of.
 
-First, custom Gutenberg blocks which store links in block attributes should implement `hook_silverback_gutenberg_link_processor_block_attributes_alter`. See [`silverback_gutenberg.api.php`](./silverback_gutenberg.api.php) for an example.
+First, custom Gutenberg blocks which store links in block attributes should implement `hook_silverback_gutenberg_link_processor_block_attrs_alter`. See [`silverback_gutenberg.api.php`](./silverback_gutenberg.api.php) for an example.
 
 Next, GraphQL resolvers which parse Gutenberg code should call `LinkProcessor::processLinks` before parsing the blocks. See [`DataProducer/Gutenberg.php`](../../../../apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/src/Plugin/GraphQL/DataProducer/Gutenberg.php) for an example.

--- a/packages/composer/amazeelabs/silverback_gutenberg/jest.config.js
+++ b/packages/composer/amazeelabs/silverback_gutenberg/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: '@amazeelabs/jest-preset',
+};

--- a/packages/composer/amazeelabs/silverback_gutenberg/js/base.js
+++ b/packages/composer/amazeelabs/silverback_gutenberg/js/base.js
@@ -5,10 +5,10 @@ var silverbackGutenbergUtils = {
         // When copying text from Word, HTML comments are escaped. So we get this:
         // ...<br>&lt;!-- /* Font Definitions */ @font-face {...} --&gt;<br>...
         // Unescape them back.
-        .replace("&lt;!--", "<!--")
-        .replace("--&gt;", "-->")
+        .replace('&lt;!--', '<!--')
+        .replace('--&gt;', '-->')
         // Now clean all HTML tags.
-        .replace(/(<([^>]+)>)/gi, "")
+        .replace(/(<([^>]+)>)/gi, '')
     );
   },
 

--- a/packages/composer/amazeelabs/silverback_gutenberg/js/gutenberg-tweaks.js
+++ b/packages/composer/amazeelabs/silverback_gutenberg/js/gutenberg-tweaks.js
@@ -1,3 +1,4 @@
+/* global drupalSettings, wp */
 drupalSettings.gutenberg._listeners.init.push(
   // For all block types:
   function () {
@@ -17,14 +18,14 @@ drupalSettings.gutenberg._listeners.init.push(
   function () {
     var coreColumnsAllowed =
       drupalSettings.editor.formats.gutenberg.editorSettings.allowedBlocks[
-        "core/columns"
+        'core/columns'
       ];
     var coreImageAllowed =
       drupalSettings.editor.formats.gutenberg.editorSettings.allowedBlocks[
-        "core/image"
+        'core/image'
       ];
     if (coreColumnsAllowed && !coreImageAllowed) {
-      var coreColumnsBlock = wp.blocks.getBlockType("core/columns");
+      var coreColumnsBlock = wp.blocks.getBlockType('core/columns');
       // Remove core/image from the example.
       coreColumnsBlock.example.innerBlocks[0].innerBlocks.splice(1, 1);
     }
@@ -32,7 +33,7 @@ drupalSettings.gutenberg._listeners.init.push(
 
   // Remove most of the columns options.
   function () {
-    var coreColumnsBlock = wp.blocks.getBlockType("core/columns");
+    var coreColumnsBlock = wp.blocks.getBlockType('core/columns');
     coreColumnsBlock.supports.inserter = false;
     coreColumnsBlock.supports.align = false;
     coreColumnsBlock.supports.__experimentalColor = false;
@@ -40,13 +41,13 @@ drupalSettings.gutenberg._listeners.init.push(
 
   // We never want some of the format options.
   function () {
-    wp.richText.unregisterFormatType("core/image");
-    wp.richText.unregisterFormatType("core/text-color");
+    wp.richText.unregisterFormatType('core/image');
+    wp.richText.unregisterFormatType('core/text-color');
   },
 
   // We don't want table styles.
   function () {
-    wp.blocks.unregisterBlockStyle("core/table", "regular");
-    wp.blocks.unregisterBlockStyle("core/table", "stripes");
-  }
+    wp.blocks.unregisterBlockStyle('core/table', 'regular');
+    wp.blocks.unregisterBlockStyle('core/table', 'stripes');
+  },
 );

--- a/packages/composer/amazeelabs/silverback_gutenberg/no-op.ts
+++ b/packages/composer/amazeelabs/silverback_gutenberg/no-op.ts
@@ -1,1 +1,1 @@
-// To keep tcs calm.
+// To keep tsc calm.

--- a/packages/composer/amazeelabs/silverback_gutenberg/no-op.ts
+++ b/packages/composer/amazeelabs/silverback_gutenberg/no-op.ts
@@ -1,0 +1,1 @@
+// To keep tcs calm.

--- a/packages/composer/amazeelabs/silverback_gutenberg/package.json
+++ b/packages/composer/amazeelabs/silverback_gutenberg/package.json
@@ -11,18 +11,24 @@
   "scripts": {
     "precommit": "lint-staged",
     "watch": "jest --watch",
-    "test": "tsc --noEmit && jest --passWithNoTests && if [ -f test.sh ]; then ./test.sh; fi"
+    "test": "yarn test:static && yarn test:unit && yarn test:integration",
+    "prepare": "exit 0",
+    "test:static": "tsc --noEmit && eslint \"**/*.{ts,tsx,js,jsx}\" --ignore-path=\"./.gitignore\" --fix",
+    "test:unit": "jest --passWithNoTests",
+    "test:integration": "exit 0",
+    "test:watch": "jest --watch"
   },
   "dependencies": {},
   "devDependencies": {
-    "@amazeelabs/eslint-config": "^1.4.0",
-    "@amazeelabs/jest-preset": "^1.3.6",
-    "@amazeelabs/prettier-config": "^1.1.0",
-    "@types/jest": "^27.0.2",
-    "eslint": "^7.32.0",
-    "jest": "^27.2.4",
+    "@amazeelabs/eslint-config": "^1.4.5",
+    "@amazeelabs/jest-preset": "^1.3.11",
+    "@amazeelabs/prettier-config": "^1.1.1",
+    "@types/jest": "^27",
+    "eslint": "^8",
+    "jest": "^27",
     "lint-staged": "^11.1.2",
-    "ts-jest": "^27.0.5",
-    "typescript": "^4.4.3"
+    "ts-jest": "^27",
+    "typescript": "^4.4.4",
+    "prettier": "^2"
   }
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/package.json
+++ b/packages/composer/amazeelabs/silverback_gutenberg/package.json
@@ -9,14 +9,11 @@
     "branch": "main"
   },
   "scripts": {
-    "prepare": "amazee-scaffold",
     "precommit": "lint-staged",
     "watch": "jest --watch",
     "test": "tsc --noEmit && jest --passWithNoTests && if [ -f test.sh ]; then ./test.sh; fi"
   },
-  "dependencies": {
-    "@amazeelabs/scaffold": "^1.3.10"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@amazeelabs/eslint-config": "^1.4.0",
     "@amazeelabs/jest-preset": "^1.3.6",

--- a/packages/composer/amazeelabs/silverback_gutenberg/package.json
+++ b/packages/composer/amazeelabs/silverback_gutenberg/package.json
@@ -9,6 +9,23 @@
     "branch": "main"
   },
   "scripts": {
-    "test": "./test.sh"
+    "prepare": "amazee-scaffold",
+    "precommit": "lint-staged",
+    "watch": "jest --watch",
+    "test": "tsc --noEmit && jest --passWithNoTests && if [ -f test.sh ]; then ./test.sh; fi"
+  },
+  "dependencies": {
+    "@amazeelabs/scaffold": "^1.3.10"
+  },
+  "devDependencies": {
+    "@amazeelabs/eslint-config": "^1.4.0",
+    "@amazeelabs/jest-preset": "^1.3.6",
+    "@amazeelabs/prettier-config": "^1.1.0",
+    "@types/jest": "^27.0.2",
+    "eslint": "^7.32.0",
+    "jest": "^27.2.4",
+    "lint-staged": "^11.1.2",
+    "ts-jest": "^27.0.5",
+    "typescript": "^4.4.3"
   }
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
@@ -27,7 +27,7 @@ function hook_silverback_gutenberg_link_processor_outbound_link_alter(
   \Drupal\silverback_gutenberg\LinkProcessor $linkProcessor
 ) {
   $url = $link->getAttribute('href');
-  if ($url && !$linkProcessor->linksToCurrentHost()) {
+  if ($url && !$linkProcessor->linksToCurrentHost($url)) {
     $link->setAttribute('target', '_blank');
     $link->setAttribute('rel', 'noreferrer');
   }

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
@@ -1,16 +1,35 @@
 <?php
 
+/**
+ * @deprecated Use hook_silverback_gutenberg_link_processor_block_attrs_alter
+ */
 function hook_silverback_gutenberg_link_processor_block_attributes_alter(
   array &$attributes,
   string $blockName,
   callable $processUrlCallback
 ) {
-  if ($blockName === 'custom/my-block' && isset($attributes['urls'])) {
+  // Use hook_silverback_gutenberg_link_processor_block_attrs_alter() instead.
+}
+
+/**
+ * @param array $attributes
+ * @param array $context
+ *   Has the following keys:
+ *   - blockName: a string containing the block name
+ *   - processUrlCallback: a callback to process a single URL string
+ *   - processLinksCallback: a callback to process links in an HTML string
+ */
+function hook_silverback_gutenberg_link_processor_block_attrs_alter(array &$attributes, array $context) {
+  if ($context['blockName'] === 'custom/my-links-block' && isset($attributes['urls'])) {
     $attributes['urlsUnprocessed'] = [];
     foreach ($attributes['urls'] as $key => $url) {
       $attributes['urlsUnprocessed'][$key] = $url;
-      $attributes['urls'][$key] = $processUrlCallback($url);
+      $attributes['urls'][$key] = $context['processUrlCallback']($url);
     }
+  }
+  if ($context['blockName'] === 'custom/my-media-block' && isset($attributes['caption'])) {
+    $html = $attributes['caption'];
+    $attributes['caption'] = $context['processLinksCallback']($html);
   }
 }
 

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
@@ -2,7 +2,6 @@
 
 use Drupal\Core\Asset\AttachedAssetsInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element;
 use Drupal\node\NodeInterface;
 use Drupal\silverback_gutenberg\Utils;
 
@@ -71,5 +70,14 @@ function silverback_gutenberg_node_presave(NodeInterface $node) {
         'inbound'
       );
     }
+  }
+}
+
+/**
+ * Implements hook_silverback_gutenberg_link_processor_block_attrs_alter().
+ */
+function silverback_gutenberg_silverback_gutenberg_link_processor_block_attrs_alter(array &$attributes, array $context) {
+  if ($context['blockName'] === 'drupalmedia/drupal-media-entity' && isset($attributes['caption'])) {
+    $attributes['caption'] = $context['processLinksCallback']($attributes['caption']);
   }
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
@@ -54,13 +54,28 @@ class LinkProcessor {
         $blockName = $matches[2];
         $json = $matches[4];
         $attributes = json_decode($json, TRUE);
-        $callback = fn(string $url) => $this->processUrl($url, $direction, $language);
+        $processUrlCallback = fn(string $url) => $this->processUrl($url, $direction, $language);
+        $processLinksCallback = fn(string $html) => $this->processLinks($html, $direction, $language);
+
+        // Note: this hook is deprecated.
         $this->moduleHandler->alter(
           'silverback_gutenberg_link_processor_block_attributes',
           $attributes,
           $blockName,
-          $callback
+          $processUrlCallback
         );
+
+        $context = [
+          'blockName' => $blockName,
+          'processUrlCallback' => $processUrlCallback,
+          'processLinksCallback' => $processLinksCallback,
+        ];
+        $this->moduleHandler->alter(
+          'silverback_gutenberg_link_processor_block_attrs',
+          $attributes,
+          $context
+        );
+
         $jsonNew = json_encode($attributes);
         if ($jsonNew !== $json) {
           $comment->textContent = $matches[1] . $blockName . $matches[3] . $jsonNew . $matches[5];

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
@@ -14,8 +14,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class LinkProcessor {
 
-  protected static bool $processBlocks = TRUE;
-
   protected AliasManagerInterface $pathAliasManager;
   protected ConfigFactoryInterface $configFactory;
   protected ModuleHandlerInterface $moduleHandler;
@@ -54,14 +52,10 @@ class LinkProcessor {
     // This entity kills Gutenberg.
     $processed = str_replace('&#13;', "\r", $processed);
 
-    if (self::$processBlocks) {
-      self::$processBlocks = FALSE;
-
+    if (strpos($processed, '<!-- wp:') !== FALSE) {
       $blocks = (new BlockParser())->parse($processed);
       $this->processBlocks($blocks, $direction, $language);
       $processed = (new BlockSerializer())->serialize_blocks($blocks);
-
-      self::$processBlocks = TRUE;
     }
 
     return $processed;

--- a/packages/composer/amazeelabs/silverback_gutenberg/tsconfig.json
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"@tsconfig/recommended/tsconfig.json","compilerOptions":{"jsx":"react"}}

--- a/packages/composer/amazeelabs/silverback_gutenberg/tsconfig.json
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tsconfig.json
@@ -1,1 +1,15 @@
-{"extends":"@tsconfig/recommended/tsconfig.json","compilerOptions":{"jsx":"react"}}
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "ES2015",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": false,
+    "jsx": "react"
+  },
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Recommended"
+}

--- a/packages/npm/@amazeelabs/silverback-playwright/README.md
+++ b/packages/npm/@amazeelabs/silverback-playwright/README.md
@@ -85,6 +85,12 @@ Tests marked with `@gatsby-both` will be executed in both `gatsby-develop` and
 - `drupal` and `gatsby` provide various constants (ports, URLs, credentials,
   etc.)
 
+## Writing tests
+
+(move "To debug a particular test" here)
+
+- force kill browser
+
 ## Debugging tests
 
 There are few options.
@@ -103,9 +109,15 @@ test.only('my test', async ({ page }) => {
 
 Run the tests with `--headed` (`-h`) flag.
 
-### If you suspect that something is wrong with the test runner
+### To see all logs
 
 Start tests with `--verbose` (`-v`) flag.
+
+This will print
+
+- executed commands
+- Gatsby and Drupal logs
+- debug messages from the test runner
 
 ### Traces
 
@@ -121,7 +133,20 @@ To see the traces, go to your package dir and run
 yarn playwright show-trace ./test-results/path/to/trace.zip
 ```
 
-# Tips
+## Re-running tests
+
+Unlike Cypress, Playwright UI does not have an option to restart a test. But
+there is a workaround:
+
+- put `page.pause()` to the end of your test
+- start tests with `yarn sp-test -h -r`
+- in case if you need to re-run the test, force-kill the browser
+
+One downside of this method is that you won't see error messages if there is a
+runtime error or if an assertion fails. Track
+[#9462](https://github.com/microsoft/playwright/issues/9462) for news.
+
+## Tips
 
 To speedup tests, Drupal state is restored from the `test` snapshot. If you did
 some Drupal changes, remove `apps/silverback-drupal/.silverback-snapshots/test`.

--- a/packages/tests/silverback-gutenberg/.eslintrc.js
+++ b/packages/tests/silverback-gutenberg/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ['@amazeelabs/eslint-config'],
+  root: true,
+};

--- a/packages/tests/silverback-gutenberg/.gitignore
+++ b/packages/tests/silverback-gutenberg/.gitignore
@@ -1,0 +1,9 @@
+### MANAGED BY @amazeelabs/scaffold - START
+.eslintrc.js
+.jest-runner-eslintrc
+.lintstagedrc
+.prettierrc
+jest.config.js
+### MANAGED BY @amazeelabs/scaffold - END
+
+test-results

--- a/packages/tests/silverback-gutenberg/.gitignore
+++ b/packages/tests/silverback-gutenberg/.gitignore
@@ -1,9 +1,1 @@
-### MANAGED BY @amazeelabs/scaffold - START
-.eslintrc.js
-.jest-runner-eslintrc
-.lintstagedrc
-.prettierrc
-jest.config.js
-### MANAGED BY @amazeelabs/scaffold - END
-
 test-results

--- a/packages/tests/silverback-gutenberg/.jest-runner-eslintrc
+++ b/packages/tests/silverback-gutenberg/.jest-runner-eslintrc
@@ -1,0 +1,5 @@
+{
+  "cliOptions": {
+    "ignorePath": "./.gitignore"
+  }
+}

--- a/packages/tests/silverback-gutenberg/.lintstagedrc
+++ b/packages/tests/silverback-gutenberg/.lintstagedrc
@@ -1,8 +1,9 @@
 {
   "*.+(js|ts|tsx)": [
-    "jest --findRelatedTests"
+    "jest --findRelatedTests",
+    "eslint --fix"
   ],
   "*.+(js|ts|tsx|md|mdx|yml)": [
-    "prettier --write --ignore-path .gitignore"
+    "prettier --write"
   ]
 }

--- a/packages/tests/silverback-gutenberg/.lintstagedrc
+++ b/packages/tests/silverback-gutenberg/.lintstagedrc
@@ -1,0 +1,8 @@
+{
+  "*.+(js|ts|tsx)": [
+    "jest --findRelatedTests"
+  ],
+  "*.+(js|ts|tsx|md|mdx|yml)": [
+    "prettier --write --ignore-path .gitignore"
+  ]
+}

--- a/packages/tests/silverback-gutenberg/.npmignore
+++ b/packages/tests/silverback-gutenberg/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/tests/silverback-gutenberg/.prettierrc
+++ b/packages/tests/silverback-gutenberg/.prettierrc
@@ -1,0 +1,1 @@
+"@amazeelabs/prettier-config"

--- a/packages/tests/silverback-gutenberg/jest.config.js
+++ b/packages/tests/silverback-gutenberg/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: '@amazeelabs/jest-preset',
+};

--- a/packages/tests/silverback-gutenberg/package.json
+++ b/packages/tests/silverback-gutenberg/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@-amazeelabs/silverback-gutenberg-tests",
+  "version": "1.0.13",
+  "description": "e2e tests for Silverback Gutenberg.",
+  "author": "Amazee Labs",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "@-amazeelabs/silverback-drupal": "^1.10.23",
+    "@-amazeelabs/silverback_gutenberg": "^1.3.1",
+    "@amazeelabs/scaffold": "^1.3.11",
+    "@amazeelabs/silverback-playwright": "^1.3.3"
+  },
+  "devDependencies": {
+    "@amazeelabs/eslint-config": "^1.3.2",
+    "@amazeelabs/jest-preset": "^1.3.7",
+    "@amazeelabs/prettier-config": "^1.1.0",
+    "@types/jest": "^27.0.1",
+    "eslint": "^7.32.0",
+    "jest": "^27.0.6",
+    "lint-staged": "^11.1.2",
+    "ts-jest": "^27.0.5",
+    "typescript": "^4.3.5"
+  },
+  "scripts": {
+    "prepare": "amazee-scaffold",
+    "precommit": "lint-staged",
+    "test": "tsc --noEmit && jest --passWithNoTests && if [ -f test.sh ]; then ./test.sh; fi && sp-test",
+    "watch": "jest --watch"
+  }
+}

--- a/packages/tests/silverback-gutenberg/package.json
+++ b/packages/tests/silverback-gutenberg/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@-amazeelabs/silverback-drupal": "^1.10.23",
     "@-amazeelabs/silverback_gutenberg": "^1.3.1",
-    "@amazeelabs/scaffold": "^1.3.11",
     "@amazeelabs/silverback-playwright": "^1.3.3"
   },
   "devDependencies": {
@@ -23,7 +22,6 @@
     "typescript": "^4.3.5"
   },
   "scripts": {
-    "prepare": "amazee-scaffold",
     "precommit": "lint-staged",
     "test": "tsc --noEmit && jest --passWithNoTests && if [ -f test.sh ]; then ./test.sh; fi && sp-test",
     "watch": "jest --watch"

--- a/packages/tests/silverback-gutenberg/package.json
+++ b/packages/tests/silverback-gutenberg/package.json
@@ -11,19 +11,25 @@
     "@amazeelabs/silverback-playwright": "^1.3.3"
   },
   "devDependencies": {
-    "@amazeelabs/eslint-config": "^1.3.2",
-    "@amazeelabs/jest-preset": "^1.3.7",
-    "@amazeelabs/prettier-config": "^1.1.0",
-    "@types/jest": "^27.0.1",
-    "eslint": "^7.32.0",
-    "jest": "^27.0.6",
+    "@amazeelabs/eslint-config": "^1.4.5",
+    "@amazeelabs/jest-preset": "^1.3.11",
+    "@amazeelabs/prettier-config": "^1.1.1",
+    "@types/jest": "^27",
+    "eslint": "^8",
+    "jest": "^27",
     "lint-staged": "^11.1.2",
-    "ts-jest": "^27.0.5",
-    "typescript": "^4.3.5"
+    "ts-jest": "^27",
+    "typescript": "^4.4.4",
+    "prettier": "^2"
   },
   "scripts": {
     "precommit": "lint-staged",
-    "test": "tsc --noEmit && jest --passWithNoTests && if [ -f test.sh ]; then ./test.sh; fi && sp-test",
-    "watch": "jest --watch"
+    "test": "yarn test:static && yarn test:unit && yarn test:integration",
+    "watch": "jest --watch",
+    "prepare": "exit 0",
+    "test:static": "tsc --noEmit && eslint \"**/*.{ts,tsx,js,jsx}\" --ignore-path=\"./.gitignore\" --fix",
+    "test:unit": "jest --passWithNoTests",
+    "test:integration": "sp-test",
+    "test:watch": "jest --watch"
   }
 }

--- a/packages/tests/silverback-gutenberg/playwright-tests/link-processor.spec.ts
+++ b/packages/tests/silverback-gutenberg/playwright-tests/link-processor.spec.ts
@@ -138,31 +138,14 @@ test('@gatsby-develop test LinkProcessor', async ({ page }) => {
     expect(await link.getAttribute('href')).toEqual('/en/target-page');
   }
 
-  // Translate the Gutenberg page leaving the contents as is.
+  // Ensure that URLs are correct when translating to German.
 
   await page.goto(`${drupal.baseUrl}/en/node/${nodeId}/translations`);
   await page.click(':text-is("Add"):right-of(:text-is("German"))');
-
-  // Ensure that URLs already lead to German.
-
   await assertLinkHref('[data-type="core/paragraph"] a', `/de/target-page-de`);
   await assertLinkHref('[data-type="custom/teaser"] a', '/de/target-page-de');
   await assertLinkHref(
     '[data-type="drupalmedia/drupal-media-entity"] a',
     '/de/target-page-de',
   );
-
-  await page.click('input:text-is("Save (this translation)")');
-
-  await waitForGatsby();
-
-  // Ensure that URLs lead to German on the frontend.
-
-  await page.goto(`${gatsby.baseUrl}/de/node/${nodeId}`);
-  await page.waitForSelector('.gutenberg-body a');
-  const deLinks = await page.$$('.gutenberg-body a');
-  expect(deLinks).toHaveLength(3);
-  for (const link of deLinks) {
-    expect(await link.getAttribute('href')).toEqual('/de/target-page-de');
-  }
 });

--- a/packages/tests/silverback-gutenberg/playwright-tests/link-processor.spec.ts
+++ b/packages/tests/silverback-gutenberg/playwright-tests/link-processor.spec.ts
@@ -1,0 +1,159 @@
+import {
+  drupal,
+  drupalLogin,
+  gatsby,
+  resetState,
+  waitForGatsby,
+} from '@amazeelabs/silverback-playwright';
+import { expect, test } from '@playwright/test';
+import { $, cd } from 'zx';
+
+test.beforeAll(async () => {
+  await resetState();
+});
+
+test('@gatsby-develop test LinkProcessor', async ({ page }) => {
+  const selectFirstAutocompleteResult = async () =>
+    page.click('.block-editor-link-control__search-results-wrapper button');
+  const getNodeId = async () => {
+    const editLink = await page.waitForSelector(
+      '.tabs--primary :text-is("Edit")',
+    );
+    const href = await editLink.getAttribute('href');
+    return href!.match(/\/node\/([0-9]+)/)![1];
+  };
+  const assertLinkHref = async (selector: string, expectedHref: string) => {
+    const link = await page.waitForSelector(selector);
+    const href = await link.getAttribute('href');
+    expect(href).toEqual(expectedHref);
+  };
+
+  await drupalLogin(page);
+
+  // Create a target page.
+
+  await page.goto(`${drupal.baseUrl}/en/node/add/page`);
+  await page.fill('label:text-is("Title")', 'Target page');
+  await page.click(':text-is("URL alias")');
+  await page.fill('label:text-is("URL alias")', '/target-page');
+  await page.click(':text-is("Save")');
+
+  const targetNodeId = await getNodeId();
+
+  await page.click('.tabs--primary :text-is("Translate")');
+  await page.click(':text-is("Add"):right-of(:text-is("German"))');
+  await page.fill('label:text-is("URL alias")', '/target-page-de');
+  await page.click('input:text-is("Save (this translation)")');
+
+  // Create a Gutenberg page.
+
+  await page.goto(`${drupal.baseUrl}/en/node/add/gutenberg_page`);
+  await page.click('button[aria-label="Add block"]');
+
+  await page.click(':text-is("Paragraph")');
+  await page.type('[data-type="core/paragraph"]', 'link');
+  await page.press('[data-type="core/paragraph"]', 'Meta+a');
+  await page.click('[aria-label="Link"]');
+  await page.fill('[placeholder="Search or type url"]', 'target page');
+  await selectFirstAutocompleteResult();
+
+  await page.click(':text-is("Teaser")');
+  await page.type('[aria-label="Title"]', 'Teaser title');
+  await page.type('[aria-label="Subtitle"]', 'Teaser subtitle');
+  await page.fill('[placeholder="Search or type url"]', 'target page');
+  await selectFirstAutocompleteResult();
+
+  await page.click('.block-editor-inserter__menu :text-is("Media")');
+  await page.click('button:text-is("Media Library") >> nth=-1');
+  await page.check('input[name="media_library_select_form[0]"]');
+  await page.click('button:text-is("Insert")');
+  await page.fill('[aria-label="Write caption…"]', 'link');
+  await page.press('[aria-label="Write caption…"]', 'Meta+a');
+  await page.click('[aria-label="Link"]');
+  await page.fill('[placeholder="Search or type url"]', 'target page');
+  await selectFirstAutocompleteResult();
+
+  await page.click('[aria-label="Settings"]');
+  await page.click(':text-is("Document")');
+  await page.fill('label:text-is("Title")', 'Test link processing');
+  await page.click('input:text-is("Save")');
+
+  const nodeId = await getNodeId();
+
+  // Ensure that internal URLs are stored in Drupal database.
+
+  cd(drupal.path);
+  const result =
+    await $`source .envrc && drush eval 'echo json_encode((new \\Drupal\\gutenberg\\Parser\\BlockParser())->parse(\\Drupal\\node\\Entity\\Node::load(${nodeId})->body->value));'`;
+  const blocks = JSON.parse(result.stdout);
+
+  expect(blocks).toHaveProperty('0.innerBlocks.0');
+  const paragraphBlock = blocks[0].innerBlocks[0];
+  expect(paragraphBlock.blockName).toEqual('core/paragraph');
+  expect(paragraphBlock.innerHTML).toContain(`href="/node/${targetNodeId}"`);
+  expect(paragraphBlock.innerContent[0]).toContain(
+    `href="/node/${targetNodeId}"`,
+  );
+
+  expect(blocks).toHaveProperty('0.innerBlocks.1');
+  const teaserBlock = blocks[0].innerBlocks[1];
+  expect(teaserBlock.blockName).toEqual('custom/teaser');
+  expect(teaserBlock.attrs.url).toEqual(`/node/${targetNodeId}`);
+  expect(teaserBlock.innerHTML).toContain(`href="/node/${targetNodeId}"`);
+  expect(teaserBlock.innerContent[0]).toContain(`href="/node/${targetNodeId}"`);
+
+  expect(blocks).toHaveProperty('0.innerBlocks.2');
+  const mediaBlock = blocks[0].innerBlocks[2];
+  expect(mediaBlock.blockName).toEqual('drupalmedia/drupal-media-entity');
+  expect(mediaBlock.attrs.caption).toContain(`href="/node/${targetNodeId}"`);
+
+  // Ensure that URL aliases are used in the editor.
+
+  await page.goto(`${drupal.baseUrl}/en/node/${nodeId}/edit`);
+  await assertLinkHref('[data-type="core/paragraph"] a', '/en/target-page');
+  await assertLinkHref('[data-type="custom/teaser"] a', '/en/target-page');
+  await assertLinkHref(
+    '[data-type="drupalmedia/drupal-media-entity"] a',
+    '/en/target-page',
+  );
+
+  await waitForGatsby();
+
+  // Ensure that URL aliases are used on the frontend.
+
+  await page.goto(`${gatsby.baseUrl}/en/node/${nodeId}`);
+  await page.waitForSelector('.gutenberg-body a');
+  const links = await page.$$('.gutenberg-body a');
+  expect(links).toHaveLength(3);
+  for (const link of links) {
+    expect(await link.getAttribute('href')).toEqual('/en/target-page');
+  }
+
+  // Translate the Gutenberg page leaving the contents as is.
+
+  await page.goto(`${drupal.baseUrl}/en/node/${nodeId}/translations`);
+  await page.click(':text-is("Add"):right-of(:text-is("German"))');
+
+  // Ensure that URLs already lead to German.
+
+  await assertLinkHref('[data-type="core/paragraph"] a', `/de/target-page-de`);
+  await assertLinkHref('[data-type="custom/teaser"] a', '/de/target-page-de');
+  await assertLinkHref(
+    '[data-type="drupalmedia/drupal-media-entity"] a',
+    '/de/target-page-de',
+  );
+
+  await page.click('input:text-is("Save (this translation)")');
+
+  await waitForGatsby();
+
+  // Ensure that URLs lead to German on the frontend.
+
+  await page.goto(`${gatsby.baseUrl}/de/node/${nodeId}`);
+  await page.waitForSelector('.gutenberg-body a');
+  const deLinks = await page.$$('.gutenberg-body a');
+  expect(deLinks).toHaveLength(3);
+  for (const link of deLinks) {
+    expect(await link.getAttribute('href')).toEqual('/de/target-page-de');
+  }
+});

--- a/packages/tests/silverback-gutenberg/playwright-tests/link-processor.spec.ts
+++ b/packages/tests/silverback-gutenberg/playwright-tests/link-processor.spec.ts
@@ -6,6 +6,7 @@ import {
   waitForGatsby,
 } from '@amazeelabs/silverback-playwright';
 import { expect, test } from '@playwright/test';
+import os from 'os';
 import { $, cd } from 'zx';
 
 test.beforeAll(async () => {
@@ -52,7 +53,10 @@ test('@gatsby-develop test LinkProcessor', async ({ page }) => {
 
   await page.click(':text-is("Paragraph")');
   await page.type('[data-type="core/paragraph"]', 'link');
-  await page.press('[data-type="core/paragraph"]', 'Meta+a');
+  await page.press(
+    '[data-type="core/paragraph"]',
+    os.platform() === 'darwin' ? 'Meta+a' : 'Control+a',
+  );
   await page.click('[aria-label="Link"]');
   await page.fill('[placeholder="Search or type url"]', 'target page');
   await selectFirstAutocompleteResult();
@@ -68,7 +72,10 @@ test('@gatsby-develop test LinkProcessor', async ({ page }) => {
   await page.check('input[name="media_library_select_form[0]"]');
   await page.click('button:text-is("Insert")');
   await page.fill('[aria-label="Write caption…"]', 'link');
-  await page.press('[aria-label="Write caption…"]', 'Meta+a');
+  await page.press(
+    '[aria-label="Write caption…"]',
+    os.platform() === 'darwin' ? 'Meta+a' : 'Control+a',
+  );
   await page.click('[aria-label="Link"]');
   await page.fill('[placeholder="Search or type url"]', 'target page');
   await selectFirstAutocompleteResult();

--- a/packages/tests/silverback-gutenberg/playwright-tests/link-processor.spec.ts
+++ b/packages/tests/silverback-gutenberg/playwright-tests/link-processor.spec.ts
@@ -72,9 +72,11 @@ test('@gatsby-develop test LinkProcessor', async ({ page }) => {
   await page.check('input[name="media_library_select_form[0]"]');
   await page.click('button:text-is("Insert")');
   await page.fill('[aria-label="Write caption…"]', 'link');
-  await page.press(
-    '[aria-label="Write caption…"]',
-    os.platform() === 'darwin' ? 'Meta+a' : 'Control+a',
+  await page.keyboard.press(
+    os.platform() === 'darwin'
+      ? 'Meta+a'
+      : // On Ubuntu, "Control+a" selects all Gutenberg blocks 🤯
+        'Shift+Control+ArrowLeft',
   );
   await page.click('[aria-label="Link"]');
   await page.fill('[placeholder="Search or type url"]', 'target page');

--- a/packages/tests/silverback-gutenberg/tsconfig.json
+++ b/packages/tests/silverback-gutenberg/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"@tsconfig/recommended/tsconfig.json","compilerOptions":{"jsx":"react"}}

--- a/packages/tests/silverback-gutenberg/tsconfig.json
+++ b/packages/tests/silverback-gutenberg/tsconfig.json
@@ -1,1 +1,15 @@
-{"extends":"@tsconfig/recommended/tsconfig.json","compilerOptions":{"jsx":"react"}}
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "ES2015",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": false,
+    "jsx": "react"
+  },
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Recommended"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,6 +2391,18 @@
     jest-util "^27.2.5"
     slash "^3.0.0"
 
+"@jest/console@^27.3.0":
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.3.0.tgz#a55f03a4f7e1e92a5879bdab2e8b9fe4dd5312ba"
+  integrity sha512-+Tr/xoNiosjckq96xIGpDaGsybeIm45VWXpSvDR8T9deXmWjYKX85prhz8yFPhLG4UVOeMo/B6RI/+flw3sO8A==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^27.3.0"
+    jest-util "^27.3.0"
+    slash "^3.0.0"
+
 "@jest/core@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.1.1.tgz#d9d42214920cb96c2a6cc48517cf62d4351da3aa"
@@ -2460,6 +2472,40 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
+"@jest/core@^27.3.0":
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.3.0.tgz#50a521c663181f3a34ecb24bb9fe717e125dc784"
+  integrity sha512-0B3PWQouwS651m8AbQDse08dfRlzLHqSmywRPGYn2ZzU6RT4aP2Xwz8mEWfSPXXZmtwAtNgUXy0Cbt6QsBqKvw==
+  dependencies:
+    "@jest/console" "^27.3.0"
+    "@jest/reporters" "^27.3.0"
+    "@jest/test-result" "^27.3.0"
+    "@jest/transform" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    emittery "^0.8.1"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    jest-changed-files "^27.3.0"
+    jest-config "^27.3.0"
+    jest-haste-map "^27.3.0"
+    jest-message-util "^27.3.0"
+    jest-regex-util "^27.0.6"
+    jest-resolve "^27.3.0"
+    jest-resolve-dependencies "^27.3.0"
+    jest-runner "^27.3.0"
+    jest-runtime "^27.3.0"
+    jest-snapshot "^27.3.0"
+    jest-util "^27.3.0"
+    jest-validate "^27.3.0"
+    jest-watcher "^27.3.0"
+    micromatch "^4.0.4"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
+
 "@jest/environment@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.1.1.tgz#a1f7a552f7008f773988b9c0e445ede35f77bbb7"
@@ -2479,6 +2525,16 @@
     "@jest/types" "^27.2.5"
     "@types/node" "*"
     jest-mock "^27.2.5"
+
+"@jest/environment@^27.3.0":
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.3.0.tgz#21b85e6f0baa18e92c5bb173a65c0df24565536d"
+  integrity sha512-OWx5RBd8QaPLlw7fL6l2IVyhYDpamaW3dDXlBnXb4IPGCIwoXAHZkmHV+VPIzb6xAkcPyXOmVm/rSaEneTqweg==
+  dependencies:
+    "@jest/fake-timers" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    jest-mock "^27.3.0"
 
 "@jest/fake-timers@^27.1.1":
   version "27.1.1"
@@ -2504,6 +2560,18 @@
     jest-mock "^27.2.5"
     jest-util "^27.2.5"
 
+"@jest/fake-timers@^27.3.0":
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.3.0.tgz#716f166f56abc01901b7823da503bf16c8a00ade"
+  integrity sha512-GCWgnItK6metb75QKflFxcVRlraVGomZonBQ+9B5UPc6wxBB3xzS7dATDWe/73R5P6BfnzCEaiizna771M5r9w==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    "@sinonjs/fake-timers" "^8.0.1"
+    "@types/node" "*"
+    jest-message-util "^27.3.0"
+    jest-mock "^27.3.0"
+    jest-util "^27.3.0"
+
 "@jest/globals@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.1.1.tgz#cfe5f4d5b37483cef62b79612128ccc7e3c951d8"
@@ -2521,6 +2589,15 @@
     "@jest/environment" "^27.2.5"
     "@jest/types" "^27.2.5"
     expect "^27.2.5"
+
+"@jest/globals@^27.3.0":
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.3.0.tgz#8822f9a72aea428e3f11a688ff13c7992bfe1ea4"
+  integrity sha512-EEqmQHMLXgEZfchMVAavUfJuZmORRrP+zhomfREqVE85d1nccd7nw8uN4FQDJ53m5Glm1XtVCyOIJ9kQLrqjeA==
+  dependencies:
+    "@jest/environment" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    expect "^27.3.0"
 
 "@jest/reporters@^27.1.1":
   version "27.1.1"
@@ -2583,6 +2660,37 @@
     terminal-link "^2.0.0"
     v8-to-istanbul "^8.1.0"
 
+"@jest/reporters@^27.3.0":
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.3.0.tgz#8d5fd17916aeb1ab415b3ce0a94a31bda654020b"
+  integrity sha512-D9QLaLgbH+nIjDbKIvoX7yiRX6aXHO56/GzOxKNzKuvJVYhrzeQHcCMttXpp5SB08TdxVvFOPKZfFvkIcVgfBA==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^27.3.0"
+    "@jest/test-result" "^27.3.0"
+    "@jest/transform" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    graceful-fs "^4.2.4"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^4.0.3"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.2"
+    jest-haste-map "^27.3.0"
+    jest-resolve "^27.3.0"
+    jest-util "^27.3.0"
+    jest-worker "^27.3.0"
+    slash "^3.0.0"
+    source-map "^0.6.0"
+    string-length "^4.0.1"
+    terminal-link "^2.0.0"
+    v8-to-istanbul "^8.1.0"
+
 "@jest/source-map@^27.0.6":
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.0.6.tgz#be9e9b93565d49b0548b86e232092491fb60551f"
@@ -2612,6 +2720,16 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
+"@jest/test-result@^27.3.0":
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.3.0.tgz#e093c5d9eb34afa1b653cdb550c4bcaeb3096233"
+  integrity sha512-5+rYZgj562oPKjExQngfboobeIF2FSrgAvoxlkrogEMIbgT7FY+VAMIkp03klVfJtqo3XKzVWkTfsDSmZFI29w==
+  dependencies:
+    "@jest/console" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
 "@jest/test-sequencer@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.1.1.tgz#cea3722ec6f6330000240fd999ad3123adaf5992"
@@ -2631,6 +2749,16 @@
     graceful-fs "^4.2.4"
     jest-haste-map "^27.2.5"
     jest-runtime "^27.2.5"
+
+"@jest/test-sequencer@^27.3.0":
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.3.0.tgz#ac245f4f29ce7f81ae5afa441e5bf7bbdd342ef4"
+  integrity sha512-6eQHyBUCtK06sPfsufzEVijZtAtT7yGR1qaAZBlcz6P+FGJ569VW2O5o7mZc+L++uZc7BH4X2Ks7SMIgy1npJw==
+  dependencies:
+    "@jest/test-result" "^27.3.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^27.3.0"
+    jest-runtime "^27.3.0"
 
 "@jest/transform@^26.6.2":
   version "26.6.2"
@@ -2689,6 +2817,27 @@
     jest-haste-map "^27.2.5"
     jest-regex-util "^27.0.6"
     jest-util "^27.2.5"
+    micromatch "^4.0.4"
+    pirates "^4.0.1"
+    slash "^3.0.0"
+    source-map "^0.6.1"
+    write-file-atomic "^3.0.0"
+
+"@jest/transform@^27.3.0":
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.3.0.tgz#f2a63883eaada30f8141938ec1ad23ba7fdfb97e"
+  integrity sha512-IKrFhIT/+WIfeNjIRKTwQN7HYCdjKF/mmBqoD660gyGWVw1MzCO9pQuEJK9GXEnFWIuOcMHlm8XfUaDohP/zxA==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/types" "^27.2.5"
+    babel-plugin-istanbul "^6.0.0"
+    chalk "^4.0.0"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^27.3.0"
+    jest-regex-util "^27.0.6"
+    jest-util "^27.3.0"
     micromatch "^4.0.4"
     pirates "^4.0.1"
     slash "^3.0.0"
@@ -6746,7 +6895,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^27":
+"@types/jest@^27", "@types/jest@^27.0.1", "@types/jest@^27.0.2":
   version "27.0.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.2.tgz#ac383c4d4aaddd29bbf2b916d8d105c304a5fcd7"
   integrity sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==
@@ -8758,6 +8907,20 @@ babel-jest@^27.2.5:
   integrity sha512-GC9pWCcitBhSuF7H3zl0mftoKizlswaF0E3qi+rPL417wKkCB0d+Sjjb0OfXvxj7gWiBf497ldgRMii68Xz+2g==
   dependencies:
     "@jest/transform" "^27.2.5"
+    "@jest/types" "^27.2.5"
+    "@types/babel__core" "^7.1.14"
+    babel-plugin-istanbul "^6.0.0"
+    babel-preset-jest "^27.2.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    slash "^3.0.0"
+
+babel-jest@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.3.0.tgz#72237bff40e1fdaaf869bcaaa43bec58b51b6159"
+  integrity sha512-+Utvd2yZkT7tkgbBqVcH3uRpgRSTKRi0uBtVkjmuw2jFxp45rQ9fROSqqeHKzHYRelgdVOtQ3M745Wnyme/xOg==
+  dependencies:
+    "@jest/transform" "^27.3.0"
     "@jest/types" "^27.2.5"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.0.0"
@@ -14629,6 +14792,18 @@ expect@^27.2.5:
     jest-message-util "^27.2.5"
     jest-regex-util "^27.0.6"
 
+expect@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-27.3.0.tgz#6cf2864a2553fe8ea68e19a6ce1641b08c3a5a98"
+  integrity sha512-JBRU82EBkZUBqLBAoF3ovzNGEBm14QQnePK4PmZdm6de6q/UzPnmIuWP3dRCw/FE8wRQhf/1eKzy1p1q8d6EvQ==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    ansi-styles "^5.0.0"
+    jest-get-type "^27.0.6"
+    jest-matcher-utils "^27.3.0"
+    jest-message-util "^27.3.0"
+    jest-regex-util "^27.0.6"
+
 express-graphql@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/express-graphql/-/express-graphql-0.12.0.tgz#58deabc309909ca2c9fe2f83f5fbe94429aa23df"
@@ -18771,6 +18946,15 @@ jest-changed-files@^27.2.5:
     execa "^5.0.0"
     throat "^6.0.1"
 
+jest-changed-files@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.3.0.tgz#22a02cc2b34583fc66e443171dc271c0529d263c"
+  integrity sha512-9DJs9garMHv4RhylUMZgbdCJ3+jHSkpL9aaVKp13xtXAD80qLTLrqcDZL1PHA9dYA0bCI86Nv2BhkLpLhrBcPg==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    execa "^5.0.0"
+    throat "^6.0.1"
+
 jest-circus@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.1.1.tgz#08dd3ec5cbaadce68ce6388ebccbe051d1b34bc6"
@@ -18821,6 +19005,31 @@ jest-circus@^27.2.5:
     stack-utils "^2.0.3"
     throat "^6.0.1"
 
+jest-circus@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.3.0.tgz#adc822231f5e634bd676a1eeaa7f4cd6b840cc1d"
+  integrity sha512-i2P6t92Z6qujHD7C0nVYWm9YofUBMbOOTE9q9vEGi9qFotKUZv1H8M0H3NPTOWButgFuSXZfcwGBXGDAt7b9NA==
+  dependencies:
+    "@jest/environment" "^27.3.0"
+    "@jest/test-result" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    dedent "^0.7.0"
+    expect "^27.3.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^27.3.0"
+    jest-matcher-utils "^27.3.0"
+    jest-message-util "^27.3.0"
+    jest-runtime "^27.3.0"
+    jest-snapshot "^27.3.0"
+    jest-util "^27.3.0"
+    pretty-format "^27.3.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+    throat "^6.0.1"
+
 jest-cli@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.1.1.tgz#6491a0278231ffee61083ad468809328e96a8eb2"
@@ -18854,6 +19063,24 @@ jest-cli@^27.2.5:
     jest-config "^27.2.5"
     jest-util "^27.2.5"
     jest-validate "^27.2.5"
+    prompts "^2.0.1"
+    yargs "^16.2.0"
+
+jest-cli@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.3.0.tgz#f9d4278c6ffa1a77127d9d22d7167c2606b1a0f5"
+  integrity sha512-PUM2RHhqgGRuGc+7QTuyfqPPWGDTCQNMKhtlVBTBYOvhP+7g8a1a7OztM/wfpsKHfqQLHFIe1Mms6jVSXSi4Vg==
+  dependencies:
+    "@jest/core" "^27.3.0"
+    "@jest/test-result" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    import-local "^3.0.2"
+    jest-config "^27.3.0"
+    jest-util "^27.3.0"
+    jest-validate "^27.3.0"
     prompts "^2.0.1"
     yargs "^16.2.0"
 
@@ -18911,6 +19138,33 @@ jest-config@^27.2.5:
     micromatch "^4.0.4"
     pretty-format "^27.2.5"
 
+jest-config@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.3.0.tgz#d5d614098e042b4b33ca8a19aca93f8cc82999a4"
+  integrity sha512-hGknSnu6qJmwENNSUNY4qQjE9PENIYp4P8yHLVzo7qoQN4wuYHZuZEwAKaoQ66iHeSXmcZkCqFvAUa5WFdB0sg==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    babel-jest "^27.3.0"
+    chalk "^4.0.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.1"
+    graceful-fs "^4.2.4"
+    is-ci "^3.0.0"
+    jest-circus "^27.3.0"
+    jest-environment-jsdom "^27.3.0"
+    jest-environment-node "^27.3.0"
+    jest-get-type "^27.0.6"
+    jest-jasmine2 "^27.3.0"
+    jest-regex-util "^27.0.6"
+    jest-resolve "^27.3.0"
+    jest-runner "^27.3.0"
+    jest-util "^27.3.0"
+    jest-validate "^27.3.0"
+    micromatch "^4.0.4"
+    pretty-format "^27.3.0"
+
 jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -18951,6 +19205,16 @@ jest-diff@^27.2.5:
     jest-get-type "^27.0.6"
     pretty-format "^27.2.5"
 
+jest-diff@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.3.0.tgz#4d6f6f9d34f7e2a359b3c7eb142bba4de1e37695"
+  integrity sha512-Nl2rE58B2ye+RvPcU4hN+6wBCHxX7aWz6RMTMFxe9jAg8ZueMj5QQ+T/nmHRutbBc5BEjrbbEWOrRzp9rUEsYA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.0.6"
+    jest-get-type "^27.0.6"
+    pretty-format "^27.3.0"
+
 jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
@@ -18985,6 +19249,17 @@ jest-each@^27.2.5:
     jest-util "^27.2.5"
     pretty-format "^27.2.5"
 
+jest-each@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.3.0.tgz#7976cf15bebeef28aa5108a589f4c335b6f0eec9"
+  integrity sha512-i7qQt+puYusxOoiNyq/M6EyNcfEbvKvqOp89FbiHfm6/POTxgzpp5wAmoS9+BAssoX20t7Zt1A1M7yT3FLVvdg==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    chalk "^4.0.0"
+    jest-get-type "^27.0.6"
+    jest-util "^27.3.0"
+    pretty-format "^27.3.0"
+
 jest-environment-jsdom@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.1.1.tgz#e53e98a16e6a764b8ee8db3b29b3a8c27db06f66"
@@ -19011,6 +19286,19 @@ jest-environment-jsdom@^27.2.5:
     jest-util "^27.2.5"
     jsdom "^16.6.0"
 
+jest-environment-jsdom@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.3.0.tgz#bdf6282ff12a68fbc77cb26d6f56c6bddddd5f58"
+  integrity sha512-2R1w1z7ZlQkK22bo/MrMp7ItuCxXXFspn3HNdbusbtW4OfutaPNWPmAch1Shtuu7G75jEnDb2q0PXSfFD6kEHQ==
+  dependencies:
+    "@jest/environment" "^27.3.0"
+    "@jest/fake-timers" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    jest-mock "^27.3.0"
+    jest-util "^27.3.0"
+    jsdom "^16.6.0"
+
 jest-environment-node@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.1.1.tgz#97425d4762b2aeab15892ffba08c6cbed7653e75"
@@ -19034,6 +19322,18 @@ jest-environment-node@^27.2.5:
     "@types/node" "*"
     jest-mock "^27.2.5"
     jest-util "^27.2.5"
+
+jest-environment-node@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.3.0.tgz#32483ad819a4b93ba8cf89614a5fb108efba6566"
+  integrity sha512-bH2Zb73K4x2Yw8j83mmlJUUOFJLzwIpupRvlS9PXiCeIgVTPxL5syBeq5lz310DQBQkNLDTSD5+yYRhheVKvWg==
+  dependencies:
+    "@jest/environment" "^27.3.0"
+    "@jest/fake-timers" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    jest-mock "^27.3.0"
+    jest-util "^27.3.0"
 
 jest-get-type@^25.2.6:
   version "25.2.6"
@@ -19111,6 +19411,26 @@ jest-haste-map@^27.2.5:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-haste-map@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.3.0.tgz#06305f57064af766fdbb54da4c4bc663f72e8a78"
+  integrity sha512-HV7BXCWhHFuQyLCnmy+VzvYQDccTdt5gpmt2abwIrWTnQiHNAklLB3Djq7Ze3OypTmWBMLgF8AHcKNmLKx8Rzw==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    "@types/graceful-fs" "^4.1.2"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-regex-util "^27.0.6"
+    jest-serializer "^27.0.6"
+    jest-util "^27.3.0"
+    jest-worker "^27.3.0"
+    micromatch "^4.0.4"
+    walker "^1.0.7"
+  optionalDependencies:
+    fsevents "^2.3.2"
+
 jest-jasmine2@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.1.1.tgz#efb9e7b70ce834c35c91e1a2f01bb41b462fad43"
@@ -19159,6 +19479,30 @@ jest-jasmine2@^27.2.5:
     pretty-format "^27.2.5"
     throat "^6.0.1"
 
+jest-jasmine2@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.3.0.tgz#d5ac6bec10f6696da99d990bf3df2377578fd331"
+  integrity sha512-c12xS913sE56pBYZYIuukttDyMJTgK+T/aYKuHse/jyBHk2r78IFxrEl0BL8iiezLZw6g6bKtyww/j9XWOVxqg==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^27.3.0"
+    "@jest/source-map" "^27.0.6"
+    "@jest/test-result" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    expect "^27.3.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^27.3.0"
+    jest-matcher-utils "^27.3.0"
+    jest-message-util "^27.3.0"
+    jest-runtime "^27.3.0"
+    jest-snapshot "^27.3.0"
+    jest-util "^27.3.0"
+    pretty-format "^27.3.0"
+    throat "^6.0.1"
+
 jest-leak-detector@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.1.1.tgz#8e05ec4b339814fc4202f07d875da65189e3d7d4"
@@ -19174,6 +19518,14 @@ jest-leak-detector@^27.2.5:
   dependencies:
     jest-get-type "^27.0.6"
     pretty-format "^27.2.5"
+
+jest-leak-detector@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.3.0.tgz#2a881226a08068f6c2f3f238a65a788d4d3e787e"
+  integrity sha512-xlCDZUaVVpCOAAiW7b8sgxIzTkEmpElwmWe9wVdU01WnFCvQ0aQiq2JTNbeCgalhjxJVeZlACRHIsLjWrmtlRA==
+  dependencies:
+    jest-get-type "^27.0.6"
+    pretty-format "^27.3.0"
 
 jest-matcher-utils@^26.6.2:
   version "26.6.2"
@@ -19204,6 +19556,16 @@ jest-matcher-utils@^27.2.5:
     jest-diff "^27.2.5"
     jest-get-type "^27.0.6"
     pretty-format "^27.2.5"
+
+jest-matcher-utils@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.3.0.tgz#82c41750db4384d7a8db319348752df2bb0acf7a"
+  integrity sha512-AK2ds5J29PJcZhfJ/5J8ycbjCXTHnwc6lQeOV1a1GahU1MCpSvyHG1iIevyvp6PXPy6r0q9ywGdCObWHmkK16g==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.3.0"
+    jest-get-type "^27.0.6"
+    pretty-format "^27.3.0"
 
 jest-message-util@^26.6.2:
   version "26.6.2"
@@ -19250,6 +19612,21 @@ jest-message-util@^27.2.5:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-message-util@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.3.0.tgz#d64d24c2f19111ea916c092fea015076bb7615fe"
+  integrity sha512-0c79aomiyE3mlta4NCWsICydvv2W0HlM/eVx46YEO+vdDuwUvNuQn8LqOtcHC1hSd25i03RrPvscrWgHBJQpRQ==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^27.2.5"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.4"
+    pretty-format "^27.3.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.1.1.tgz#c7a2e81301fdcf3dab114931d23d89ec9d0c3a82"
@@ -19262,6 +19639,14 @@ jest-mock@^27.2.5:
   version "27.2.5"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.2.5.tgz#0ec38d5ff1e49c4802e7a4a8179e8d7a2fd84de0"
   integrity sha512-HiMB3LqE9RzmeMzZARi2Bz3NoymxyP0gCid4y42ca1djffNtYFKgI220aC1VP1mUZ8rbpqZbHZOJ15093bZV/Q==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+
+jest-mock@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.3.0.tgz#ddf0ec3cc3e68c8ccd489bef4d1f525571a1b867"
+  integrity sha512-ziZiLk0elZOQjD08bLkegBzv5hCABu/c8Ytx45nJKkysQwGaonvmTxwjLqEA4qGdasq9o2I8/HtdGMNnVsMTGw==
   dependencies:
     "@jest/types" "^27.2.5"
     "@types/node" "*"
@@ -19299,6 +19684,15 @@ jest-resolve-dependencies@^27.2.5:
     jest-regex-util "^27.0.6"
     jest-snapshot "^27.2.5"
 
+jest-resolve-dependencies@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.3.0.tgz#1467ed51d87635aec7133b2e29a283500f4609d1"
+  integrity sha512-YVmlWHdSUCOLrJl8lOIjda6+DtbgOCfExfoSx9gvHFYaXPq0UP2EELiX514H0rURTbSaLsDTodLNyqqEd/IqeA==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    jest-regex-util "^27.0.6"
+    jest-snapshot "^27.3.0"
+
 jest-resolve@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.1.1.tgz#3a86762f9affcad9697bc88140b0581b623add33"
@@ -19329,6 +19723,22 @@ jest-resolve@^27.2.5:
     jest-util "^27.2.5"
     jest-validate "^27.2.5"
     resolve "^1.20.0"
+    slash "^3.0.0"
+
+jest-resolve@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.3.0.tgz#ffd1db6828b3ee2243f4e4973d80d02e988f2443"
+  integrity sha512-SZxjtEkM0+f5vxJVpaGztQfnzEqgVnQqHzeGW1P9UON9qDtAET01HWaPCnb10SNUaNRG9NhhOMP418zl44FaIA==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^27.3.0"
+    jest-pnp-resolver "^1.2.2"
+    jest-util "^27.3.0"
+    jest-validate "^27.3.0"
+    resolve "^1.20.0"
+    resolve.exports "^1.1.0"
     slash "^3.0.0"
 
 jest-runner-eslint@^1.0.0:
@@ -19397,6 +19807,34 @@ jest-runner@^27.2.5:
     source-map-support "^0.5.6"
     throat "^6.0.1"
 
+jest-runner@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.3.0.tgz#0affed8232bf50daacb186091a98e4c50cc83c7a"
+  integrity sha512-gbkXXJdV5YpGjHvHZAAl5905qAgi+HLYO9lvLqGBxAWpx+oPOpBcMZfkRef7u86heZj1lmULzEdLjY459Z+rNQ==
+  dependencies:
+    "@jest/console" "^27.3.0"
+    "@jest/environment" "^27.3.0"
+    "@jest/test-result" "^27.3.0"
+    "@jest/transform" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    emittery "^0.8.1"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    jest-docblock "^27.0.6"
+    jest-environment-jsdom "^27.3.0"
+    jest-environment-node "^27.3.0"
+    jest-haste-map "^27.3.0"
+    jest-leak-detector "^27.3.0"
+    jest-message-util "^27.3.0"
+    jest-resolve "^27.3.0"
+    jest-runtime "^27.3.0"
+    jest-util "^27.3.0"
+    jest-worker "^27.3.0"
+    source-map-support "^0.5.6"
+    throat "^6.0.1"
+
 jest-runtime@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.1.1.tgz#bd0a0958a11c2f7d94d2e5f6f71864ad1c65fe44"
@@ -19459,6 +19897,38 @@ jest-runtime@^27.2.5:
     jest-snapshot "^27.2.5"
     jest-util "^27.2.5"
     jest-validate "^27.2.5"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^16.2.0"
+
+jest-runtime@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.3.0.tgz#6957699d74a675441f50627bca9fe8b035c82b83"
+  integrity sha512-CRhIM45UlYVY2u5IfCx+0jsCm6DLvY9fz34CzDi3c4W1prb7hGKLOJlxbayQIHHMhUx22WhK4eRqXjOKDnKdAQ==
+  dependencies:
+    "@jest/console" "^27.3.0"
+    "@jest/environment" "^27.3.0"
+    "@jest/globals" "^27.3.0"
+    "@jest/source-map" "^27.0.6"
+    "@jest/test-result" "^27.3.0"
+    "@jest/transform" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+    cjs-module-lexer "^1.0.0"
+    collect-v8-coverage "^1.0.0"
+    execa "^5.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^27.3.0"
+    jest-message-util "^27.3.0"
+    jest-mock "^27.3.0"
+    jest-regex-util "^27.0.6"
+    jest-resolve "^27.3.0"
+    jest-snapshot "^27.3.0"
+    jest-util "^27.3.0"
+    jest-validate "^27.3.0"
     slash "^3.0.0"
     strip-bom "^4.0.0"
     yargs "^16.2.0"
@@ -19539,6 +20009,36 @@ jest-snapshot@^27.2.5:
     pretty-format "^27.2.5"
     semver "^7.3.2"
 
+jest-snapshot@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.3.0.tgz#3792e1d22633050a1817c3e0d9a18666d43746ee"
+  integrity sha512-JaFXNS6D1BxvU2ORKaQwpen3Qic7IJAtGb09lbYiYk/GXXlde67Ts990i2nC5oBs0CstbeQE3jTeRayIZpM1Pw==
+  dependencies:
+    "@babel/core" "^7.7.2"
+    "@babel/generator" "^7.7.2"
+    "@babel/parser" "^7.7.2"
+    "@babel/plugin-syntax-typescript" "^7.7.2"
+    "@babel/traverse" "^7.7.2"
+    "@babel/types" "^7.0.0"
+    "@jest/transform" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/babel__traverse" "^7.0.4"
+    "@types/prettier" "^2.1.5"
+    babel-preset-current-node-syntax "^1.0.0"
+    chalk "^4.0.0"
+    expect "^27.3.0"
+    graceful-fs "^4.2.4"
+    jest-diff "^27.3.0"
+    jest-get-type "^27.0.6"
+    jest-haste-map "^27.3.0"
+    jest-matcher-utils "^27.3.0"
+    jest-message-util "^27.3.0"
+    jest-resolve "^27.3.0"
+    jest-util "^27.3.0"
+    natural-compare "^1.4.0"
+    pretty-format "^27.3.0"
+    semver "^7.3.2"
+
 jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
@@ -19575,6 +20075,18 @@ jest-util@^27.2.5:
     is-ci "^3.0.0"
     picomatch "^2.2.3"
 
+jest-util@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.3.0.tgz#178f211d308c25c9593d1c5a2f2b3aef28411741"
+  integrity sha512-SFSDBGKkxXi4jClmU1WLp/cMMlb4YX6+5Lb0CUySxmonArio8yJ2NALMWvQuXchgySiH7Rb912hVZ2QZ6t3x7w==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^3.0.0"
+    picomatch "^2.2.3"
+
 jest-validate@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.1.1.tgz#0783733af02c988d503995fc0a07bbdc58c7dd50"
@@ -19598,6 +20110,18 @@ jest-validate@^27.2.5:
     jest-get-type "^27.0.6"
     leven "^3.1.0"
     pretty-format "^27.2.5"
+
+jest-validate@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.3.0.tgz#1a92dd52d0a493037f6e1776c49457c031e0adc8"
+  integrity sha512-5oqWnb9MrkicE+ywR+BxoZr0L7H3WBDAt6LZggnyFHieAk8nnIQAKRpSodNPhiNJTwaMSbNjCe7SxAzKwTsBoA==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    camelcase "^6.2.0"
+    chalk "^4.0.0"
+    jest-get-type "^27.0.6"
+    leven "^3.1.0"
+    pretty-format "^27.3.0"
 
 jest-watch-select-projects@^2:
   version "2.0.0"
@@ -19647,6 +20171,19 @@ jest-watcher@^27.2.5:
     jest-util "^27.2.5"
     string-length "^4.0.1"
 
+jest-watcher@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.3.0.tgz#13730b347e2ae8ba3c9435055bdad2ad73e5c348"
+  integrity sha512-xpTFRhqzUnNwTGaSBoHcyXROGbAfj2u4LS7Xosb+hzgrFgWgiHtCy3PWyN1DQk31Na98bBjXKxAbfSBACrvEiQ==
+  dependencies:
+    "@jest/test-result" "^27.3.0"
+    "@jest/types" "^27.2.5"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    jest-util "^27.3.0"
+    string-length "^4.0.1"
+
 jest-worker@^25.1.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.5.0.tgz#2611d071b79cea0f43ee57a3d118593ac1547db1"
@@ -19682,6 +20219,15 @@ jest-worker@^27.2.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jest-worker@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.3.0.tgz#6b636b63b6672208b91b92d8dcde112d1d4dba2d"
+  integrity sha512-xTTvvJqOjKBqE1AmwDHiQN8qzp9VoT981LtfXA+XiJVxHn4435vpnrzVcJ6v/ESiuB+IXPjZakn/ppT00xBCWA==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
 jest@^27:
   version "27.2.5"
   resolved "https://registry.yarnpkg.com/jest/-/jest-27.2.5.tgz#7d8a5c8781a160f693beeb7c68e46c16ef948148"
@@ -19699,6 +20245,15 @@ jest@^27.0.0:
     "@jest/core" "^27.1.1"
     import-local "^3.0.2"
     jest-cli "^27.1.1"
+
+jest@^27.0.6, jest@^27.2.4:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-27.3.0.tgz#25f0e02aaa51d53bc6e1941eb4838a3452f3320e"
+  integrity sha512-ZSwT6ROUbUs3bXirxzxBvohE/1y7t+IHIu3fL8WgIeJppE2XsFoa2dB03CI9kXA81znW0Kt0t2R+QVOWeY8cYw==
+  dependencies:
+    "@jest/core" "^27.3.0"
+    import-local "^3.0.2"
+    jest-cli "^27.3.0"
 
 jimp@^0.14.0:
   version "0.14.0"
@@ -24799,6 +25354,16 @@ pretty-format@^27.2.5:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
+pretty-format@^27.3.0:
+  version "27.3.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.3.0.tgz#ab4679ffc25dd9bc29bab220a4a70a873a19600e"
+  integrity sha512-Nkdd0xmxZdjCe6GoJomHnrLcCYGYzZKI/fRnUX0sCwDai2mmCHJfC9Ecx33lYgaxAFS/pJCAqhfxmWlm1wNVag==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -26382,6 +26947,11 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
+resolve.exports@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
+  integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
 resolve@1.1.7:
   version "1.1.7"
@@ -29404,7 +29974,7 @@ typescript@^4.0.2, typescript@^4.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
   integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
-typescript@^4.4.4:
+typescript@^4.3.5, typescript@^4.4.3, typescript@^4.4.4:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,18 +2391,6 @@
     jest-util "^27.2.5"
     slash "^3.0.0"
 
-"@jest/console@^27.3.0":
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.3.0.tgz#a55f03a4f7e1e92a5879bdab2e8b9fe4dd5312ba"
-  integrity sha512-+Tr/xoNiosjckq96xIGpDaGsybeIm45VWXpSvDR8T9deXmWjYKX85prhz8yFPhLG4UVOeMo/B6RI/+flw3sO8A==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    jest-message-util "^27.3.0"
-    jest-util "^27.3.0"
-    slash "^3.0.0"
-
 "@jest/core@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.1.1.tgz#d9d42214920cb96c2a6cc48517cf62d4351da3aa"
@@ -2472,40 +2460,6 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/core@^27.3.0":
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.3.0.tgz#50a521c663181f3a34ecb24bb9fe717e125dc784"
-  integrity sha512-0B3PWQouwS651m8AbQDse08dfRlzLHqSmywRPGYn2ZzU6RT4aP2Xwz8mEWfSPXXZmtwAtNgUXy0Cbt6QsBqKvw==
-  dependencies:
-    "@jest/console" "^27.3.0"
-    "@jest/reporters" "^27.3.0"
-    "@jest/test-result" "^27.3.0"
-    "@jest/transform" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    ansi-escapes "^4.2.1"
-    chalk "^4.0.0"
-    emittery "^0.8.1"
-    exit "^0.1.2"
-    graceful-fs "^4.2.4"
-    jest-changed-files "^27.3.0"
-    jest-config "^27.3.0"
-    jest-haste-map "^27.3.0"
-    jest-message-util "^27.3.0"
-    jest-regex-util "^27.0.6"
-    jest-resolve "^27.3.0"
-    jest-resolve-dependencies "^27.3.0"
-    jest-runner "^27.3.0"
-    jest-runtime "^27.3.0"
-    jest-snapshot "^27.3.0"
-    jest-util "^27.3.0"
-    jest-validate "^27.3.0"
-    jest-watcher "^27.3.0"
-    micromatch "^4.0.4"
-    rimraf "^3.0.0"
-    slash "^3.0.0"
-    strip-ansi "^6.0.0"
-
 "@jest/environment@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.1.1.tgz#a1f7a552f7008f773988b9c0e445ede35f77bbb7"
@@ -2525,16 +2479,6 @@
     "@jest/types" "^27.2.5"
     "@types/node" "*"
     jest-mock "^27.2.5"
-
-"@jest/environment@^27.3.0":
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.3.0.tgz#21b85e6f0baa18e92c5bb173a65c0df24565536d"
-  integrity sha512-OWx5RBd8QaPLlw7fL6l2IVyhYDpamaW3dDXlBnXb4IPGCIwoXAHZkmHV+VPIzb6xAkcPyXOmVm/rSaEneTqweg==
-  dependencies:
-    "@jest/fake-timers" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    jest-mock "^27.3.0"
 
 "@jest/fake-timers@^27.1.1":
   version "27.1.1"
@@ -2560,18 +2504,6 @@
     jest-mock "^27.2.5"
     jest-util "^27.2.5"
 
-"@jest/fake-timers@^27.3.0":
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.3.0.tgz#716f166f56abc01901b7823da503bf16c8a00ade"
-  integrity sha512-GCWgnItK6metb75QKflFxcVRlraVGomZonBQ+9B5UPc6wxBB3xzS7dATDWe/73R5P6BfnzCEaiizna771M5r9w==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    "@sinonjs/fake-timers" "^8.0.1"
-    "@types/node" "*"
-    jest-message-util "^27.3.0"
-    jest-mock "^27.3.0"
-    jest-util "^27.3.0"
-
 "@jest/globals@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.1.1.tgz#cfe5f4d5b37483cef62b79612128ccc7e3c951d8"
@@ -2589,15 +2521,6 @@
     "@jest/environment" "^27.2.5"
     "@jest/types" "^27.2.5"
     expect "^27.2.5"
-
-"@jest/globals@^27.3.0":
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.3.0.tgz#8822f9a72aea428e3f11a688ff13c7992bfe1ea4"
-  integrity sha512-EEqmQHMLXgEZfchMVAavUfJuZmORRrP+zhomfREqVE85d1nccd7nw8uN4FQDJ53m5Glm1XtVCyOIJ9kQLrqjeA==
-  dependencies:
-    "@jest/environment" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    expect "^27.3.0"
 
 "@jest/reporters@^27.1.1":
   version "27.1.1"
@@ -2660,37 +2583,6 @@
     terminal-link "^2.0.0"
     v8-to-istanbul "^8.1.0"
 
-"@jest/reporters@^27.3.0":
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.3.0.tgz#8d5fd17916aeb1ab415b3ce0a94a31bda654020b"
-  integrity sha512-D9QLaLgbH+nIjDbKIvoX7yiRX6aXHO56/GzOxKNzKuvJVYhrzeQHcCMttXpp5SB08TdxVvFOPKZfFvkIcVgfBA==
-  dependencies:
-    "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^27.3.0"
-    "@jest/test-result" "^27.3.0"
-    "@jest/transform" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    collect-v8-coverage "^1.0.0"
-    exit "^0.1.2"
-    glob "^7.1.2"
-    graceful-fs "^4.2.4"
-    istanbul-lib-coverage "^3.0.0"
-    istanbul-lib-instrument "^4.0.3"
-    istanbul-lib-report "^3.0.0"
-    istanbul-lib-source-maps "^4.0.0"
-    istanbul-reports "^3.0.2"
-    jest-haste-map "^27.3.0"
-    jest-resolve "^27.3.0"
-    jest-util "^27.3.0"
-    jest-worker "^27.3.0"
-    slash "^3.0.0"
-    source-map "^0.6.0"
-    string-length "^4.0.1"
-    terminal-link "^2.0.0"
-    v8-to-istanbul "^8.1.0"
-
 "@jest/source-map@^27.0.6":
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.0.6.tgz#be9e9b93565d49b0548b86e232092491fb60551f"
@@ -2720,16 +2612,6 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-result@^27.3.0":
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.3.0.tgz#e093c5d9eb34afa1b653cdb550c4bcaeb3096233"
-  integrity sha512-5+rYZgj562oPKjExQngfboobeIF2FSrgAvoxlkrogEMIbgT7FY+VAMIkp03klVfJtqo3XKzVWkTfsDSmZFI29w==
-  dependencies:
-    "@jest/console" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    collect-v8-coverage "^1.0.0"
-
 "@jest/test-sequencer@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.1.1.tgz#cea3722ec6f6330000240fd999ad3123adaf5992"
@@ -2749,16 +2631,6 @@
     graceful-fs "^4.2.4"
     jest-haste-map "^27.2.5"
     jest-runtime "^27.2.5"
-
-"@jest/test-sequencer@^27.3.0":
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.3.0.tgz#ac245f4f29ce7f81ae5afa441e5bf7bbdd342ef4"
-  integrity sha512-6eQHyBUCtK06sPfsufzEVijZtAtT7yGR1qaAZBlcz6P+FGJ569VW2O5o7mZc+L++uZc7BH4X2Ks7SMIgy1npJw==
-  dependencies:
-    "@jest/test-result" "^27.3.0"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.3.0"
-    jest-runtime "^27.3.0"
 
 "@jest/transform@^26.6.2":
   version "26.6.2"
@@ -2817,27 +2689,6 @@
     jest-haste-map "^27.2.5"
     jest-regex-util "^27.0.6"
     jest-util "^27.2.5"
-    micromatch "^4.0.4"
-    pirates "^4.0.1"
-    slash "^3.0.0"
-    source-map "^0.6.1"
-    write-file-atomic "^3.0.0"
-
-"@jest/transform@^27.3.0":
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.3.0.tgz#f2a63883eaada30f8141938ec1ad23ba7fdfb97e"
-  integrity sha512-IKrFhIT/+WIfeNjIRKTwQN7HYCdjKF/mmBqoD660gyGWVw1MzCO9pQuEJK9GXEnFWIuOcMHlm8XfUaDohP/zxA==
-  dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/types" "^27.2.5"
-    babel-plugin-istanbul "^6.0.0"
-    chalk "^4.0.0"
-    convert-source-map "^1.4.0"
-    fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.3.0"
-    jest-regex-util "^27.0.6"
-    jest-util "^27.3.0"
     micromatch "^4.0.4"
     pirates "^4.0.1"
     slash "^3.0.0"
@@ -6895,7 +6746,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^27", "@types/jest@^27.0.1", "@types/jest@^27.0.2":
+"@types/jest@^27":
   version "27.0.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.2.tgz#ac383c4d4aaddd29bbf2b916d8d105c304a5fcd7"
   integrity sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==
@@ -8907,20 +8758,6 @@ babel-jest@^27.2.5:
   integrity sha512-GC9pWCcitBhSuF7H3zl0mftoKizlswaF0E3qi+rPL417wKkCB0d+Sjjb0OfXvxj7gWiBf497ldgRMii68Xz+2g==
   dependencies:
     "@jest/transform" "^27.2.5"
-    "@jest/types" "^27.2.5"
-    "@types/babel__core" "^7.1.14"
-    babel-plugin-istanbul "^6.0.0"
-    babel-preset-jest "^27.2.0"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    slash "^3.0.0"
-
-babel-jest@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.3.0.tgz#72237bff40e1fdaaf869bcaaa43bec58b51b6159"
-  integrity sha512-+Utvd2yZkT7tkgbBqVcH3uRpgRSTKRi0uBtVkjmuw2jFxp45rQ9fROSqqeHKzHYRelgdVOtQ3M745Wnyme/xOg==
-  dependencies:
-    "@jest/transform" "^27.3.0"
     "@jest/types" "^27.2.5"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.0.0"
@@ -14792,18 +14629,6 @@ expect@^27.2.5:
     jest-message-util "^27.2.5"
     jest-regex-util "^27.0.6"
 
-expect@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-27.3.0.tgz#6cf2864a2553fe8ea68e19a6ce1641b08c3a5a98"
-  integrity sha512-JBRU82EBkZUBqLBAoF3ovzNGEBm14QQnePK4PmZdm6de6q/UzPnmIuWP3dRCw/FE8wRQhf/1eKzy1p1q8d6EvQ==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    ansi-styles "^5.0.0"
-    jest-get-type "^27.0.6"
-    jest-matcher-utils "^27.3.0"
-    jest-message-util "^27.3.0"
-    jest-regex-util "^27.0.6"
-
 express-graphql@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/express-graphql/-/express-graphql-0.12.0.tgz#58deabc309909ca2c9fe2f83f5fbe94429aa23df"
@@ -18946,15 +18771,6 @@ jest-changed-files@^27.2.5:
     execa "^5.0.0"
     throat "^6.0.1"
 
-jest-changed-files@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.3.0.tgz#22a02cc2b34583fc66e443171dc271c0529d263c"
-  integrity sha512-9DJs9garMHv4RhylUMZgbdCJ3+jHSkpL9aaVKp13xtXAD80qLTLrqcDZL1PHA9dYA0bCI86Nv2BhkLpLhrBcPg==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    execa "^5.0.0"
-    throat "^6.0.1"
-
 jest-circus@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.1.1.tgz#08dd3ec5cbaadce68ce6388ebccbe051d1b34bc6"
@@ -19005,31 +18821,6 @@ jest-circus@^27.2.5:
     stack-utils "^2.0.3"
     throat "^6.0.1"
 
-jest-circus@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.3.0.tgz#adc822231f5e634bd676a1eeaa7f4cd6b840cc1d"
-  integrity sha512-i2P6t92Z6qujHD7C0nVYWm9YofUBMbOOTE9q9vEGi9qFotKUZv1H8M0H3NPTOWButgFuSXZfcwGBXGDAt7b9NA==
-  dependencies:
-    "@jest/environment" "^27.3.0"
-    "@jest/test-result" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    co "^4.6.0"
-    dedent "^0.7.0"
-    expect "^27.3.0"
-    is-generator-fn "^2.0.0"
-    jest-each "^27.3.0"
-    jest-matcher-utils "^27.3.0"
-    jest-message-util "^27.3.0"
-    jest-runtime "^27.3.0"
-    jest-snapshot "^27.3.0"
-    jest-util "^27.3.0"
-    pretty-format "^27.3.0"
-    slash "^3.0.0"
-    stack-utils "^2.0.3"
-    throat "^6.0.1"
-
 jest-cli@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.1.1.tgz#6491a0278231ffee61083ad468809328e96a8eb2"
@@ -19063,24 +18854,6 @@ jest-cli@^27.2.5:
     jest-config "^27.2.5"
     jest-util "^27.2.5"
     jest-validate "^27.2.5"
-    prompts "^2.0.1"
-    yargs "^16.2.0"
-
-jest-cli@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.3.0.tgz#f9d4278c6ffa1a77127d9d22d7167c2606b1a0f5"
-  integrity sha512-PUM2RHhqgGRuGc+7QTuyfqPPWGDTCQNMKhtlVBTBYOvhP+7g8a1a7OztM/wfpsKHfqQLHFIe1Mms6jVSXSi4Vg==
-  dependencies:
-    "@jest/core" "^27.3.0"
-    "@jest/test-result" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    chalk "^4.0.0"
-    exit "^0.1.2"
-    graceful-fs "^4.2.4"
-    import-local "^3.0.2"
-    jest-config "^27.3.0"
-    jest-util "^27.3.0"
-    jest-validate "^27.3.0"
     prompts "^2.0.1"
     yargs "^16.2.0"
 
@@ -19138,33 +18911,6 @@ jest-config@^27.2.5:
     micromatch "^4.0.4"
     pretty-format "^27.2.5"
 
-jest-config@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.3.0.tgz#d5d614098e042b4b33ca8a19aca93f8cc82999a4"
-  integrity sha512-hGknSnu6qJmwENNSUNY4qQjE9PENIYp4P8yHLVzo7qoQN4wuYHZuZEwAKaoQ66iHeSXmcZkCqFvAUa5WFdB0sg==
-  dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    babel-jest "^27.3.0"
-    chalk "^4.0.0"
-    deepmerge "^4.2.2"
-    glob "^7.1.1"
-    graceful-fs "^4.2.4"
-    is-ci "^3.0.0"
-    jest-circus "^27.3.0"
-    jest-environment-jsdom "^27.3.0"
-    jest-environment-node "^27.3.0"
-    jest-get-type "^27.0.6"
-    jest-jasmine2 "^27.3.0"
-    jest-regex-util "^27.0.6"
-    jest-resolve "^27.3.0"
-    jest-runner "^27.3.0"
-    jest-util "^27.3.0"
-    jest-validate "^27.3.0"
-    micromatch "^4.0.4"
-    pretty-format "^27.3.0"
-
 jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -19205,16 +18951,6 @@ jest-diff@^27.2.5:
     jest-get-type "^27.0.6"
     pretty-format "^27.2.5"
 
-jest-diff@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.3.0.tgz#4d6f6f9d34f7e2a359b3c7eb142bba4de1e37695"
-  integrity sha512-Nl2rE58B2ye+RvPcU4hN+6wBCHxX7aWz6RMTMFxe9jAg8ZueMj5QQ+T/nmHRutbBc5BEjrbbEWOrRzp9rUEsYA==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^27.0.6"
-    jest-get-type "^27.0.6"
-    pretty-format "^27.3.0"
-
 jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
@@ -19249,17 +18985,6 @@ jest-each@^27.2.5:
     jest-util "^27.2.5"
     pretty-format "^27.2.5"
 
-jest-each@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.3.0.tgz#7976cf15bebeef28aa5108a589f4c335b6f0eec9"
-  integrity sha512-i7qQt+puYusxOoiNyq/M6EyNcfEbvKvqOp89FbiHfm6/POTxgzpp5wAmoS9+BAssoX20t7Zt1A1M7yT3FLVvdg==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    chalk "^4.0.0"
-    jest-get-type "^27.0.6"
-    jest-util "^27.3.0"
-    pretty-format "^27.3.0"
-
 jest-environment-jsdom@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.1.1.tgz#e53e98a16e6a764b8ee8db3b29b3a8c27db06f66"
@@ -19286,19 +19011,6 @@ jest-environment-jsdom@^27.2.5:
     jest-util "^27.2.5"
     jsdom "^16.6.0"
 
-jest-environment-jsdom@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.3.0.tgz#bdf6282ff12a68fbc77cb26d6f56c6bddddd5f58"
-  integrity sha512-2R1w1z7ZlQkK22bo/MrMp7ItuCxXXFspn3HNdbusbtW4OfutaPNWPmAch1Shtuu7G75jEnDb2q0PXSfFD6kEHQ==
-  dependencies:
-    "@jest/environment" "^27.3.0"
-    "@jest/fake-timers" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    jest-mock "^27.3.0"
-    jest-util "^27.3.0"
-    jsdom "^16.6.0"
-
 jest-environment-node@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.1.1.tgz#97425d4762b2aeab15892ffba08c6cbed7653e75"
@@ -19322,18 +19034,6 @@ jest-environment-node@^27.2.5:
     "@types/node" "*"
     jest-mock "^27.2.5"
     jest-util "^27.2.5"
-
-jest-environment-node@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.3.0.tgz#32483ad819a4b93ba8cf89614a5fb108efba6566"
-  integrity sha512-bH2Zb73K4x2Yw8j83mmlJUUOFJLzwIpupRvlS9PXiCeIgVTPxL5syBeq5lz310DQBQkNLDTSD5+yYRhheVKvWg==
-  dependencies:
-    "@jest/environment" "^27.3.0"
-    "@jest/fake-timers" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    jest-mock "^27.3.0"
-    jest-util "^27.3.0"
 
 jest-get-type@^25.2.6:
   version "25.2.6"
@@ -19411,26 +19111,6 @@ jest-haste-map@^27.2.5:
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-haste-map@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.3.0.tgz#06305f57064af766fdbb54da4c4bc663f72e8a78"
-  integrity sha512-HV7BXCWhHFuQyLCnmy+VzvYQDccTdt5gpmt2abwIrWTnQiHNAklLB3Djq7Ze3OypTmWBMLgF8AHcKNmLKx8Rzw==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    "@types/graceful-fs" "^4.1.2"
-    "@types/node" "*"
-    anymatch "^3.0.3"
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-regex-util "^27.0.6"
-    jest-serializer "^27.0.6"
-    jest-util "^27.3.0"
-    jest-worker "^27.3.0"
-    micromatch "^4.0.4"
-    walker "^1.0.7"
-  optionalDependencies:
-    fsevents "^2.3.2"
-
 jest-jasmine2@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.1.1.tgz#efb9e7b70ce834c35c91e1a2f01bb41b462fad43"
@@ -19479,30 +19159,6 @@ jest-jasmine2@^27.2.5:
     pretty-format "^27.2.5"
     throat "^6.0.1"
 
-jest-jasmine2@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.3.0.tgz#d5ac6bec10f6696da99d990bf3df2377578fd331"
-  integrity sha512-c12xS913sE56pBYZYIuukttDyMJTgK+T/aYKuHse/jyBHk2r78IFxrEl0BL8iiezLZw6g6bKtyww/j9XWOVxqg==
-  dependencies:
-    "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^27.3.0"
-    "@jest/source-map" "^27.0.6"
-    "@jest/test-result" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    co "^4.6.0"
-    expect "^27.3.0"
-    is-generator-fn "^2.0.0"
-    jest-each "^27.3.0"
-    jest-matcher-utils "^27.3.0"
-    jest-message-util "^27.3.0"
-    jest-runtime "^27.3.0"
-    jest-snapshot "^27.3.0"
-    jest-util "^27.3.0"
-    pretty-format "^27.3.0"
-    throat "^6.0.1"
-
 jest-leak-detector@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.1.1.tgz#8e05ec4b339814fc4202f07d875da65189e3d7d4"
@@ -19518,14 +19174,6 @@ jest-leak-detector@^27.2.5:
   dependencies:
     jest-get-type "^27.0.6"
     pretty-format "^27.2.5"
-
-jest-leak-detector@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.3.0.tgz#2a881226a08068f6c2f3f238a65a788d4d3e787e"
-  integrity sha512-xlCDZUaVVpCOAAiW7b8sgxIzTkEmpElwmWe9wVdU01WnFCvQ0aQiq2JTNbeCgalhjxJVeZlACRHIsLjWrmtlRA==
-  dependencies:
-    jest-get-type "^27.0.6"
-    pretty-format "^27.3.0"
 
 jest-matcher-utils@^26.6.2:
   version "26.6.2"
@@ -19556,16 +19204,6 @@ jest-matcher-utils@^27.2.5:
     jest-diff "^27.2.5"
     jest-get-type "^27.0.6"
     pretty-format "^27.2.5"
-
-jest-matcher-utils@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.3.0.tgz#82c41750db4384d7a8db319348752df2bb0acf7a"
-  integrity sha512-AK2ds5J29PJcZhfJ/5J8ycbjCXTHnwc6lQeOV1a1GahU1MCpSvyHG1iIevyvp6PXPy6r0q9ywGdCObWHmkK16g==
-  dependencies:
-    chalk "^4.0.0"
-    jest-diff "^27.3.0"
-    jest-get-type "^27.0.6"
-    pretty-format "^27.3.0"
 
 jest-message-util@^26.6.2:
   version "26.6.2"
@@ -19612,21 +19250,6 @@ jest-message-util@^27.2.5:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-message-util@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.3.0.tgz#d64d24c2f19111ea916c092fea015076bb7615fe"
-  integrity sha512-0c79aomiyE3mlta4NCWsICydvv2W0HlM/eVx46YEO+vdDuwUvNuQn8LqOtcHC1hSd25i03RrPvscrWgHBJQpRQ==
-  dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^27.2.5"
-    "@types/stack-utils" "^2.0.0"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    micromatch "^4.0.4"
-    pretty-format "^27.3.0"
-    slash "^3.0.0"
-    stack-utils "^2.0.3"
-
 jest-mock@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.1.1.tgz#c7a2e81301fdcf3dab114931d23d89ec9d0c3a82"
@@ -19639,14 +19262,6 @@ jest-mock@^27.2.5:
   version "27.2.5"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.2.5.tgz#0ec38d5ff1e49c4802e7a4a8179e8d7a2fd84de0"
   integrity sha512-HiMB3LqE9RzmeMzZARi2Bz3NoymxyP0gCid4y42ca1djffNtYFKgI220aC1VP1mUZ8rbpqZbHZOJ15093bZV/Q==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-
-jest-mock@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.3.0.tgz#ddf0ec3cc3e68c8ccd489bef4d1f525571a1b867"
-  integrity sha512-ziZiLk0elZOQjD08bLkegBzv5hCABu/c8Ytx45nJKkysQwGaonvmTxwjLqEA4qGdasq9o2I8/HtdGMNnVsMTGw==
   dependencies:
     "@jest/types" "^27.2.5"
     "@types/node" "*"
@@ -19684,15 +19299,6 @@ jest-resolve-dependencies@^27.2.5:
     jest-regex-util "^27.0.6"
     jest-snapshot "^27.2.5"
 
-jest-resolve-dependencies@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.3.0.tgz#1467ed51d87635aec7133b2e29a283500f4609d1"
-  integrity sha512-YVmlWHdSUCOLrJl8lOIjda6+DtbgOCfExfoSx9gvHFYaXPq0UP2EELiX514H0rURTbSaLsDTodLNyqqEd/IqeA==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    jest-regex-util "^27.0.6"
-    jest-snapshot "^27.3.0"
-
 jest-resolve@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.1.1.tgz#3a86762f9affcad9697bc88140b0581b623add33"
@@ -19723,22 +19329,6 @@ jest-resolve@^27.2.5:
     jest-util "^27.2.5"
     jest-validate "^27.2.5"
     resolve "^1.20.0"
-    slash "^3.0.0"
-
-jest-resolve@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.3.0.tgz#ffd1db6828b3ee2243f4e4973d80d02e988f2443"
-  integrity sha512-SZxjtEkM0+f5vxJVpaGztQfnzEqgVnQqHzeGW1P9UON9qDtAET01HWaPCnb10SNUaNRG9NhhOMP418zl44FaIA==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.3.0"
-    jest-pnp-resolver "^1.2.2"
-    jest-util "^27.3.0"
-    jest-validate "^27.3.0"
-    resolve "^1.20.0"
-    resolve.exports "^1.1.0"
     slash "^3.0.0"
 
 jest-runner-eslint@^1.0.0:
@@ -19807,34 +19397,6 @@ jest-runner@^27.2.5:
     source-map-support "^0.5.6"
     throat "^6.0.1"
 
-jest-runner@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.3.0.tgz#0affed8232bf50daacb186091a98e4c50cc83c7a"
-  integrity sha512-gbkXXJdV5YpGjHvHZAAl5905qAgi+HLYO9lvLqGBxAWpx+oPOpBcMZfkRef7u86heZj1lmULzEdLjY459Z+rNQ==
-  dependencies:
-    "@jest/console" "^27.3.0"
-    "@jest/environment" "^27.3.0"
-    "@jest/test-result" "^27.3.0"
-    "@jest/transform" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    emittery "^0.8.1"
-    exit "^0.1.2"
-    graceful-fs "^4.2.4"
-    jest-docblock "^27.0.6"
-    jest-environment-jsdom "^27.3.0"
-    jest-environment-node "^27.3.0"
-    jest-haste-map "^27.3.0"
-    jest-leak-detector "^27.3.0"
-    jest-message-util "^27.3.0"
-    jest-resolve "^27.3.0"
-    jest-runtime "^27.3.0"
-    jest-util "^27.3.0"
-    jest-worker "^27.3.0"
-    source-map-support "^0.5.6"
-    throat "^6.0.1"
-
 jest-runtime@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.1.1.tgz#bd0a0958a11c2f7d94d2e5f6f71864ad1c65fe44"
@@ -19897,38 +19459,6 @@ jest-runtime@^27.2.5:
     jest-snapshot "^27.2.5"
     jest-util "^27.2.5"
     jest-validate "^27.2.5"
-    slash "^3.0.0"
-    strip-bom "^4.0.0"
-    yargs "^16.2.0"
-
-jest-runtime@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.3.0.tgz#6957699d74a675441f50627bca9fe8b035c82b83"
-  integrity sha512-CRhIM45UlYVY2u5IfCx+0jsCm6DLvY9fz34CzDi3c4W1prb7hGKLOJlxbayQIHHMhUx22WhK4eRqXjOKDnKdAQ==
-  dependencies:
-    "@jest/console" "^27.3.0"
-    "@jest/environment" "^27.3.0"
-    "@jest/globals" "^27.3.0"
-    "@jest/source-map" "^27.0.6"
-    "@jest/test-result" "^27.3.0"
-    "@jest/transform" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/yargs" "^16.0.0"
-    chalk "^4.0.0"
-    cjs-module-lexer "^1.0.0"
-    collect-v8-coverage "^1.0.0"
-    execa "^5.0.0"
-    exit "^0.1.2"
-    glob "^7.1.3"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.3.0"
-    jest-message-util "^27.3.0"
-    jest-mock "^27.3.0"
-    jest-regex-util "^27.0.6"
-    jest-resolve "^27.3.0"
-    jest-snapshot "^27.3.0"
-    jest-util "^27.3.0"
-    jest-validate "^27.3.0"
     slash "^3.0.0"
     strip-bom "^4.0.0"
     yargs "^16.2.0"
@@ -20009,36 +19539,6 @@ jest-snapshot@^27.2.5:
     pretty-format "^27.2.5"
     semver "^7.3.2"
 
-jest-snapshot@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.3.0.tgz#3792e1d22633050a1817c3e0d9a18666d43746ee"
-  integrity sha512-JaFXNS6D1BxvU2ORKaQwpen3Qic7IJAtGb09lbYiYk/GXXlde67Ts990i2nC5oBs0CstbeQE3jTeRayIZpM1Pw==
-  dependencies:
-    "@babel/core" "^7.7.2"
-    "@babel/generator" "^7.7.2"
-    "@babel/parser" "^7.7.2"
-    "@babel/plugin-syntax-typescript" "^7.7.2"
-    "@babel/traverse" "^7.7.2"
-    "@babel/types" "^7.0.0"
-    "@jest/transform" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/babel__traverse" "^7.0.4"
-    "@types/prettier" "^2.1.5"
-    babel-preset-current-node-syntax "^1.0.0"
-    chalk "^4.0.0"
-    expect "^27.3.0"
-    graceful-fs "^4.2.4"
-    jest-diff "^27.3.0"
-    jest-get-type "^27.0.6"
-    jest-haste-map "^27.3.0"
-    jest-matcher-utils "^27.3.0"
-    jest-message-util "^27.3.0"
-    jest-resolve "^27.3.0"
-    jest-util "^27.3.0"
-    natural-compare "^1.4.0"
-    pretty-format "^27.3.0"
-    semver "^7.3.2"
-
 jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
@@ -20075,18 +19575,6 @@ jest-util@^27.2.5:
     is-ci "^3.0.0"
     picomatch "^2.2.3"
 
-jest-util@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.3.0.tgz#178f211d308c25c9593d1c5a2f2b3aef28411741"
-  integrity sha512-SFSDBGKkxXi4jClmU1WLp/cMMlb4YX6+5Lb0CUySxmonArio8yJ2NALMWvQuXchgySiH7Rb912hVZ2QZ6t3x7w==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^3.0.0"
-    picomatch "^2.2.3"
-
 jest-validate@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.1.1.tgz#0783733af02c988d503995fc0a07bbdc58c7dd50"
@@ -20110,18 +19598,6 @@ jest-validate@^27.2.5:
     jest-get-type "^27.0.6"
     leven "^3.1.0"
     pretty-format "^27.2.5"
-
-jest-validate@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.3.0.tgz#1a92dd52d0a493037f6e1776c49457c031e0adc8"
-  integrity sha512-5oqWnb9MrkicE+ywR+BxoZr0L7H3WBDAt6LZggnyFHieAk8nnIQAKRpSodNPhiNJTwaMSbNjCe7SxAzKwTsBoA==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    camelcase "^6.2.0"
-    chalk "^4.0.0"
-    jest-get-type "^27.0.6"
-    leven "^3.1.0"
-    pretty-format "^27.3.0"
 
 jest-watch-select-projects@^2:
   version "2.0.0"
@@ -20171,19 +19647,6 @@ jest-watcher@^27.2.5:
     jest-util "^27.2.5"
     string-length "^4.0.1"
 
-jest-watcher@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.3.0.tgz#13730b347e2ae8ba3c9435055bdad2ad73e5c348"
-  integrity sha512-xpTFRhqzUnNwTGaSBoHcyXROGbAfj2u4LS7Xosb+hzgrFgWgiHtCy3PWyN1DQk31Na98bBjXKxAbfSBACrvEiQ==
-  dependencies:
-    "@jest/test-result" "^27.3.0"
-    "@jest/types" "^27.2.5"
-    "@types/node" "*"
-    ansi-escapes "^4.2.1"
-    chalk "^4.0.0"
-    jest-util "^27.3.0"
-    string-length "^4.0.1"
-
 jest-worker@^25.1.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.5.0.tgz#2611d071b79cea0f43ee57a3d118593ac1547db1"
@@ -20219,15 +19682,6 @@ jest-worker@^27.2.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest-worker@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.3.0.tgz#6b636b63b6672208b91b92d8dcde112d1d4dba2d"
-  integrity sha512-xTTvvJqOjKBqE1AmwDHiQN8qzp9VoT981LtfXA+XiJVxHn4435vpnrzVcJ6v/ESiuB+IXPjZakn/ppT00xBCWA==
-  dependencies:
-    "@types/node" "*"
-    merge-stream "^2.0.0"
-    supports-color "^8.0.0"
-
 jest@^27:
   version "27.2.5"
   resolved "https://registry.yarnpkg.com/jest/-/jest-27.2.5.tgz#7d8a5c8781a160f693beeb7c68e46c16ef948148"
@@ -20245,15 +19699,6 @@ jest@^27.0.0:
     "@jest/core" "^27.1.1"
     import-local "^3.0.2"
     jest-cli "^27.1.1"
-
-jest@^27.0.6, jest@^27.2.4:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-27.3.0.tgz#25f0e02aaa51d53bc6e1941eb4838a3452f3320e"
-  integrity sha512-ZSwT6ROUbUs3bXirxzxBvohE/1y7t+IHIu3fL8WgIeJppE2XsFoa2dB03CI9kXA81znW0Kt0t2R+QVOWeY8cYw==
-  dependencies:
-    "@jest/core" "^27.3.0"
-    import-local "^3.0.2"
-    jest-cli "^27.3.0"
 
 jimp@^0.14.0:
   version "0.14.0"
@@ -25354,16 +24799,6 @@ pretty-format@^27.2.5:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.3.0:
-  version "27.3.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.3.0.tgz#ab4679ffc25dd9bc29bab220a4a70a873a19600e"
-  integrity sha512-Nkdd0xmxZdjCe6GoJomHnrLcCYGYzZKI/fRnUX0sCwDai2mmCHJfC9Ecx33lYgaxAFS/pJCAqhfxmWlm1wNVag==
-  dependencies:
-    "@jest/types" "^27.2.5"
-    ansi-regex "^5.0.1"
-    ansi-styles "^5.0.0"
-    react-is "^17.0.1"
-
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -26947,11 +26382,6 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
-
-resolve.exports@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
-  integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
 resolve@1.1.7:
   version "1.1.7"
@@ -29974,7 +29404,7 @@ typescript@^4.0.2, typescript@^4.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
   integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
-typescript@^4.3.5, typescript@^4.4.3, typescript@^4.4.4:
+typescript@^4.4.4:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback_gutenberg`
- `npm/@amazeelabs/silverback-playwright`

## Description of changes

### Gutenberg

Fixed two bugs in `LinkProcessor`:
- Links were not processed inside HTML attributes (e.g. media captions)
- Some blocks were completely ignored because the regex was buggy. `BlockParser` and `BlockSerializer` are used instead of dom-parser and regex.

Documented `LinkProcessor`.

### Playwright test runner

Added docs how to continuously re-run tests while writing them. (This is a temporary solution. I hope 😅 )

## Related Issue(s)

Closes https://github.com/AmazeeLabs/silverback-mono/issues/749

## How has this been tested?

Playwright tests.