### PR TITLE
Simulated routing in Storybook

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
@@ -286,6 +286,34 @@ describe('buildForm', () => {
     });
   });
 
+  it('also sends submission to the onSubmit callback', async () => {
+    const callback = jest.fn();
+    const Form = buildForm({ initialValues: { foo: '' }, onSubmit: callback });
+    render(
+      ActionsDecorator(
+        (props) => {
+          return (
+            <props.args.Form>
+              <Field type="text" name="foo" />
+              <button type="submit" />
+            </props.args.Form>
+          );
+        },
+        {
+          args: { wouldSubmit, Form },
+        } as any,
+      ),
+    );
+    userEvent.type(screen.getByRole('textbox'), 'bar');
+    userEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(wouldSubmit).toHaveBeenCalledTimes(1);
+      expect(wouldSubmit).toHaveBeenCalledWith({ foo: 'bar' });
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith({ foo: 'bar' }, expect.anything());
+    });
+  });
+
   it('emits value changes via the "onChange" callback', async () => {
     const onChange = jest.fn();
     const Form = buildForm({ initialValues: { foo: '' }, onChange });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
@@ -1,6 +1,6 @@
 import { DecoratorFn } from '@storybook/react';
 import { Form as FormComponent, Formik } from 'formik';
-import React, { PropsWithChildren, useContext, useEffect, useRef } from 'react';
+import React, { PropsWithChildren, useEffect, useRef } from 'react';
 
 import {
   Form,
@@ -42,6 +42,12 @@ const ActionsWrapper = ({
     eventBoundary.current?.addEventListener('would-navigate', (event) => {
       if (event instanceof CustomEvent) {
         wouldNavigate(event.detail);
+      }
+    });
+
+    eventBoundary.current?.addEventListener('would-submit', (event) => {
+      if (event instanceof CustomEvent) {
+        wouldSubmit(event.detail);
       }
     });
   });
@@ -87,13 +93,16 @@ export function buildLink<Query = {}>({
     children,
   }) {
     const target = buildUrl(queryOverride, fragment);
-    const ctx = useContext(ActionsContext);
     return (
       <a
         href={target}
         onClick={(ev) => {
           ev.preventDefault();
-          ctx.wouldNavigate(target);
+          document.getElementById('storybook-event-boundary')?.dispatchEvent(
+            new CustomEvent('would-navigate', {
+              detail: target,
+            }),
+          );
         }}
         className={
           target?.includes('active')
@@ -134,11 +143,14 @@ export function buildForm<Values>({
   ...formikProps
 }: FormBuilderProps<Values>): Form<Values> {
   return function StorybookFormBuilder({ children, ...formProps }) {
-    const ctx = useContext(ActionsContext);
     return (
       <Formik
         onSubmit={(values) => {
-          ctx.wouldSubmit(values);
+          document.getElementById('storybook-event-boundary')?.dispatchEvent(
+            new CustomEvent('would-submit', {
+              detail: values,
+            }),
+          );
         }}
         {...formikProps}
       >

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
@@ -170,12 +170,14 @@ export const buildHtml = buildHtmlBuilder(buildLink);
 export function buildForm<Values>({
   onChange,
   useInitialValues,
+  onSubmit,
   ...formikProps
 }: FormBuilderProps<Values>): Form<Values> {
   return function StorybookFormBuilder({ children, ...formProps }) {
     return (
       <Formik
-        onSubmit={(values) => {
+        onSubmit={(values, formikHelpers) => {
+          onSubmit?.(values, formikHelpers);
           document.getElementById('storybook-event-boundary')?.dispatchEvent(
             new CustomEvent('would-submit', {
               detail: values,


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/react-framework-bridge`

## Description of changes

Collect latest routing invocations of `buildLink` and expose them with the `useLocation` hook. Allow to react to form submissions in Storybook by passing `onSubmit` callbacks to `buildForm`.

## Motivation and context

Simulate interactions in Storybook by reacting to navigation events (e.g. query change) or form submissions.