### PR TITLE
Menu link fixes

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
@@ -182,7 +182,7 @@ class MenuFeed extends FeedBase implements ContainerFactoryPluginInterface {
   public function resolveLangcode(): ResolverInterface {
     return $this->builder->callback(
       fn(Menu $value, $args, $context, $info, FieldContext $fieldContext) =>
-      $value->__language ?? $this->languageManager->getDefaultLanguage()->getId()
+      $value->__language ?? $this->languageManager->getCurrentLanguage()->getId()
     );
   }
 
@@ -230,7 +230,7 @@ class MenuFeed extends FeedBase implements ContainerFactoryPluginInterface {
       $builder->tap($builder->produce('language_switch')
         ->map('language', $builder->callback(
           function ($menu) {
-            return $menu->__language ?? $this->languageManager->getDefaultLanguage()->getId();
+            return $menu->__language ?? $this->languageManager->getCurrentLanguage()->getId();
           }
         ))
       ),

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/GatsbyMenuLinks.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/GatsbyMenuLinks.php
@@ -65,7 +65,10 @@ class GatsbyMenuLinks extends DataProducerPluginBase {
       $menuLink = \Drupal::entityTypeManager()
         ->getStorage('menu_link_content')
         ->load($entity_id);
-      return !$language || $menuLink->hasTranslation($language) || $menuLink->language()->getId() === $language;
+      return !$language ||
+        !$menuLink->isTranslatable() ||
+        $menuLink->hasTranslation($language) ||
+        $menuLink->language()->getId() === $language;
     });
 
     return $items;

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/GatsbyMenuLinks.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/GatsbyMenuLinks.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\silverback_gatsby\Plugin\GraphQL\DataProducer;
 
-use Drupal\Core\Annotation\ContextDefinition;
 use Drupal\Core\Menu\InaccessibleMenuLink;
 use Drupal\Core\Menu\MenuLinkTreeElement;
 use Drupal\graphql\GraphQL\Execution\FieldContext;


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback_gatsby`

## Description of changes

Render links in _current_ language (which usually is `selected_language`) in case of not translatable menu items.

## Motivation and context

Link URLs were rendered in _default_ language (which usually is English) in case of not translatable menu items.
