### PR TITLE
fix: double encoding in the outbound link processing

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
@@ -286,6 +286,10 @@ class LinkProcessor {
         ->setOption('language', $language)
         ->toString(TRUE)
         ->getGeneratedUrl();
+      // The toString() call above will encode the urls, so now we need to
+      // decode them to avoid double encoding upon the save operation
+      // afterwards.
+      $pathAlias = rawurldecode($pathAlias);
       if ($pathAlias !== $parts['path']) {
         $parts['path'] = $pathAlias;
       }

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
@@ -161,6 +161,7 @@ class LinkProcessorTest extends MediaKernelTestBase {
         'inbound' => [
           '/unrouted-path' => '/unrouted-path',
           '/de/unrouted-path' => '/de/unrouted-path',
+          '/unrouted-path with spaces' => '/unrouted-path with spaces',
         ],
         'outbound' => [
           '/unrouted-path' => [

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
@@ -122,6 +122,8 @@ class LinkProcessorTest extends MediaKernelTestBase {
               'en' => '/node/' . $withoutAlias->id(),
               'de' => '/de/node/' . $withoutAlias->id(),
             ],
+          ],
+          [
             '/node/' . $withoutAlias->uuid() => [
               'en' => '/node/' . $withoutAlias->id(),
               'de' => '/de/node/' . $withoutAlias->id(),
@@ -142,6 +144,8 @@ class LinkProcessorTest extends MediaKernelTestBase {
               'en' => '/english',
               'de' => '/de/german',
             ],
+          ],
+          [
             '/node/' . $withAlias->uuid() => [
               'en' => '/english',
               'de' => '/de/german',
@@ -160,6 +164,8 @@ class LinkProcessorTest extends MediaKernelTestBase {
               'en' => '/media/' . $media->id() . '/edit',
               'de' => '/de/media/' . $media->id() . '/edit',
             ],
+          ],
+          [
             '/media/' . $media->uuid() . '/edit' => [
               'en' => '/media/' . $media->id() . '/edit',
               'de' => '/de/media/' . $media->id() . '/edit',
@@ -178,10 +184,18 @@ class LinkProcessorTest extends MediaKernelTestBase {
               'en' => '/unrouted-path',
               'de' => '/unrouted-path',
             ],
+          ],
+          [
             '/de/unrouted-path' => [
               'en' => '/de/unrouted-path',
               'de' => '/de/unrouted-path',
             ],
+          ],
+          [
+            '/unrouted-path with spaces' => [
+              'en' => '/unrouted-path with spaces',
+              'de' => '/unrouted-path with spaces',
+            ]
           ],
         ],
       ],

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
@@ -93,136 +93,109 @@ class LinkProcessorTest extends MediaKernelTestBase {
     $cases = [
       'absolute' => [
         'inbound' => [
-          ['https://example.com/foo' => 'https://example.com/foo'],
-          ['https://example.com/de/foo' => 'https://example.com/de/foo'],
+          'https://example.com/foo' => 'https://example.com/foo',
+          'https://example.com/de/foo' => 'https://example.com/de/foo',
         ],
         'outbound' => [
-          [
-            'https://example.com/foo' => [
-              'en' => 'https://example.com/foo',
-              'de' => 'https://example.com/foo',
-            ],
+          'https://example.com/foo' => [
+            'en' => 'https://example.com/foo',
+            'de' => 'https://example.com/foo',
           ],
-          [
-            'https://example.com/de/foo' => [
-              'en' => 'https://example.com/de/foo',
-              'de' => 'https://example.com/de/foo',
-            ],
+          'https://example.com/de/foo' => [
+            'en' => 'https://example.com/de/foo',
+            'de' => 'https://example.com/de/foo',
           ],
         ],
       ],
       'without alias' => [
         'inbound' => [
-          ['/node/' . $withoutAlias->id() => '/node/' . $withoutAlias->uuid()],
-          ['/de/node/' . $withoutAlias->id() => '/node/' . $withoutAlias->uuid()],
+          '/node/' . $withoutAlias->id() => '/node/' . $withoutAlias->uuid(),
+          '/de/node/' . $withoutAlias->id() => '/node/' . $withoutAlias->uuid(),
         ],
         'outbound' => [
-          [
-            '/node/' . $withoutAlias->id() => [
-              'en' => '/node/' . $withoutAlias->id(),
-              'de' => '/de/node/' . $withoutAlias->id(),
-            ],
+          '/node/' . $withoutAlias->id() => [
+            'en' => '/node/' . $withoutAlias->id(),
+            'de' => '/de/node/' . $withoutAlias->id(),
           ],
-          [
-            '/node/' . $withoutAlias->uuid() => [
-              'en' => '/node/' . $withoutAlias->id(),
-              'de' => '/de/node/' . $withoutAlias->id(),
-            ],
+          '/node/' . $withoutAlias->uuid() => [
+            'en' => '/node/' . $withoutAlias->id(),
+            'de' => '/de/node/' . $withoutAlias->id(),
           ],
         ],
       ],
       'with alias' => [
         'inbound' => [
-          ['/node/' . $withAlias->id() => '/node/' . $withAlias->uuid()],
-          ['/de/node/' . $withAlias->id() => '/node/' . $withAlias->uuid()],
-          ['/english' => '/node/' . $withAlias->uuid()],
-          ['/de/german' => '/node/' . $withAlias->uuid()],
+          '/node/' . $withAlias->id() => '/node/' . $withAlias->uuid(),
+          '/de/node/' . $withAlias->id() => '/node/' . $withAlias->uuid(),
+          '/english' => '/node/' . $withAlias->uuid(),
+          '/de/german' => '/node/' . $withAlias->uuid(),
         ],
         'outbound' => [
-          [
-            '/node/' . $withAlias->id() => [
-              'en' => '/english',
-              'de' => '/de/german',
-            ],
+          '/node/' . $withAlias->id() => [
+            'en' => '/english',
+            'de' => '/de/german',
           ],
-          [
-            '/node/' . $withAlias->uuid() => [
-              'en' => '/english',
-              'de' => '/de/german',
-            ],
+          '/node/' . $withAlias->uuid() => [
+            'en' => '/english',
+            'de' => '/de/german',
           ],
         ],
       ],
       'media' => [
         'inbound' => [
-          ['/media/' . $media->id() . '/edit' => '/media/' . $media->uuid() . '/edit'],
-          ['/de/media/' . $media->id() . '/edit' => '/media/' . $media->uuid() . '/edit'],
+          '/media/' . $media->id() . '/edit' => '/media/' . $media->uuid() . '/edit',
+          '/de/media/' . $media->id() . '/edit' => '/media/' . $media->uuid() . '/edit',
         ],
         'outbound' => [
-          [
-            '/media/' . $media->id() . '/edit' => [
-              'en' => '/media/' . $media->id() . '/edit',
-              'de' => '/de/media/' . $media->id() . '/edit',
-            ],
+          '/media/' . $media->id() . '/edit' => [
+            'en' => '/media/' . $media->id() . '/edit',
+            'de' => '/de/media/' . $media->id() . '/edit',
           ],
-          [
-            '/media/' . $media->uuid() . '/edit' => [
-              'en' => '/media/' . $media->id() . '/edit',
-              'de' => '/de/media/' . $media->id() . '/edit',
-            ],
+          '/media/' . $media->uuid() . '/edit' => [
+            'en' => '/media/' . $media->id() . '/edit',
+            'de' => '/de/media/' . $media->id() . '/edit',
           ],
         ],
       ],
       'unrouted' => [
         'inbound' => [
-          ['/unrouted-path' => '/unrouted-path'],
-          ['/de/unrouted-path' => '/de/unrouted-path'],
+          '/unrouted-path' => '/unrouted-path',
+          '/de/unrouted-path' => '/de/unrouted-path',
         ],
         'outbound' => [
-          [
-            '/unrouted-path' => [
-              'en' => '/unrouted-path',
-              'de' => '/unrouted-path',
-            ],
+          '/unrouted-path' => [
+            'en' => '/unrouted-path',
+            'de' => '/unrouted-path',
           ],
-          [
-            '/de/unrouted-path' => [
-              'en' => '/de/unrouted-path',
-              'de' => '/de/unrouted-path',
-            ],
+          '/de/unrouted-path' => [
+            'en' => '/de/unrouted-path',
+            'de' => '/de/unrouted-path',
           ],
-          [
-            '/unrouted-path with spaces' => [
-              'en' => '/unrouted-path with spaces',
-              'de' => '/unrouted-path with spaces',
-            ]
+          '/unrouted-path with spaces' => [
+            'en' => '/unrouted-path with spaces',
+            'de' => '/unrouted-path with spaces',
           ],
         ],
       ],
       'mailto' => [
         'inbound' => [
-          ['mailto:someone@example.site' => 'mailto:someone@example.site'],
+          'mailto:someone@example.site' => 'mailto:someone@example.site',
         ],
         'outbound' => [
-          [
-            'mailto:someone@example.site' => [
-              'en' => 'mailto:someone@example.site',
-              'de' => 'mailto:someone@example.site',
-            ]
-          ]
+          'mailto:someone@example.site' => [
+            'en' => 'mailto:someone@example.site',
+            'de' => 'mailto:someone@example.site',
+          ],
         ],
       ],
     ];
 
     foreach ($cases as $name => $directions) {
       foreach ($directions as $direction => $samples) {
-        foreach ($samples as $sample) {
-          $target = reset($sample);
-          $original = key($sample);
+        foreach ($samples as $original => $target) {
           if ($direction === 'inbound') {
-            $processed = $target;
             $url = $linkProcessor->processUrl($original, 'inbound');
-            $this->assertEquals($processed, $url, "Case name: {$name}, direction: {$direction}, original: {$original}");
+            $this->assertEquals($target, $url, "Case name: {$name}, direction: {$direction}, original: {$original}");
           }
           else {
             foreach ($target as $langcode => $processed) {


### PR DESCRIPTION
## Package(s) involved

silverback_gutenberg

## Description of changes

Decode the outbound urls during the link processing so that they are not double encoded when the node gets saved.

## Related Issue(s)

[Multiple url encoding in internal links by the gutenberg url processor](https://github.com/AmazeeLabs/silverback-mono/issues/959)

## How has this been tested?

automated tests (kernel).
