### PR TITLE
fix: move schema customization to `createSchemaCustomization` to be c…

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -48,7 +48,6 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   // TODO: Accept configuration and fragment overrides from plugin settings.
   const config = await createSourcingConfig(gatsbyApi, executor);
   const context = createSourcingContext(config);
-  await createToolkitSchemaCustomization(config);
 
   // Source only what was changed. If there is something in cache.
   const lastBuildId = (await gatsbyApi.cache.get(`LAST_BUILD_ID`)) || -1;
@@ -126,6 +125,15 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
     if (!validOptions(options)) {
       return;
     }
+
+    const executor = createQueryExecutor(
+      apiUrl(options),
+      options.auth_user,
+      options.auth_pass,
+    );
+    // TODO: Accept configuration and fragment overrides from plugin settings.
+    const config = await createSourcingConfig(args, executor);
+    await createToolkitSchemaCustomization(config);
 
     await createTranslationQueryField(
       args,

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -74,7 +74,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   // data that is stored in Gatsby and we have to re-fetch everything anyway.
   if (
     // Current build id is lower than the last one -> out of sync with CMS, re-fetch everything
-    currentBuildId <= lastBuildId ||
+    currentBuildId < lastBuildId ||
     // No information about a current build in the CMS -> re-fetch everything
     currentBuildId === -1 ||
     // No information about the latest build in Gatsby -> re-fetch everything

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-sourcing-config.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-sourcing-config.ts
@@ -1,4 +1,4 @@
-import { SourceNodesArgs } from 'gatsby';
+import { NodePluginArgs } from 'gatsby';
 import {
   buildNodeDefinitions,
   compileNodeQueries,
@@ -35,7 +35,7 @@ type ITranslatablePaginationAdapter = IPaginationAdapter<
 >;
 
 export const createSourcingConfig = async (
-  gatsbyApi: SourceNodesArgs,
+  gatsbyApi: NodePluginArgs,
   execute: IQueryExecutor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   customFragments?: Map<RemoteTypeName, string>,


### PR DESCRIPTION
## Package(s) involved
* `gatsby-source-silverback`

## Description of changes
* Move schema customizations to the appropriate hook to get rid of the deprecation warning
* don't clear drupal data if gatsby and drupal are on the same build already
