### PR TITLE
Improve Form interactions

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/gatsby.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/gatsby.test.tsx
@@ -228,4 +228,23 @@ describe('buildForm', () => {
       expect(callback).toHaveBeenCalledWith({ foo: 'bar' });
     });
   });
+
+  it('emits value changes via the "onChange" callback', async () => {
+    const onChange = jest.fn();
+    const Form = buildForm({ initialValues: { foo: '' }, onChange });
+    render(
+      <Form>
+        <Field type="text" name="foo" />
+        <button type="submit" />
+      </Form>,
+    );
+    await userEvent.type(screen.getByRole('textbox'), 'bar');
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(4);
+      expect(onChange).toHaveBeenNthCalledWith(1, { foo: '' });
+      expect(onChange).toHaveBeenNthCalledWith(2, { foo: 'b' });
+      expect(onChange).toHaveBeenNthCalledWith(3, { foo: 'ba' });
+      expect(onChange).toHaveBeenNthCalledWith(4, { foo: 'bar' });
+    });
+  });
 });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/gatsby.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/gatsby.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Field } from 'formik';
+import { Field, FormikValues } from 'formik';
 import { GatsbyLinkProps } from 'gatsby';
 import { GatsbyImageProps } from 'gatsby-plugin-image';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { buildForm, buildImage, buildLink } from '../gatsby';
 
@@ -246,5 +246,27 @@ describe('buildForm', () => {
       expect(onChange).toHaveBeenNthCalledWith(3, { foo: 'ba' });
       expect(onChange).toHaveBeenNthCalledWith(4, { foo: 'bar' });
     });
+  });
+
+  it('pre-populates the from useInitialValues hook if available', async () => {
+    const useInitialValues = () => {
+      const [values, setValues] = useState<FormikValues | undefined>(undefined);
+      useEffect(() => {
+        setTimeout(() => {
+          setValues({ foo: 'foo' });
+        }, 100);
+      }, [setValues]);
+      return values;
+    };
+
+    const Form = buildForm({ initialValues: { foo: '' }, useInitialValues });
+    render(
+      <Form>
+        <Field type="text" name="foo" />
+        <button type="submit" />
+      </Form>,
+    );
+    const input = screen.getByRole('textbox');
+    await waitFor(() => expect(input.getAttribute('value')).toEqual('foo'));
   });
 });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
@@ -218,4 +218,23 @@ describe('buildForm', () => {
       expect(wouldSubmit).toHaveBeenCalledWith({ foo: 'bar' });
     });
   });
+
+  it('emits value changes via the "onChange" callback', async () => {
+    const onChange = jest.fn();
+    const Form = buildForm({ initialValues: { foo: '' }, onChange });
+    render(
+      <Form>
+        <Field type="text" name="foo" />
+        <button type="submit" />
+      </Form>,
+    );
+    await userEvent.type(screen.getByRole('textbox'), 'bar');
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(4);
+      expect(onChange).toHaveBeenNthCalledWith(1, { foo: '' });
+      expect(onChange).toHaveBeenNthCalledWith(2, { foo: 'b' });
+      expect(onChange).toHaveBeenNthCalledWith(3, { foo: 'ba' });
+      expect(onChange).toHaveBeenNthCalledWith(4, { foo: 'bar' });
+    });
+  });
 });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Field } from 'formik';
-import React from 'react';
+import { Field, FormikValues } from 'formik';
+import React, { useEffect, useState } from 'react';
 
 import {
   ActionsDecorator,
@@ -236,5 +236,27 @@ describe('buildForm', () => {
       expect(onChange).toHaveBeenNthCalledWith(3, { foo: 'ba' });
       expect(onChange).toHaveBeenNthCalledWith(4, { foo: 'bar' });
     });
+  });
+
+  it('pre-populates the from useInitialValues hook if available', async () => {
+    const useInitialValues = () => {
+      const [values, setValues] = useState<FormikValues | undefined>(undefined);
+      useEffect(() => {
+        setTimeout(() => {
+          setValues({ foo: 'foo' });
+        }, 100);
+      }, [setValues]);
+      return values;
+    };
+
+    const Form = buildForm({ initialValues: { foo: '' }, useInitialValues });
+    render(
+      <Form>
+        <Field type="text" name="foo" />
+        <button type="submit" />
+      </Form>,
+    );
+    const input = screen.getByRole('textbox');
+    await waitFor(() => expect(input.getAttribute('value')).toEqual('foo'));
   });
 });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/utils.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/utils.test.tsx
