### PR TITLE
react-framework-bridge: `Image.src` and `Link.href`

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/gatsby.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/gatsby.test.tsx
@@ -34,6 +34,7 @@ describe('buildLink', () => {
         a: 'b',
       },
     });
+    expect(Link.href).toEqual('/foo/bar?a=b');
     render(<Link>Test</Link>);
     expect(screen.getByRole('link').getAttribute('data-gatsby')).toBeTruthy();
     expect(screen.getByRole('link').getAttribute('href')).toEqual(
@@ -47,6 +48,7 @@ describe('buildLink', () => {
         a: 'b',
       },
     });
+    expect(Link.href).toEqual('?a=b');
     render(<Link>Test</Link>);
     expect(screen.getByRole('link').getAttribute('data-gatsby')).toBeTruthy();
     expect(screen.getByRole('link').getAttribute('href')).toEqual('?a=b');
@@ -56,6 +58,7 @@ describe('buildLink', () => {
     const Link = buildLink({
       href: '/foo',
     });
+    expect(Link.href).toEqual('/foo');
     render(<Link query={{ a: 'b' }}>Test</Link>);
     expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo?a=b');
   });
@@ -64,6 +67,7 @@ describe('buildLink', () => {
     const Link = buildLink({
       href: '/foo',
     });
+    expect(Link.href).toEqual('/foo');
     render(<Link fragment="bar">Test</Link>);
     expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo#bar');
   });
