### PR TITLE
react-framework-bridge: a way to get initial html string from `Html` component

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/utils.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/utils.test.tsx
@@ -49,7 +49,9 @@ describe('buildHtmlBuilder', () => {
   beforeEach(jest.resetAllMocks);
 
   it('renders a simple paragraph', () => {
-    const Html = buildHtml('<main><p>Test</p></main>');
+    const htmlString = '<main><p>Test</p></main>';
+    const Html = buildHtml(htmlString);
+    expect(Html.initialHtmlString).toEqual(htmlString);
     render(<Html />);
     expect(screen.getByRole('main')).toMatchInlineSnapshot(`
 <main>

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
@@ -9,7 +9,9 @@ export type Html = React.VFC<{
   classNames?: {
     [key: string]: string | ClassFunction;
   };
-}>;
+}> & {
+  initialHtmlString: string;
+};
 
 export type HtmlBuilder = (input: string) => Html;
 

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils.tsx
@@ -112,9 +112,11 @@ export const htmlParserOptions = (
 export const buildHtmlBuilder =
   (buildLink: LinkBuilder) =>
   (input: string): Html => {
-    return function MockHtml({ classNames }) {
+    const Element: Html = function MockHtml({ classNames }) {
       return <>{parse(input, htmlParserOptions(buildLink, classNames))}</>;
     };
+    Element.initialHtmlString = input;
+    return Element;
   };
 
 const isTruthy = (i: string | null | undefined): i is string => Boolean(i);


### PR DESCRIPTION
## Package(s) involved

- `npm/@amazeelabs/react-framework-bridge`

## Description of changes

Introduced `Html.initialHtmlString`.

## Motivation and context

In projects we often pass html to components as `Html` type. Yet there could be cases when we need to get initial HTML string. For example, to use with [`react-pdf-html`](https://www.npmjs.com/package/react-pdf-html).

## How has this been tested?

Locally, on a project. Extended a unit test.
