### PR TITLE
feat: cache 404 responses in CDN to reduce Drupal hits

### DIFF
--- a/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
@@ -63,7 +63,9 @@ class CdnRedirectController extends ControllerBase {
       ]);
       $response = $http->get($location);
       if ($response->getStatusCode() === 200) {
-        return new Response($response->getBody(), 404);
+        return new Response($response->getBody(), 404, [
+          'cache-control' => 'public, max-age=' . 60*60*24*30,
+        ]);
       }
       elseif (
         $response->getStatusCode() === 401 &&
@@ -75,7 +77,9 @@ class CdnRedirectController extends ControllerBase {
           ],
         ]);
         if ($response->getStatusCode() === 200) {
-          return new Response($response->getBody(), 404);
+          return new Response($response->getBody(), 404, [
+            'cache-control' => 'public, max-age=' . 60*60*24*30,
+          ]);
         }
       }
     }


### PR DESCRIPTION
## Package(s) involved

CDN redirect

## How has this been tested?

On a project where we have Dev working with Netlify. With a patch.

Now the first `/non-existing-page` request takes some time to reach Drupal. But the following ones are served cached.