### PR TITLE
Allow to authorize GraphQL queries with key_auth module

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.info.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.info.yml
@@ -5,5 +5,4 @@ package: Silverback
 core: 8.x
 dependencies:
   - graphql:graphql (>=8.x-4.0)
-  - basic_auth
 core_version_requirement: ^8 || ^9

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
@@ -39,16 +39,23 @@ The following configuration options are supported:
   connect to.
 - `graphql_path` **(required)**: The configured path of the configured Drupal
   GraphQL server instance.
-- `auth_user` **(optional)**: A Drupal username to use for sending requests.
-- `auth_pass` **(optional)**: A Drupal password to use for sending requests.
+- `auth_user` and `auth_pass` **(optional)**: A username and a password for
+  either
+  - passing by the basic auth protection (e.g. if Drupal is protected with
+    Lagoon's basic auth)
+  - authorizing GraphQL requests (e.g. if Drupal's `basic_auth` module is
+    enabled)
+- `auth_key` **(optional)**: A key to be passed in `api-key` header to authorize
+  GraphQL requests (e.g. if [key_auth](https://www.drupal.org/project/key_auth)
+  module is enabled)
 
-The optional credential parameters (`auth_user` and `auth_pass`) can be used to
-enable different workflows. On production, they can be omitted to make sure
-Drupal handles these requests anonymously and won't expose any unpublished
-content. Alternatively one can also configure a dedicated role and user for this
-task and block anonymous users entirely from accessing Drupal. In a preview
-environment on the other hand, the credentials should allow Gatsby to access
-unpublished content to be able to display previews.
+The optional credential parameters can be used to enable different workflows. On
+production, they can be omitted to make sure Drupal handles these requests
+anonymously and won't expose any unpublished content. Alternatively one can also
+configure a dedicated role and user for this task and block anonymous users
+entirely from accessing Drupal. In a preview environment on the other hand, the
+credentials should allow Gatsby to access unpublished content to be able to
+display previews.
 
 ## Automatic creation of Gatsby pages
 

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -28,17 +28,17 @@ export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
   Joi.object<Options>({
     drupal_url: Joi.string().uri({ allowRelative: false }).required(),
     graphql_path: Joi.string().uri({ relativeOnly: true }).required(),
-    drupal_external_url: Joi.string().uri({allowRelative: false}),
+    drupal_external_url: Joi.string().uri({ allowRelative: false }),
     auth_user: Joi.string().optional(),
     auth_pass: Joi.string().optional(),
+    auth_key: Joi.string().optional(),
   });
 
 const getForwardedHeaders = (url: URL) => ({
   'X-Forwarded-Proto': url.protocol,
   'X-Forwarded-Host': url.hostname,
   'X-Forwarded-Port': url.port,
-})
-
+});
 
 export const sourceNodes: GatsbyNode['sourceNodes'] = async (
   gatsbyApi: SourceNodesArgs & { webhookBody?: { buildId?: number } },
@@ -52,7 +52,10 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     apiUrl(options),
     options.auth_user,
     options.auth_pass,
-    options.drupal_external_url ? getForwardedHeaders(new URL(options.drupal_external_url)) : undefined
+    options.auth_key,
+    options.drupal_external_url
+      ? getForwardedHeaders(new URL(options.drupal_external_url))
+      : undefined,
   );
   // TODO: Accept configuration and fragment overrides from plugin settings.
   const config = await createSourcingConfig(gatsbyApi, executor);
@@ -139,6 +142,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       apiUrl(options),
       options.auth_user,
       options.auth_pass,
+      options.auth_key,
     );
     // TODO: Accept configuration and fragment overrides from plugin settings.
     const config = await createSourcingConfig(args, executor);
@@ -150,6 +154,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
         apiUrl(options),
         options.auth_user,
         options.auth_pass,
+        options.auth_key,
       ),
     );
     args.actions.createTypes(`

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-pages.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-pages.ts
@@ -17,6 +17,7 @@ export const createPages = async (
     apiUrl(options),
     options.auth_user,
     options.auth_pass,
+    options.auth_key,
   );
   const feeds = await drupalFeeds(executor);
   for (const feed of feeds) {

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
@@ -2,22 +2,22 @@ import { createDefaultQueryExecutor } from 'gatsby-graphql-source-toolkit';
 
 export const createQueryExecutor = (
   url: string,
-  user?: string,
-  pass?: string,
-  headers?: RequestInit['headers']
+  authUser?: string,
+  authPass?: string,
+  authKey?: string,
+  headers?: RequestInit['headers'],
 ) => {
-  return createDefaultQueryExecutor(
-    url,
-    {
-      ...headers,
-      ...(!!user && !!pass
+  return createDefaultQueryExecutor(url, {
+    ...headers,
+    ...(!!authUser && !!authPass
       ? {
           headers: {
-            Authorization: `Basic ${Buffer.from(`${user}:${pass}`).toString(
-              'base64',
-            )}`,
+            Authorization: `Basic ${Buffer.from(
+              `${authUser}:${authPass}`,
+            ).toString('base64')}`,
           },
         }
-      : {})},
-  );
+      : {}),
+    ...(authKey ? { 'api-key': authKey } : {}),
+  });
 };

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
@@ -5,10 +5,12 @@ export type Options = {
   drupal_external_url?: string;
   // The Drupal GraphQL server path.
   graphql_path: string;
-  // Optional Basic Auth Drupal user.
+  // Optional Basic Auth user.
   auth_user?: string;
-  // Optional Basic Auth Drupal password.
+  // Optional Basic Auth password.
   auth_pass?: string;
+  // Optional Key Auth.
+  auth_key?: string;
 };
 
 export const validOptions = (options: {


### PR DESCRIPTION
## Package(s) involved

- `composer/amazeelabs/silverback_gatsby`
- `npm/@amazeelabs/gatsby-source-silverback`

## Related Issue(s)

Closes https://github.com/AmazeeLabs/silverback-mono/issues/975

## How has this been tested?

It was not.
