### PR TITLE
feat: add more context to the gutenberg hook

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php
@@ -17,13 +17,19 @@ function hook_silverback_gutenberg_link_processor_block_attributes_alter(
  *   Has the following keys:
  *   - blockName: a string containing the block name
  *   - processUrlCallback: a callback to process a single URL string
+ *       Callback signature: (string $url): string
  *   - processLinksCallback: a callback to process links in an HTML string
+ *       Callback signature: (string $html): string
+ *   - direction: "inbound" or "outbound"
+ *   - language: LanguageInterface or null
  */
 function hook_silverback_gutenberg_link_processor_block_attrs_alter(array &$attributes, array $context) {
   if ($context['blockName'] === 'custom/my-links-block' && isset($attributes['urls'])) {
     $attributes['urlsUnprocessed'] = [];
     foreach ($attributes['urls'] as $key => $url) {
-      $attributes['urlsUnprocessed'][$key] = $url;
+      if ($context['direction'] === 'outbound') {
+        $attributes['urlsUnprocessed'][$key] = $url;
+      }
       $attributes['urls'][$key] = $context['processUrlCallback']($url);
     }
   }

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/LinkProcessor.php
@@ -95,6 +95,8 @@ class LinkProcessor {
         'blockName' => $block['blockName'],
         'processUrlCallback' => $processUrlCallback,
         'processLinksCallback' => $processLinksCallback,
+        'direction' => $direction,
+        'language' => $language,
       ];
       $this->moduleHandler->alter(
         'silverback_gutenberg_link_processor_block_attrs',


### PR DESCRIPTION
## Package(s) involved

`composer/amazeelabs/silverback_gutenberg`

## Description of changes

Provide more context for `hook_silverback_gutenberg_link_processor_block_attrs_alter`.

## Motivation and context

If modules add additional attributes, like in this example
https://github.com/AmazeeLabs/silverback-mono/blob/e5444e31da2a6fc19c357b48a836152346dc57d9/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php#L26
the added attributes appear in the exported default content. Which we don't want to happen.

And now the modules can do
https://github.com/AmazeeLabs/silverback-mono/blob/3791be2e7099503bf2f3dda3320e8dab54b26afb/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.api.php#L30-L32

## How has this been tested?

Not really tested.
