### PR TITLE
Gatsby: Support internal DNS when sourcing data

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -28,9 +28,17 @@ export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
   Joi.object<Options>({
     drupal_url: Joi.string().uri({ allowRelative: false }).required(),
     graphql_path: Joi.string().uri({ relativeOnly: true }).required(),
+    drupal_external_url: Joi.string().uri({allowRelative: false}),
     auth_user: Joi.string().optional(),
     auth_pass: Joi.string().optional(),
   });
+
+const getForwardedHeaders = (url: URL) => ({
+  'X-Forwarded-Proto': url.protocol,
+  'X-Forwarded-Host': url.hostname,
+  'X-Forwarded-Port': url.port,
+})
+
 
 export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   gatsbyApi: SourceNodesArgs & { webhookBody?: { buildId?: number } },
@@ -44,6 +52,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     apiUrl(options),
     options.auth_user,
     options.auth_pass,
+    options.drupal_external_url ? getForwardedHeaders(new URL(options.drupal_external_url)) : undefined
   );
   // TODO: Accept configuration and fragment overrides from plugin settings.
   const config = await createSourcingConfig(gatsbyApi, executor);

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
@@ -4,10 +4,13 @@ export const createQueryExecutor = (
   url: string,
   user?: string,
   pass?: string,
+  headers?: RequestInit['headers']
 ) => {
   return createDefaultQueryExecutor(
     url,
-    !!user && !!pass
+    {
+      ...headers,
+      ...(!!user && !!pass
       ? {
           headers: {
             Authorization: `Basic ${Buffer.from(`${user}:${pass}`).toString(
@@ -15,6 +18,6 @@ export const createQueryExecutor = (
             )}`,
           },
         }
-      : {},
+      : {})},
   );
 };

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
@@ -1,6 +1,8 @@
 export type Options = {
-  // The url of the Drupal installation.
+  // The internal url of the Drupal installation, used to fetch data.
   drupal_url: string;
+  // The external url of the Drupal installation, used to set the x-forwarded headers.
+  drupal_external_url?: string;
   // The Drupal GraphQL server path.
   graphql_path: string;
   // Optional Basic Auth Drupal user.


### PR DESCRIPTION
### Current state
Absolute URL’s in the GraphQL response will inherit the request host by default. When using internal routing (e.g. `http://nginx:8080`) for fetching data, this host will be emitted when Drupal generates absolute Url’s to itself (e.g. image style urls).

### Solution
Allow to set an “external” drupal url in the configuration of `gatsby-source-silverback` that will be used to send `X-Forwarded-*` headers and trigger Drupal’s reverse proxy behavior (which the build script technically is).

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)