### PR TITLE
fix(gatsby): emit a cjs build for storybook helpers

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/.gitignore
+++ b/packages/npm/@amazeelabs/react-framework-bridge/.gitignore
@@ -6,6 +6,7 @@ index.js
 index.esm.js
 index.d.ts
 storybook.js
+storybook.cjs.js
 storybook.d.ts
 utils.js
 utils.d.ts

--- a/packages/npm/@amazeelabs/react-framework-bridge/rollup.config.ts
+++ b/packages/npm/@amazeelabs/react-framework-bridge/rollup.config.ts
@@ -43,7 +43,7 @@ export default [
         format: 'esm',
       },
       {
-        file: 'index.cjs.js',
+        file: 'storybook.cjs.js',
         format: 'cjs',
       },
     ],

--- a/packages/npm/@amazeelabs/react-framework-bridge/rollup.config.ts
+++ b/packages/npm/@amazeelabs/react-framework-bridge/rollup.config.ts
@@ -37,10 +37,16 @@ export default [
   },
   {
     input: `src/storybook.tsx`,
-    output: {
-      file: 'storybook.js',
-      format: 'esm',
-    },
+    output: [
+      {
+        file: 'storybook.js',
+        format: 'esm',
+      },
+      {
+        file: 'index.cjs.js',
+        format: 'cjs',
+      },
+    ],
     external: [
       ...Object.keys(pkg.dependencies),
       ...Object.keys(pkg.peerDependencies),


### PR DESCRIPTION
## Package(s) involved
* `@amazeelabs/react-framework-bridge`

## Description of changes
Add a commonjs build of the storybook helpers so it can be used in jest.