@@ -72,6 +76,7 @@ describe('buildLink', () => {
     const Link = buildLink({
       href: '/foo',
     });
+    expect(Link.href).toEqual('/foo');
     render(
       <Link query={{ a: 'b' }} fragment="bar">
         Test
@@ -84,12 +89,14 @@ describe('buildLink', () => {
 
   it('renders a Gatsby link for an internal path', () => {
     const Link = buildLink({ href: '/test' });
+    expect(Link.href).toEqual('/test');
     render(<Link>Test</Link>);
     expect(screen.getByRole('link').getAttribute('data-gatsby')).toBeTruthy();
   });
 
   it('renders normal link for an external path', () => {
     const Link = buildLink({ href: 'http://www.amazeelabs.com' });
+    expect(Link.href).toEqual('http://www.amazeelabs.com');
     render(<Link>Test</Link>);
     expect(screen.getByRole('link').getAttribute('data-gatsby')).toBeFalsy();
   });
@@ -99,6 +106,7 @@ describe('buildLink', () => {
       href: 'http://www.amazeelabs.com',
       target: '_blank',
     });
+    expect(Link.href).toEqual('http://www.amazeelabs.com');
     render(<Link>Test</Link>);
     expect(screen.getByRole('link').getAttribute('data-gatsby')).toBeFalsy();
   });
@@ -107,12 +115,14 @@ describe('buildLink', () => {
     const Link = buildLink({
       href: 'mailto:development@amazeelabs.com',
     });
+    expect(Link.href).toEqual('mailto:development@amazeelabs.com');
     render(<Link>Test</Link>);
     expect(screen.getByRole('link').getAttribute('data-gatsby')).toBeFalsy();
   });
 
   it('exposes Gatsby navigate', () => {
     const Link = buildLink({ href: '#test' });
+    expect(Link.href).toEqual('#test');
     Link.navigate();
     expect(gatsbyNav).toHaveBeenCalledTimes(1);
     expect(gatsbyNav).toHaveBeenCalledWith('#test');
@@ -120,6 +130,7 @@ describe('buildLink', () => {
 
   it('exposes Gatsby navigate that allows to override query and fragments', () => {
     const Link = buildLink({ href: '/foo', query: { a: 'b' } });
+    expect(Link.href).toEqual('/foo?a=b');
     Link.navigate({ query: { a: 'c' }, fragment: 'bar' });
     expect(gatsbyNav).toHaveBeenCalledTimes(1);
     expect(gatsbyNav).toHaveBeenCalledWith('/foo?a=c#bar');

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
@@ -21,6 +21,7 @@ describe('buildLink', () => {
         a: 'b',
       },
     });
+    expect(Link.href).toEqual('/foo/bar?a=b');
     render(<Link>Test</Link>);
     expect(screen.getByRole('link').getAttribute('href')).toEqual(
       '/foo/bar?a=b',
@@ -33,6 +34,7 @@ describe('buildLink', () => {
         a: 'b',
       },
     });
+    expect(Link.href).toEqual('?a=b');
     render(<Link>Test</Link>);
     expect(screen.getByRole('link').getAttribute('href')).toEqual('?a=b');
   });
@@ -41,6 +43,7 @@ describe('buildLink', () => {
     const Link = buildLink<{ a: string }>({
       href: '/foo',
     });
+    expect(Link.href).toEqual('/foo');
     render(<Link query={{ a: 'b' }}>Test</Link>);
     expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo?a=b');
   });
@@ -50,6 +53,7 @@ describe('buildLink', () => {
       href: '/foo',
       query: { a: 'b' },
     });
+    expect(Link.href).toEqual('/foo?a=b');
     render(<Link query={{ a: 'c' }}>Test</Link>);
     expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo?a=c');
   });
@@ -58,6 +62,7 @@ describe('buildLink', () => {
     const Link = buildLink({
       href: '/foo',
     });
+    expect(Link.href).toEqual('/foo');
     render(<Link fragment="bar">Test</Link>);
     expect(screen.getByRole('link').getAttribute('href')).toEqual('/foo#bar');
   });
@@ -66,6 +71,7 @@ describe('buildLink', () => {
     const Link = buildLink<{ a: string }>({
       href: '/foo',
     });
+    expect(Link.href).toEqual('/foo');
     render(
       <Link query={{ a: 'b' }} fragment="bar">
         Test
@@ -78,6 +84,7 @@ describe('buildLink', () => {
 
   it('renders a simple link', () => {
     const Link = buildLink({ href: '#test' });
+    expect(Link.href).toEqual('#test');
     render(<Link>test</Link>);
     expect(screen.getByRole('link').textContent).toEqual('test');
     expect(screen.getByRole('link').getAttribute('href')).toEqual('#test');
@@ -85,12 +92,14 @@ describe('buildLink', () => {
 
   it('allows to pass a class', () => {
     const Link = buildLink({ href: '#test' });
+    expect(Link.href).toEqual('#test');
     render(<Link className={'text-red'}>test</Link>);
     expect(screen.getByRole('link').getAttribute('class')).toEqual('text-red');
   });
 
   it('applies active class if the path contains "active"', () => {
     const Link = buildLink({ href: '/imsoactive' });
+    expect(Link.href).toEqual('/imsoactive');
     render(
       <Link className={'text-red'} activeClassName={'text-green'}>
         test
@@ -104,12 +113,14 @@ describe('buildLink', () => {
 
   it('does not break if path contains "active" and no active class is defined', () => {
     const Link = buildLink({ href: '/imsoactive' });
+    expect(Link.href).toEqual('/imsoactive');
     render(<Link className={'text-red'}>test</Link>);
     expect(screen.getByRole('link').getAttribute('class')).toEqual('text-red');
   });
 
   it('logs a storybook action on click', () => {
     const Link = buildLink({ href: '#test' });
+    expect(Link.href).toEqual('#test');
     render(<Link>test</Link>);
     fireEvent.click(screen.getByRole('link'));
     expect(action).toHaveBeenCalledTimes(1);
@@ -118,6 +129,7 @@ describe('buildLink', () => {
 
   it('exposes a navigate function that logs a storybook action', () => {
     const Link = buildLink({ href: '#test' });
+    expect(Link.href).toEqual('#test');
     Link.navigate();
     expect(action).toHaveBeenCalledTimes(1);
     expect(action).toHaveBeenCalledWith('#test');
@@ -125,6 +137,7 @@ describe('buildLink', () => {
 
   it('exposes a navigate function that logs a storybook action and allows to override queries and fragments', () => {
     const Link = buildLink({ href: '/foo', query: { a: 'b' } });
+    expect(Link.href).toEqual('/foo?a=b');
     Link.navigate({ query: { a: 'c' }, fragment: 'bar' });
     expect(action).toHaveBeenCalledTimes(1);
     expect(action).toHaveBeenCalledWith('/foo?a=c#bar');
@@ -134,6 +147,7 @@ describe('buildLink', () => {
 describe('buildImage', () => {
   it('renders an image with all attributes', () => {
     const Image = buildImage({ src: 'test.png', alt: 'Test' });
+    expect(Image.src).toEqual('test.png');
     render(<Image />);
     expect(screen.getByRole('img').getAttribute('src')).toEqual('test.png');
     expect(screen.getByRole('img').getAttribute('alt')).toEqual('Test');
@@ -141,6 +155,7 @@ describe('buildImage', () => {
 
   it('allows to specify a classname', () => {
     const Image = buildImage({ src: 'test.png', alt: 'Test' });
+    expect(Image.src).toEqual('test.png');
     render(<Image className={'border-red'} />);
     expect(screen.getByRole('img').getAttribute('class')).toEqual('border-red');
   });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/utils.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/utils.test.tsx
@@ -40,6 +40,7 @@ const buildLink = ({ href, ...props }: LinkProps): Link => {
     );
   };
   Element.navigate = () => nav(href);
+  Element.href = href || '';
   return Element;
 };
 

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
@@ -60,15 +60,19 @@ export function buildLink<Query = {}>({
     navigate(uri, props);
   };
 
+  Element.href = buildUrl();
+
   return Element as Link<Query>;
 }
 
 export const buildImage = (
   props: Omit<GatsbyImageProps, 'className'>,
 ): Image => {
-  return function GatsbyImageBuilder({ className }) {
+  const Element: Image = function GatsbyImageBuilder({ className }) {
     return <GatsbyImage {...props} className={className} />;
   };
+  Element.src = props.image.images.fallback?.src;
+  return Element;
 };
 
 export const buildHtml = buildHtmlBuilder(buildLink);

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
@@ -51,13 +51,16 @@ export function buildLink<Query = {}>({
     const target = buildUrl(opts?.query, opts?.fragment);
     action('navigate to')(target);
   };
+  Element.href = buildUrl();
   return Element as Link<Query>;
 }
 
 export const buildImage = (props: ImageProps): Image => {
-  return function MockImage({ className }) {
+  const Element: Image = function MockImage({ className }) {
     return <img {...props} className={className} />;
   };
+  Element.src = props.src;
+  return Element;
 };
 
 export const buildHtml = buildHtmlBuilder(buildLink);

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
@@ -17,7 +17,9 @@ export type HtmlBuilder = (input: string) => Html;
 
 export type Image = React.VFC<{
   className?: string;
-}>;
+}> & {
+  src: string | undefined;
+};
 
 export type ImageProps = Omit<
   React.DetailedHTMLProps<
@@ -37,6 +39,7 @@ export type Link<Query extends Parameters<typeof stringify>[0] = {}> =
     fragment?: string;
   }> & {
     navigate: (opts?: { query?: Query; fragment?: string }) => void;
+    href: string;
   };
 
 export type LinkProps<Query extends Parameters<typeof stringify>[0] = {}> =


### PR DESCRIPTION
## Package(s) involved

- `npm/@amazeelabs/react-framework-bridge`

## Description of changes

Introduced `Image.src` and `Link.href`.

## Motivation and context

Same as https://github.com/AmazeeLabs/silverback-mono/pull/831 - to be able to use components with [`@react-pdf/renderer`](https://www.npmjs.com/package/@react-pdf/renderer).

## How has this been tested?

Locally, on a project. Extended unit tests.
