### PR TITLE
chore: estimate the build duration based on the previous ones

### DIFF
--- a/packages/composer/drupal/gatsby_build_monitor/css/state.css
+++ b/packages/composer/drupal/gatsby_build_monitor/css/state.css
@@ -1,0 +1,10 @@
+.monitor-progress-border {
+  margin-top: 5px;
+  border: 1px solid grey;
+  width: 100px;
+}
+
+.monitor-progress-bar {
+  height: 24px;
+  background-color: green;
+}

--- a/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.libraries.yml
+++ b/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.libraries.yml
@@ -1,5 +1,8 @@
 state:
   version: VERSION
+  css:
+    theme:
+      css/state.css: {}
   js:
     js/state.js: {}
   dependencies:

--- a/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.module
+++ b/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.module
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\Core\Url;
+use Drupal\gatsby_build_monitor\BuildMonitorStatsInterface;
 use Drupal\silverback_gatsby\Gatsby;
 
 /**
@@ -51,11 +52,22 @@ function gatsby_build_monitor_toolbar() {
         'drupalSettings' => [
           'gatsbyBuildMonitor' => [
             'autoRefresh' => getenv('LAGOON') ||
-              getenv('GATSBY_BUILD_MONITOR_AUTO_REFRESH') === 'true',
+               getenv('GATSBY_BUILD_MONITOR_AUTO_REFRESH') === 'true'
           ],
         ],
       ],
       '#weight' => 1000,
+    ],
+    'gatsby_build_monitor_progress' => [
+      '#type' => 'toolbar_item',
+      'tab' => [
+        '#type' => 'inline_template',
+        '#template' => '<div class="build-monitor-progress" title="' . t('This is only an estimate based on the previous build times, and it may not be accurate in all the cases.') . '"></div>',
+        '#cache' => [
+          'max-age' => 0,
+        ],
+      ],
+      '#weight' => 1001,
     ],
   ];
 }
@@ -75,4 +87,8 @@ function _gatsby_build_monitor_state($state = NULL) {
   }
   \Drupal::state()->set('gatsby_build_monitor.state', $state);
   \Drupal::state()->set('gatsby_build_monitor.state_updated', \Drupal::time()->getCurrentTime());
+
+  /* @var BuildMonitorStatsInterface $statsService */
+  $statsService = \Drupal::service('gatsby_build_monitor.stats');
+  \Drupal::state()->set('gatsby_build_monitor.average_build_duration', $statsService->getAverageBuildDuration());
 }

--- a/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.services.yml
+++ b/packages/composer/drupal/gatsby_build_monitor/gatsby_build_monitor.services.yml
@@ -1,0 +1,4 @@
+services:
+  gatsby_build_monitor.stats:
+    class: Drupal\gatsby_build_monitor\BuildMonitorStats
+    arguments: ["@database"]