@@ -1,8 +1,15 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Field, Form, Formik } from 'formik';
 import React from 'react';
 
 import { Link, LinkProps } from '../types';
-import { buildHtmlBuilder, buildUrl, isElement, isRelative } from '../utils';
+import {
+  buildHtmlBuilder,
+  buildUrl,
+  FormikChanges,
+  isElement,
+  isRelative,
+} from '../utils';
 
 describe('isRelative', () => {
   it('returns true for a relative url', () => {
@@ -55,12 +62,12 @@ describe('buildHtmlBuilder', () => {
     expect(Html.initialHtmlString).toEqual(htmlString);
     render(<Html />);
     expect(screen.getByRole('main')).toMatchInlineSnapshot(`
-<main>
-  <p>
-    Test
-  </p>
-</main>
-`);
+      <main>
+        <p>
+          Test
+        </p>
+      </main>
+    `);
   });
 
   it('wraps list element contents in a div to avoid Tailwind styling issues', () => {
@@ -70,44 +77,44 @@ describe('buildHtmlBuilder', () => {
     const Html = buildHtml('<main><ul><li>Test</li></ul></main>');
     render(<Html />);
     expect(screen.getByRole('main')).toMatchInlineSnapshot(`
-<main>
-  <ul>
-    <li>
-      <div>
-        Test
-      </div>
-    </li>
-  </ul>
-</main>
-`);
+      <main>
+        <ul>
+          <li>
+            <div>
+              Test
+            </div>
+          </li>
+        </ul>
+      </main>
+    `);
   });
 
   it('adds automatic ids to h2 elements', () => {
     const Html = buildHtml('<main><h2>Test</h2></main>');
     render(<Html />);
     expect(screen.getByRole('main')).toMatchInlineSnapshot(`
-<main>
-  <h2
-    id="test"
-  >
-    Test
-  </h2>
-</main>
-`);
+      <main>
+        <h2
+          id="test"
+        >
+          Test
+        </h2>
+      </main>
+    `);
   });
 
   it('applies framework-specific link components', () => {
     const Html = buildHtml('<main><a href="/test">Test</a></main>');
     render(<Html />);
     expect(screen.getByRole('main')).toMatchInlineSnapshot(`
-<main>
-  <a
-    href="/test"
-  >
-    Test
-  </a>
-</main>
-`);
+      <main>
+        <a
+          href="/test"
+        >
+          Test
+        </a>
+      </main>
+    `);
 
     fireEvent.click(screen.getByRole('link'));
     expect(nav).toHaveBeenCalledTimes(1);
@@ -124,14 +131,14 @@ describe('buildHtmlBuilder', () => {
       />,
     );
     expect(screen.getByRole('main')).toMatchInlineSnapshot(`
-<main>
-  <p
-    class="text-red"
-  >
-    Test
-  </p>
-</main>
-`);
+      <main>
+        <p
+          class="text-red"
+        >
+          Test
+        </p>
+      </main>
+    `);
   });
 
   it('allows to define class functions for elements', () => {
@@ -152,20 +159,20 @@ describe('buildHtmlBuilder', () => {
       />,
     );
     expect(screen.getByRole('main')).toMatchInlineSnapshot(`
-<main>
-  <a
-    href="http://www.amazeelabs.com"
-  >
-    Amazee
-  </a>
-  <a
-    class="text-blue"
-    href="http://www.google.com"
-  >
-    Google
-  </a>
-</main>
-`);
+      <main>
+        <a
+          href="http://www.amazeelabs.com"
+        >
+          Amazee
+        </a>
+        <a
+          class="text-blue"
+          href="http://www.google.com"
+        >
+          Google
+        </a>
+      </main>
+    `);
   });
 });
 
