### PR TITLE
Fix scaffolded dependencies

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/package.json
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/package.json
@@ -10,14 +10,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@amazeelabs/prettier-config": "^1.1.0",
-    "@amazeelabs/scaffold": "^1.3.12"
-  },
   "devDependencies": {
+    "@amazeelabs/prettier-config": "^1.1.0",
+    "@amazeelabs/scaffold": "^1.3.12",
     "@amazeelabs/eslint-config": "^1.4.1",
     "@amazeelabs/jest-preset": "^1.3.8",
-    "@amazeelabs/prettier-config": "^1.1.0",
     "@types/jest": "^27.0.0",
     "eslint": "^7.25.0",
     "gatsby": "^3.7.2",

--- a/packages/npm/@amazeelabs/gatsby-starter/package.json
+++ b/packages/npm/@amazeelabs/gatsby-starter/package.json
@@ -5,8 +5,6 @@
   "version": "0.7.38",
   "author": "Amazee Labs <developers@amazeelabs.com>",
   "dependencies": {
-    "@amazeelabs/eslint-config": "^1.4.1",
-    "@amazeelabs/scaffold": "^1.3.12",
     "dotenv": "^10.0.0",
     "gatsby": "^3.0.0",
     "gatsby-plugin-schema-export": "^1.1.3",
@@ -14,7 +12,8 @@
     "react-dom": "^17.0.0"
   },
   "devDependencies": {
-    "@amazeelabs/eslint-config": "^1.3.0",
+    "@amazeelabs/eslint-config": "^1.4.1",
+    "@amazeelabs/scaffold": "^1.3.12",
     "@amazeelabs/jest-preset": "^1.3.8",
     "@amazeelabs/prettier-config": "^1.1.0",
     "@graphql-codegen/cli": "^2.0.0",

--- a/packages/npm/@amazeelabs/react-framework-bridge/package.json
+++ b/packages/npm/@amazeelabs/react-framework-bridge/package.json
@@ -10,10 +10,6 @@
   "private": false,
   "sideEffects": false,
   "dependencies": {
-    "@amazeelabs/eslint-config": "^1.4.1",
-    "@amazeelabs/jest-preset": "^1.3.8",
-    "@amazeelabs/prettier-config": "^1.1.0",
-    "@amazeelabs/scaffold": "^1.3.12",
     "html-react-parser": "^1.2.7",
     "qs": "^6.10.1"
   },
@@ -27,9 +23,10 @@
     "yup": ">=0.32"
   },
   "devDependencies": {
-    "@amazeelabs/eslint-config": "^1.3.2",
-    "@amazeelabs/jest-preset": "^1.3.3",
+    "@amazeelabs/eslint-config": "^1.4.1",
+    "@amazeelabs/jest-preset": "^1.3.8",
     "@amazeelabs/prettier-config": "^1.1.0",
+    "@amazeelabs/scaffold": "^1.3.12",
     "@rollup/plugin-commonjs": "^21.0.0",
     "@rollup/plugin-multi-entry": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.5",

--- a/packages/npm/@amazeelabs/scaffold/README.md
+++ b/packages/npm/@amazeelabs/scaffold/README.md
@@ -6,18 +6,23 @@ testing tools.
 ## Installation
 
 ```shell
-yarn add @amazeelabs/scaffold
+yarn add -D @amazeelabs/scaffold
 yarn amazee-scaffold
 ```
 
-This will alter the packages `.gitignore` file, add a `prepare` hook and
-make sure that configurations for code quality tools like `eslint`, `prettier`
-or `jest` are in place. The scaffolded configuration files are added to
+This will alter the packages `.gitignore` file, add a `prepare` hook and make
+sure that configurations for code quality tools like `eslint`, `prettier` or
+`jest` are in place. The scaffolded configuration files are added to
 `.gitignore` and should not be committed. They will be auto-added and updated
 with every `yarn install`.
+
+> **Alert:** When using this within the Silverback monorepo, yarn will falsely
+> add the dependencies to `dependencies` instead of `devDependencies`. This has
+> to be fixed manually until we are able to switch to a newer version of `yarn`.
 
 ## Usage
 
 After install there is a `test` that should run all testsin a package. It will
-also look for an optional `test.sh` in the package root that will also be executed.
-The `watch` command should be used for live-feedback features (like `jest --watch`).
+also look for an optional `test.sh` in the package root that will also be
+executed. The `watch` command should be used for live-feedback features (like
+`jest --watch`).


### PR DESCRIPTION
## Package(s) involved
* `@amazeelabs/gatsby-source-silverback`
* `@amazeelabs/gatsby-starter`
* `@amazeelabs/react-framework-bridge`
* `@amazeelabs/scaffold`

## Description of changes

Fixed `devDependencies` in packages that where subject to the `yarn` bug that falsely adds local packages to `dependencies` instead of `devDependencies`. Added a notice about that in the `README`.

## Motivation and context
When creating a silverback package with `amazee-scaffold`, dependencies are not added as `devDependencies` due to this bug: https://github.com/yarnpkg/yarn/issues/4971

This PR fixes broken packages and adds a notice to the readme.
