### PR TITLE
Workaround for the Gutenberg link autocomplete bug

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/js/gutenberg-tweaks.js
+++ b/packages/composer/amazeelabs/silverback_gutenberg/js/gutenberg-tweaks.js
@@ -1,53 +1,77 @@
-/* global drupalSettings, wp */
-drupalSettings.gutenberg._listeners.init.push(
-  // For all block types:
-  function () {
-    var blockTypes = wp.blocks.getBlockTypes();
-    for (var i = 0; i < blockTypes.length; i++) {
-      if (!blockTypes[i].supports) {
-        blockTypes[i].supports = {};
+/* global drupalSettings, wp, jQuery */
+(function ($) {
+  drupalSettings.gutenberg._listeners.init.push(
+    // For all block types:
+    function () {
+      var blockTypes = wp.blocks.getBlockTypes();
+      for (var i = 0; i < blockTypes.length; i++) {
+        if (!blockTypes[i].supports) {
+          blockTypes[i].supports = {};
+        }
+        // Disable "Additional CSS class(es)" section.
+        blockTypes[i].supports.customClassName = false;
+        // Disable align options.
+        blockTypes[i].supports.align = false;
       }
-      // Disable "Additional CSS class(es)" section.
-      blockTypes[i].supports.customClassName = false;
-      // Disable align options.
-      blockTypes[i].supports.align = false;
-    }
-  },
+    },
 
-  // Workaround for https://github.com/WordPress/gutenberg/issues/19815
-  function () {
-    var coreColumnsAllowed =
-      drupalSettings.editor.formats.gutenberg.editorSettings.allowedBlocks[
-        'core/columns'
-      ];
-    var coreImageAllowed =
-      drupalSettings.editor.formats.gutenberg.editorSettings.allowedBlocks[
-        'core/image'
-      ];
-    if (coreColumnsAllowed && !coreImageAllowed) {
+    // Workaround for https://github.com/WordPress/gutenberg/issues/19815
+    function () {
+      var coreColumnsAllowed =
+        drupalSettings.editor.formats.gutenberg.editorSettings.allowedBlocks[
+          'core/columns'
+        ];
+      var coreImageAllowed =
+        drupalSettings.editor.formats.gutenberg.editorSettings.allowedBlocks[
+          'core/image'
+        ];
+      if (coreColumnsAllowed && !coreImageAllowed) {
+        var coreColumnsBlock = wp.blocks.getBlockType('core/columns');
+        // Remove core/image from the example.
+        coreColumnsBlock.example.innerBlocks[0].innerBlocks.splice(1, 1);
+      }
+    },
+
+    // Remove most of the columns options.
+    function () {
       var coreColumnsBlock = wp.blocks.getBlockType('core/columns');
-      // Remove core/image from the example.
-      coreColumnsBlock.example.innerBlocks[0].innerBlocks.splice(1, 1);
-    }
-  },
+      coreColumnsBlock.supports.inserter = false;
+      coreColumnsBlock.supports.align = false;
+      coreColumnsBlock.supports.__experimentalColor = false;
+    },
 
-  // Remove most of the columns options.
-  function () {
-    var coreColumnsBlock = wp.blocks.getBlockType('core/columns');
-    coreColumnsBlock.supports.inserter = false;
-    coreColumnsBlock.supports.align = false;
-    coreColumnsBlock.supports.__experimentalColor = false;
-  },
+    // We never want some of the format options.
+    function () {
+      wp.richText.unregisterFormatType('core/image');
+      wp.richText.unregisterFormatType('core/text-color');
+    },
 
-  // We never want some of the format options.
-  function () {
-    wp.richText.unregisterFormatType('core/image');
-    wp.richText.unregisterFormatType('core/text-color');
-  },
+    // We don't want table styles.
+    function () {
+      wp.blocks.unregisterBlockStyle('core/table', 'regular');
+      wp.blocks.unregisterBlockStyle('core/table', 'stripes');
+    },
 
-  // We don't want table styles.
-  function () {
-    wp.blocks.unregisterBlockStyle('core/table', 'regular');
-    wp.blocks.unregisterBlockStyle('core/table', 'stripes');
-  },
-);
+    // Workaround for https://www.drupal.org/project/gutenberg/issues/3261702
+    function () {
+      $('.gutenberg-full-editor').on('keydown', function (event) {
+        if (
+          event &&
+          (event.code === 'Enter' || event.code === 'Space') &&
+          event.target &&
+          $(event.target).hasClass('block-editor-link-control__search-submit')
+        ) {
+          var $chosenResult = $(event.target)
+            .closest('.block-editor-link-control__search-input-wrapper')
+            .find(
+              '.block-editor-link-control__search-results button[aria-selected="true"].is-entity',
+            );
+          if ($chosenResult.length) {
+            event.preventDefault();
+            $chosenResult.click();
+          }
+        }
+      });
+    },
+  );
+})(jQuery);

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.libraries.yml
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.libraries.yml
@@ -6,6 +6,7 @@ tweaks:
       css/gutenberg-tweaks.css: { }
   dependencies:
     - core/drupalSettings
+    - core/jquery
 
 base:
   version: VERSION

--- a/packages/tests/silverback-gutenberg/playwright-tests/url-autocomplete-keyboard-selection.spec.ts
+++ b/packages/tests/silverback-gutenberg/playwright-tests/url-autocomplete-keyboard-selection.spec.ts
@@ -1,0 +1,29 @@
+import {
+  drupal,
+  drupalLogin,
+  resetState,
+} from '@amazeelabs/silverback-playwright';
+import { expect, test } from '@playwright/test';
+
+test.beforeAll(async () => {
+  await resetState();
+});
+
+test('@drupal-only test url autocomplete keyboard selection.spec.ts', async ({
+  page,
+}) => {
+  await drupalLogin(page);
+  await page.goto(`${drupal.baseUrl}/en/node/add/gutenberg_page`);
+
+  await page.click('[data-type="core/paragraph"]');
+  await page.click('button[aria-label="Toggle block inserter"]');
+  await page.click(':text-is("Teaser")');
+  await page.fill('[placeholder="Search or type url"]', 'page');
+  await page.waitForSelector('.block-editor-link-control__search-item');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+  //await page.waitForSelector('.block-editor-link-control__search-item-title');
+  await expect(
+    page.locator('.block-editor-link-control__search-item-title'),
+  ).toHaveAttribute('href', /^\//);
+});


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback_gutenberg`

## Description of changes

Added a workaround for a bug introduced in Gutenberg 2.3: https://www.drupal.org/project/gutenberg/issues/3261702

## How has this been tested?

Playwright test.