@@ -239,5 +246,39 @@ describe('buildUrl', () => {
     expect(
       buildUrl(['https://fake.url/', 'a', 'b'], undefined, undefined, 'foo'),
     ).toStrictEqual(`https://fake.url/a/b#foo`);
+  });
+});
+
+describe('FormikChanges', () => {
+  it('emits form value changes via "onChange"', async () => {
+    const onChange = jest.fn();
+    render(
+      <Formik initialValues={{ query: '' }} onSubmit={() => {}}>
+        <Form>
+          <FormikChanges onChange={onChange} />
+          <label>
+            Query
+            <Field type="text" name="query" />
+          </label>
+        </Form>
+      </Formik>,
+    );
+    const input = await screen.findByRole('textbox');
+
+    await userEvent.type(input, 'foo');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'bar');
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(8);
+      expect(onChange).toHaveBeenNthCalledWith(1, { query: '' });
+      expect(onChange).toHaveBeenNthCalledWith(2, { query: 'f' });
+      expect(onChange).toHaveBeenNthCalledWith(3, { query: 'fo' });
+      expect(onChange).toHaveBeenNthCalledWith(4, { query: 'foo' });
+      expect(onChange).toHaveBeenNthCalledWith(5, { query: '' });
+      expect(onChange).toHaveBeenNthCalledWith(6, { query: 'b' });
+      expect(onChange).toHaveBeenNthCalledWith(7, { query: 'ba' });
+      expect(onChange).toHaveBeenNthCalledWith(8, { query: 'bar' });
+    });
   });
 });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
@@ -8,6 +8,7 @@ import { Form, FormBuilderProps } from './types';
 import {
   buildHtmlBuilder,
   buildUrlBuilder,
+  FormikChanges,
   isInternalTarget,
   isRelative,
 } from './utils';
