### PR TITLE
Define initial locations for storybook stories

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/__tests__/storybook.test.tsx
@@ -229,7 +229,11 @@ describe('buildLink', () => {
     });
 
     expect(locationTest).toHaveBeenCalledTimes(3);
-    expect(locationTest).toHaveBeenNthCalledWith(1, undefined);
+    expect(locationTest).toHaveBeenNthCalledWith(1, {
+      pathname: '/',
+      params: new URLSearchParams(),
+      hash: '',
+    });
     expect(locationTest).toHaveBeenNthCalledWith(2, {
       pathname: '/foo',
       params: new URLSearchParams('?a=b'),
@@ -239,6 +243,31 @@ describe('buildLink', () => {
       pathname: '/bar',
       params: new URLSearchParams('?a=c'),
       hash: 'y',
+    });
+  });
+
+  it('allows to set an initial location', () => {
+    const locationTest = jest.fn();
+
+    function Test() {
+      const location = useLocation();
+      useEffect(() => {
+        locationTest(location);
+      }, [location]);
+      return <div />;
+    }
+    render(
+      ActionsDecorator(() => <Test />, {
+        args: {},
+        parameters: { initialLocation: '/foo?bar=baz#xyz' },
+      } as any),
+    );
+
+    expect(locationTest).toHaveBeenCalledTimes(1);
+    expect(locationTest).toHaveBeenNthCalledWith(1, {
+      pathname: '/foo',
+      params: new URLSearchParams('?bar=baz'),
+      hash: 'xyz',
     });
   });
 });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/storybook.tsx
@@ -63,9 +63,12 @@ const ActionsWrapper = ({
   wouldNavigate,
   wouldSubmit,
   children,
+  location: initialLocation,
 }: PropsWithChildren<ActionsContext>) => {
   const eventBoundary = useRef<HTMLDivElement>(null);
-  const [location, setLocation] = useState<Location | undefined>(undefined);
+  const [location, setLocation] = useState<Location | undefined>(
+    initialLocation,
+  );
 
   useEffect(() => {
     const boundary = eventBoundary.current;
@@ -106,8 +109,9 @@ const ActionsWrapper = ({
 export const ActionsDecorator: DecoratorFn = (story, context) => {
   return (
     <ActionsWrapper
-      wouldNavigate={context.args.wouldNavigate}
-      wouldSubmit={context.args.wouldSubmit}
+      wouldNavigate={context.args?.wouldNavigate}
+      wouldSubmit={context.args?.wouldSubmit}
+      location={createLocation(context.parameters?.initialLocation || '/')}
     >
       {story(context)}
     </ActionsWrapper>


### PR DESCRIPTION
Allow to set an `intialLocaion` parameter for each story which will be emitted by `useLocation` during rendering.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)