### PR TITLE
silverback-iframe: bring back compiled code

### DIFF
--- a/packages/npm/@amazeelabs/silverback-iframe/tsconfig.json
+++ b/packages/npm/@amazeelabs/silverback-iframe/tsconfig.json
@@ -3,7 +3,6 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "declaration": true,
-    "noEmit": true,
     "target": "ES2015",
     "module": "commonjs",
     "strict": true,


### PR DESCRIPTION
Looks like the last scaffold update deleted `dist` 😄 