--- a/packages/composer/drupal/gatsby_build_monitor/js/state.js
+++ b/packages/composer/drupal/gatsby_build_monitor/js/state.js
@@ -10,20 +10,37 @@
       url: Drupal.url('gatsby-build-monitor/get-state'),
       success: function (data) {
         var text;
+        var progressBar;
+        var buildPercentage;
+        var buildDuration;
         switch (data.state) {
           case 'idle':
             text = Drupal.t('Website is ready');
+            $('.build-monitor-progress').html('');
             clearInterval(interval);
             break;
           case 'building':
             text = Drupal.t('Website is building');
+            if (data.currentTime && data.timestamp && data.averageBuildDuration) {
+              // As the build duration is only an estimate, it could happen that
+              // the current build would take more than the average, in which
+              // case we will just consider the average as being the maximum
+              // possible value for the build duration. This has the side effect
+              // that the process could just stay at 100% for more time.
+              buildDuration = Math.min(data.averageBuildDuration, data.currentTime - data.timestamp);
+              buildPercentage = buildDuration * 100 / data.averageBuildDuration;
+              progressBar = '<div class="monitor-progress-border"><div class="monitor-progress-bar" style="width: ' + buildPercentage + '%"></div></div>'
+              $('.build-monitor-progress').html(progressBar);
+            }
             break;
           case 'failure':
             text = Drupal.t('Website build failed');
+            $('.build-monitor-progress').html('');
             clearInterval(interval);
             break;
           default:
             text = Drupal.t('Website status is unknown');
+            $('.build-monitor-progress').html('');
             clearInterval(interval);
         }
         var $state = $('.gatsby-build-monitor-state');

--- a/packages/composer/drupal/gatsby_build_monitor/src/BuildMonitorStats.php
+++ b/packages/composer/drupal/gatsby_build_monitor/src/BuildMonitorStats.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\gatsby_build_monitor;
+
+use Drupal\Core\Database\Connection;
+
+/**
+ * Build monitor stats service.
+ */
+class BuildMonitorStats implements BuildMonitorStatsInterface {
+
+  /**
+   * The database service.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * Constructs a BuildMonitorStats object.
+   *
+   * @param Connection $database
+   */
+  public function __construct(Connection $database) {
+    $this->database = $database;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getAverageBuildDuration($itemsCount = 100) {
+    $stats = $this->database->select('gatsby_build_monitor_stats', 's')
+      ->fields('s', ['spent', 'id'])
+      ->condition('s.has_errors', 0)
+      ->orderBy('s.id', 'DESC')
+      ->range(0, $itemsCount)
+      ->execute()->fetchAll();
+    $duration = [];
+    foreach ($stats as $stat) {
+      if (empty($duration[$stat->spent])) {
+        $duration[$stat->spent] = 0;
+      }
+      $duration[$stat->spent]++;
+    }
+    arsort($duration, SORT_NUMERIC);
+    // Only consider the first half of the duration array, because they contain
+    // the values which appear more often for the build time.
+    $duration = array_slice($duration, 0, count($duration) / 2, TRUE);
+
+    // From the remaining results, we now compute the weighted average. In the
+    // $duration array we have the keys corresponding to the number of seconds
+    // and the values the number of times a build took that number of seconds to
+    // run.
+    $weightedSum = array_sum($duration);
+    // If, for any reason, we got an empty weightedSum, just return 0 to avoid
+    // a division by 0 warning.
+    if ($weightedSum <= 0) {
+      return 0;
+    }
+    $product = 0;
+    foreach ($duration as $seconds => $weight) {
+      $product += $seconds * $weight;
+    }
+    return (int) ($product / $weightedSum);
+  }
+}

--- a/packages/composer/drupal/gatsby_build_monitor/src/BuildMonitorStatsInterface.php
+++ b/packages/composer/drupal/gatsby_build_monitor/src/BuildMonitorStatsInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\gatsby_build_monitor;
+
+/**
+ * Interface for the build monitor stats service.
+ */
+interface BuildMonitorStatsInterface {
+
+  /**
+   * Returns the average build duration of the last entries.
+   *
+   * @param int $itemsCount
+   *   How many items to consider when building the average.
+   * @return int
+   */
+  public function getAverageBuildDuration($itemsCount = 100);
+}

--- a/packages/composer/drupal/gatsby_build_monitor/src/Controller.php
+++ b/packages/composer/drupal/gatsby_build_monitor/src/Controller.php
@@ -34,7 +34,6 @@ class Controller {
         // "building" from gatsby-plugin-build-monitor.
         return Response::create();
       }
-
       _gatsby_build_monitor_state($payload->status);
       if ($payload->status === 'idle' && $payload->buildStats) {
         $this->saveBuildStats($payload->buildStats);
@@ -92,6 +91,8 @@ class Controller {
     return JsonResponse::create([
       'state' => _gatsby_build_monitor_state(),
       'timestamp' => \Drupal::state()->get('gatsby_build_monitor.state_updated'),
+      'averageBuildDuration' => \Drupal::state()->get('gatsby_build_monitor.average_build_duration'),
+      'currentTime' => \Drupal::time()->getCurrentTime(),
     ]);
   }
 


### PR DESCRIPTION
## Package(s) involved

gatsby_build_monitor

## Description of changes

Estimate the build time bases on the previous (100) ones.

## Motivation and context

In order to have a sense of how much time a build would run (for example after saving a piece of content) we should display an estimate of it, based on the previous build durations, in the toolbar.

## Related Issue(s)

[Drupal/Gatsby: Build time tracking](https://github.com/AmazeeLabs/silverback-mono/issues/522)

## How has this been tested?

Manually, local.
