### PR TITLE
Gatsby list published translations & non-required limit and offset

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -133,7 +133,7 @@ extend type Query {
 
 extend type Query {
   loadImage(id: String!): Image
-  queryImages(offset: Int!, limit: Int!): [Image]!
+  queryImages(offset: Int, limit: Int): [Image]!
 }
 extend type Image {
   id: String!
@@ -145,7 +145,7 @@ extend type Image {
 
 extend type Query {
   loadTag(id: String!): Tag
-  queryTags(offset: Int!, limit: Int!): [Tag]!
+  queryTags(offset: Int, limit: Int): [Tag]!
 }
 extend type Tag {
   id: String!
@@ -154,7 +154,7 @@ extend type Tag {
 
 extend type Query {
   loadPage(id: String!): Page
-  queryPages(offset: Int!, limit: Int!): [Page]!
+  queryPages(offset: Int, limit: Int): [Page]!
 }
 extend type Page {
   id: String!
@@ -166,7 +166,7 @@ extend type Page {
 
 extend type Query {
   loadGutenbergPage(id: String!): GutenbergPage
-  queryGutenbergPages(offset: Int!, limit: Int!): [GutenbergPage]!
+  queryGutenbergPages(offset: Int, limit: Int): [GutenbergPage]!
 }
 extend type GutenbergPage {
   id: String!
@@ -178,7 +178,7 @@ extend type GutenbergPage {
 
 extend type Query {
   loadWebform(id: String!): Webform
-  queryWebforms(offset: Int!, limit: Int!): [Webform]!
+  queryWebforms(offset: Int, limit: Int): [Webform]!
 }
 extend type Webform {
   id: String!
@@ -187,7 +187,7 @@ extend type Webform {
 
 extend type Query {
   loadArticle(id: String!): Article
-  queryArticles(offset: Int!, limit: Int!): [Article]!
+  queryArticles(offset: Int, limit: Int): [Article]!
 }
 extend type Article {
   id: String!
@@ -199,7 +199,7 @@ extend type Article {
 
 extend type Query {
   loadMainMenu(id: String!): MainMenu
-  queryMainMenus(offset: Int!, limit: Int!): [MainMenu]!
+  queryMainMenus(offset: Int, limit: Int): [MainMenu]!
 }
 extend type MainMenu {
   id: String!
@@ -217,7 +217,7 @@ extend type MenuItem {
 }
 extend type Query {
   loadFirstLevelMainMenu(id: String!): FirstLevelMainMenu
-  queryFirstLevelMainMenus(offset: Int!, limit: Int!): [FirstLevelMainMenu]!
+  queryFirstLevelMainMenus(offset: Int, limit: Int): [FirstLevelMainMenu]!
 }
 extend type FirstLevelMainMenu {
   id: String!

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -133,7 +133,7 @@ extend type Query {
 
 extend type Query {
   loadImage(id: String!): Image
-  queryImages(offset: Int!, limit: Int!): [Image]!
+  queryImages(offset: Int, limit: Int): [Image]!
 }
 extend type Image {
   id: String!
@@ -145,7 +145,7 @@ extend type Image {
 
 extend type Query {
   loadTag(id: String!): Tag
-  queryTags(offset: Int!, limit: Int!): [Tag]!
+  queryTags(offset: Int, limit: Int): [Tag]!
 }
 extend type Tag {
   id: String!
@@ -154,7 +154,7 @@ extend type Tag {
 
 extend type Query {
   loadPage(id: String!): Page
-  queryPages(offset: Int!, limit: Int!): [Page]!
+  queryPages(offset: Int, limit: Int): [Page]!
 }
 extend type Page {
   id: String!
@@ -166,7 +166,7 @@ extend type Page {
 
 extend type Query {
   loadGutenbergPage(id: String!): GutenbergPage
-  queryGutenbergPages(offset: Int!, limit: Int!): [GutenbergPage]!
+  queryGutenbergPages(offset: Int, limit: Int): [GutenbergPage]!
 }
 extend type GutenbergPage {
   id: String!
@@ -178,7 +178,7 @@ extend type GutenbergPage {
 
 extend type Query {
   loadWebform(id: String!): Webform
-  queryWebforms(offset: Int!, limit: Int!): [Webform]!
+  queryWebforms(offset: Int, limit: Int): [Webform]!
 }
 extend type Webform {
   id: String!
@@ -187,7 +187,7 @@ extend type Webform {
 
 extend type Query {
   loadArticle(id: String!): Article
-  queryArticles(offset: Int!, limit: Int!): [Article]!
+  queryArticles(offset: Int, limit: Int): [Article]!
 }
 extend type Article {
   id: String!
@@ -199,7 +199,7 @@ extend type Article {
 
 extend type Query {
   loadMainMenu(id: String!): MainMenu
-  queryMainMenus(offset: Int!, limit: Int!): [MainMenu]!
+  queryMainMenus(offset: Int, limit: Int): [MainMenu]!
 }
 extend type MainMenu {
   id: String!
@@ -217,7 +217,7 @@ extend type MenuItem {
 }
 extend type Query {
   loadFirstLevelMainMenu(id: String!): FirstLevelMainMenu
-  queryFirstLevelMainMenus(offset: Int!, limit: Int!): [FirstLevelMainMenu]!
+  queryFirstLevelMainMenus(offset: Int, limit: Int): [FirstLevelMainMenu]!
 }
 extend type FirstLevelMainMenu {
   id: String!
@@ -368,7 +368,7 @@ extend type Query {
 
 extend type Query {
   loadImage(id: String!): Image
-  queryImages(offset: Int!, limit: Int!): [Image]!
+  queryImages(offset: Int, limit: Int): [Image]!
 }
 extend type Image {
   id: String!
@@ -380,7 +380,7 @@ extend type Image {
 
 extend type Query {
   loadTag(id: String!): Tag
-  queryTags(offset: Int!, limit: Int!): [Tag]!
+  queryTags(offset: Int, limit: Int): [Tag]!
 }
 extend type Tag {
   id: String!
@@ -389,7 +389,7 @@ extend type Tag {
 
 extend type Query {
   loadPage(id: String!): Page
-  queryPages(offset: Int!, limit: Int!): [Page]!
+  queryPages(offset: Int, limit: Int): [Page]!
 }
 extend type Page {
   id: String!
@@ -401,7 +401,7 @@ extend type Page {
 
 extend type Query {
   loadGutenbergPage(id: String!): GutenbergPage
-  queryGutenbergPages(offset: Int!, limit: Int!): [GutenbergPage]!
+  queryGutenbergPages(offset: Int, limit: Int): [GutenbergPage]!
 }
 extend type GutenbergPage {
   id: String!
@@ -413,7 +413,7 @@ extend type GutenbergPage {
 
 extend type Query {
   loadWebform(id: String!): Webform
-  queryWebforms(offset: Int!, limit: Int!): [Webform]!
+  queryWebforms(offset: Int, limit: Int): [Webform]!
 }
 extend type Webform {
   id: String!
@@ -422,7 +422,7 @@ extend type Webform {
 
 extend type Query {
   loadArticle(id: String!): Article
-  queryArticles(offset: Int!, limit: Int!): [Article]!
+  queryArticles(offset: Int, limit: Int): [Article]!
 }
 extend type Article {
   id: String!
@@ -434,7 +434,7 @@ extend type Article {
 
 extend type Query {
   loadMainMenu(id: String!): MainMenu
-  queryMainMenus(offset: Int!, limit: Int!): [MainMenu]!
+  queryMainMenus(offset: Int, limit: Int): [MainMenu]!
 }
 extend type MainMenu {
   id: String!
@@ -452,7 +452,7 @@ extend type MenuItem {
 }
 extend type Query {
   loadFirstLevelMainMenu(id: String!): FirstLevelMainMenu
-  queryFirstLevelMainMenus(offset: Int!, limit: Int!): [FirstLevelMainMenu]!
+  queryFirstLevelMainMenus(offset: Int, limit: Int): [FirstLevelMainMenu]!
 }
 extend type FirstLevelMainMenu {
   id: String!

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
@@ -140,8 +140,14 @@ class EntityFeed extends FeedBase implements ContainerFactoryPluginInterface {
       ->map('type', $this->builder->fromValue($this->type))
       ->map('bundle', $this->builder->fromValue($this->bundle))
       ->map('access', $this->builder->fromValue($this->access))
-      ->map('offset', $this->builder->fromArgument('offset'))
-      ->map('limit', $this->builder->fromArgument('limit'));
+      ->map('offset', $this->builder->defaultValue(
+        $this->builder->fromArgument('offset'),
+        $this->builder->fromValue(0)
+      ))
+      ->map('limit', $this->builder->defaultValue(
+        $this->builder->fromArgument('limit'),
+        $this->builder->fromValue(10),
+      ));
   }
 
   /**

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
@@ -182,7 +182,7 @@ class SilverbackGatsbySchemaExtension extends SdlSchemaExtensionPluginBase
     $schema = [
       "extend type Query {",
       "  $singleFieldName(id: String!): $typeName",
-      "  $listFieldName(offset: Int!, limit: Int!): [$typeName]!",
+      "  $listFieldName(offset: Int, limit: Int): [$typeName]!",
     ];
 
     $schema [] = "}";

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/queries/translatable.gql
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/queries/translatable.gql
@@ -2,7 +2,7 @@ query ($id: String!) {
   loadPage(id: $id) {
     title
   }
-  queryPages(limit: 10, offset: 0) {
+  queryPages {
     id
     drupalId
     translations {

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
@@ -210,6 +210,40 @@ class EntityFeedTest extends EntityFeedTestBase {
     ], $metadata);
   }
 
+  public function testUnpublishedSource() {
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'English',
+      'status' => 0,
+    ]);
+    $node->save();
+    $node->addTranslation('de', ['title' => 'German', 'status' => 1])->save();
+
+    $query = $this->getQueryFromFile('translatable.gql');
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheContexts(['user.node_grants:view', 'static:language:de']);
+    $metadata->addCacheTags(['node:1', 'node_list']);
+
+    $this->assertResults($query, ['id' => '1:de'], [
+      'loadPage' => [
+        "title" => "German"
+      ],
+      'queryPages' => [
+        null
+      ],
+    ], $metadata);
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheContexts(['user.node_grants:view']);
+    $metadata->addCacheTags(['node:1', 'node_list']);
+    $this->assertResults($query, ['id' => '1:en'], [
+      'loadPage' => null,
+      'queryPages' => [
+        null
+      ],
+    ], $metadata);
+  }
+
   public function testCreatePageFields() {
     $regular = Node::create([
       'type' => 'blog',

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
@@ -221,7 +221,7 @@ class EntityFeedTest extends EntityFeedTestBase {
 
     $query = $this->getQueryFromFile('translatable.gql');
     $metadata = $this->defaultCacheMetaData();
-    $metadata->addCacheContexts(['user.node_grants:view', 'static:language:de']);
+    $metadata->addCacheContexts(['user.node_grants:view', 'static:language:de', 'static:language:en']);
     $metadata->addCacheTags(['node:1', 'node_list']);
 
     $this->assertResults($query, ['id' => '1:de'], [
@@ -229,17 +229,37 @@ class EntityFeedTest extends EntityFeedTestBase {
         "title" => "German"
       ],
       'queryPages' => [
-        null
+        [
+          'id' => '1:de',
+          'drupalId' => '1',
+          'translations' => [
+            [
+              'defaultTranslation' => false,
+              'langcode' => 'de',
+              'title' => 'German',
+            ]
+          ],
+        ],
       ],
     ], $metadata);
 
     $metadata = $this->defaultCacheMetaData();
-    $metadata->addCacheContexts(['user.node_grants:view']);
+    $metadata->addCacheContexts(['user.node_grants:view', 'static:language:de', 'static:language:en']);
     $metadata->addCacheTags(['node:1', 'node_list']);
     $this->assertResults($query, ['id' => '1:en'], [
       'loadPage' => null,
       'queryPages' => [
-        null
+        [
+          'id' => '1:de',
+          'drupalId' => '1',
+          'translations' => [
+            [
+              'defaultTranslation' => false,
+              'langcode' => 'de',
+              'title' => 'German',
+            ]
+          ],
+        ],
       ],
     ], $metadata);
   }


### PR DESCRIPTION
## Package(s) involved
`amazeelabs/silverback_gatsby`

## Description of changes
* Make listing queries fall back to the first published translation of an entity when the source language is not accessible.
* allow to omit `limit` and `offset` when running listing queries for debugging

## Related Issue(s)
#849 , #882 

## How has this been tested?
* unit test cases