@@ -115,10 +116,11 @@ export const buildImage = (props: ImageProps): Image => {
 
 export const buildHtml = buildHtmlBuilder(buildLink);
 
-export function buildForm<Values>(
-  formikProps: FormBuilderProps<Values>,
-): Form<Values> {
-  return function GatsbyFormBuilder(formProps) {
+export function buildForm<Values>({
+  onChange,
+  ...formikProps
+}: FormBuilderProps<Values>): Form<Values> {
+  return function GatsbyFormBuilder({ children, ...formProps }) {
     return (
       <Formik
         onSubmit={(values) => {
@@ -126,7 +128,10 @@ export function buildForm<Values>(
         }}
         {...formikProps}
       >
-        <FormComponent {...formProps} />
+        <FormComponent {...formProps}>
+          {onChange ? <FormikChanges onChange={onChange} /> : null}
+          {children}
+        </FormComponent>
       </Formik>
     );
   };

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/gatsby.tsx
@@ -9,6 +9,7 @@ import {
   buildHtmlBuilder,
   buildUrlBuilder,
   FormikChanges,
+  FormikInitialValues,
   isInternalTarget,
   isRelative,
 } from './utils';
@@ -118,6 +119,7 @@ export const buildHtml = buildHtmlBuilder(buildLink);
 
 export function buildForm<Values>({
   onChange,
+  useInitialValues,
   ...formikProps
 }: FormBuilderProps<Values>): Form<Values> {
   return function GatsbyFormBuilder({ children, ...formProps }) {
@@ -130,6 +132,9 @@ export function buildForm<Values>({
       >
         <FormComponent {...formProps}>
           {onChange ? <FormikChanges onChange={onChange} /> : null}
+          {useInitialValues ? (
+            <FormikInitialValues useInitialValues={useInitialValues} />
+          ) : null}
           {children}
         </FormComponent>
       </Formik>

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
@@ -10,7 +10,7 @@ import {
   Link,
   LinkProps,
 } from './types';
-import { buildHtmlBuilder, buildUrlBuilder } from './utils';
+import { buildHtmlBuilder, buildUrlBuilder, FormikChanges } from './utils';
 
 export type ActionsContext = {
   wouldNavigate: (to: string) => void;
@@ -123,10 +123,11 @@ export const buildImage = (props: ImageProps): Image => {
 
 export const buildHtml = buildHtmlBuilder(buildLink);
 
-export function buildForm<Values>(
-  formikProps: FormBuilderProps<Values>,
-): Form<Values> {
-  return function StorybookFormBuilder(formProps) {
+export function buildForm<Values>({
+  onChange,
+  ...formikProps
+}: FormBuilderProps<Values>): Form<Values> {
+  return function StorybookFormBuilder({ children, ...formProps }) {
     const ctx = useContext(ActionsContext);
     return (
       <Formik
@@ -135,7 +136,10 @@ export function buildForm<Values>(
         }}
         {...formikProps}
       >
-        <FormComponent {...formProps} />
+        <FormComponent {...formProps}>
+          {onChange ? <FormikChanges onChange={onChange} /> : null}
+          {children}
+        </FormComponent>
       </Formik>
     );
   };

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
@@ -10,7 +10,12 @@ import {
   Link,
   LinkProps,
 } from './types';
-import { buildHtmlBuilder, buildUrlBuilder, FormikChanges } from './utils';
+import {
+  buildHtmlBuilder,
+  buildUrlBuilder,
+  FormikChanges,
+  FormikInitialValues,
+} from './utils';
 
 export type ActionsContext = {
   wouldNavigate: (to: string) => void;
@@ -125,6 +130,7 @@ export const buildHtml = buildHtmlBuilder(buildLink);
 
 export function buildForm<Values>({
   onChange,
+  useInitialValues,
   ...formikProps
 }: FormBuilderProps<Values>): Form<Values> {
   return function StorybookFormBuilder({ children, ...formProps }) {
@@ -138,6 +144,9 @@ export function buildForm<Values>({
       >
         <FormComponent {...formProps}>
           {onChange ? <FormikChanges onChange={onChange} /> : null}
+          {useInitialValues ? (
+            <FormikInitialValues useInitialValues={useInitialValues} />
+          ) : null}
           {children}
         </FormComponent>
       </Formik>

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
@@ -75,4 +75,6 @@ export type FormBuilderProps<Values extends FormikValues> = Omit<
   FormikConfig<Values>,
   'onSubmit'
 > &
-  Partial<Pick<FormikConfig<Values>, 'onSubmit'>>;
+  Partial<Pick<FormikConfig<Values>, 'onSubmit'>> & {
+    onChange?: (values: Partial<Values>) => void;
+  };

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
@@ -77,4 +77,5 @@ export type FormBuilderProps<Values extends FormikValues> = Omit<
 > &
   Partial<Pick<FormikConfig<Values>, 'onSubmit'>> & {
     onChange?: (values: Partial<Values>) => void;
+    useInitialValues?: () => Partial<Values> | undefined;
   };

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils.tsx
@@ -1,3 +1,4 @@
+import { FormikValues, useFormikContext } from 'formik';
 import parse, {
   attributesToProps,
   DOMNode,
@@ -6,7 +7,7 @@ import parse, {
   HTMLReactParserOptions,
 } from 'html-react-parser';
 import { stringify } from 'qs';
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, useEffect } from 'react';
 
 import { Html, LinkBuilder, LinkProps } from './types';
 
@@ -30,6 +31,24 @@ export const slugify = (...args: (string | number)[]): string => {
     .replace(/[^a-z0-9 ]/g, '') // remove all chars not letters, numbers and spaces (to be replaced)
     .replace(/\s+/g, '-'); // separator
 };
+
+/**
+ * React component that will catch any updated field values within a Form.
+ *
+ * @param onChange Callback the updates will be sent to.
+ * @constructor
+ */
+export function FormikChanges<T extends FormikValues>({
+  onChange,
+}: {
+  onChange: (values: T) => void;
+}) {
+  const { values } = useFormikContext<T>();
+  useEffect(() => {
+    onChange(values);
+  }, [values, onChange]);
+  return null;
+}
 
 export const isElement = (
   node: DOMNode & { children?: DOMNode[] },

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils.tsx
@@ -9,7 +9,7 @@ import parse, {
 import { stringify } from 'qs';
 import React, { ComponentProps, useEffect } from 'react';
 
-import { Html, LinkBuilder, LinkProps } from './types';
+import { FormBuilderProps, Html, LinkBuilder, LinkProps } from './types';
 
 export const isInternalTarget = (target?: string) =>
   typeof target === 'undefined' || target === '' || target === '_self';
@@ -47,6 +47,24 @@ export function FormikChanges<T extends FormikValues>({
   useEffect(() => {
     onChange(values);
   }, [values, onChange]);
+  return null;
+}
+
+export function FormikInitialValues<T extends FormikValues>({
+  useInitialValues,
+}: Required<Pick<FormBuilderProps<T>, 'useInitialValues'>>) {
+  const { touched, setFieldTouched, setFieldValue } = useFormikContext<T>();
+  const values = useInitialValues();
+  useEffect(() => {
+    if (values) {
+      for (const field in values) {
+        if (!touched[field]) {
+          setFieldValue(field, values[field], false);
+          setFieldTouched(field, true, false);
+        }
+      }
+    }
+  }, [touched, setFieldTouched, setFieldValue, values]);
   return null;
 }
 


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/react-framework-bridge`

## Description of changes

Add `onChange` and `useInitialValues` arguments to `buildForm`.

## Motivation and context

* `onChange`: emit real time updates for form values, even without the form being submitted. Can be used to live-adapt the form based on inputs with external data (e.g. autocomplete elements).
* `useInitialValue`: initiate form values *after* the initial render. For example to populate the form with values from the query string.
