### PR TITLE
@amazeelabs/gatsby-source-silverback: fix api-key header

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
@@ -1,4 +1,5 @@
 import { createDefaultQueryExecutor } from 'gatsby-graphql-source-toolkit';
+import { RequestInit } from 'node-fetch';
 
 export const createQueryExecutor = (
   url: string,
@@ -8,16 +9,16 @@ export const createQueryExecutor = (
   headers?: RequestInit['headers'],
 ) => {
   return createDefaultQueryExecutor(url, {
-    ...headers,
-    ...(!!authUser && !!authPass
-      ? {
-          headers: {
+    headers: {
+      ...headers,
+      ...(authUser && authPass
+        ? {
             Authorization: `Basic ${Buffer.from(
               `${authUser}:${authPass}`,
             ).toString('base64')}`,
-          },
-        }
-      : {}),
-    ...(authKey ? { 'api-key': authKey } : {}),
+          }
+        : {}),
+      ...(authKey ? { 'api-key': authKey } : {}),
+    },
   });
 };


### PR DESCRIPTION
## Motivation and context

Previously `api-key` was passed directly into `fetchOptions` instead of `fetchOptions.headers`.