### PR TITLE
feat(storybook): add routing- and organism subsystem to framework bridge

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/.gitignore
+++ b/packages/npm/@amazeelabs/react-framework-bridge/.gitignore
@@ -10,4 +10,5 @@ storybook.cjs.js
 storybook.d.ts
 utils.js
 utils.d.ts
+utils/
 types.d.ts

--- a/packages/npm/@amazeelabs/react-framework-bridge/.npmignore
+++ b/packages/npm/@amazeelabs/react-framework-bridge/.npmignore
@@ -1,3 +1,4 @@
 src
 !*.js
 !*.d.ts
+!utils

--- a/packages/npm/@amazeelabs/react-framework-bridge/package.json
+++ b/packages/npm/@amazeelabs/react-framework-bridge/package.json
@@ -11,6 +11,7 @@
   "sideEffects": false,
   "dependencies": {
     "html-react-parser": "^1.4.10",
+    "lodash": "^4.17.21",
     "qs": "^6.10.3"
   },
   "peerDependencies": {
@@ -20,6 +21,7 @@
     "gatsby-plugin-image": ">=2.11.1",
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2",
+    "react-intl": "*",
     "yup": ">=0.32.11"
   },
   "devDependencies": {
@@ -42,6 +44,7 @@
     "jest": "27.5.1",
     "lint-staged": "12.3.7",
     "prettier": "2.6.1",
+    "react-intl": "^5.24.8",
     "rollup": "2.70.1",
     "rollup-plugin-multi-input": "1.3.1",
     "typescript": "4.6.3"

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/atomic.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/atomic.test.tsx
@@ -1,0 +1,360 @@
+import { render } from '@testing-library/react';
+import React, { useEffect, useState } from 'react';
+import { act } from 'react-dom/test-utils';
+
+import { buildHtml } from '../../storybook';
+import { createMapper, Route, RouteInput } from '../atomic';
+import { Content, Page } from '../example-ui';
+
+describe('Route rendering', () => {
+  it('can render a simple route without children', async () => {
+    const { container } = render(
+      <Route
+        definition={Page}
+        input={{
+          header: {},
+          footer: {},
+        }}
+        intl={{ defaultLocale: 'en', locale: 'en' }}
+      />,
+    );
+    expect(container).toMatchInlineSnapshot(`
+        <div>
+          <div>
+            <header>
+              <div>
+                Header
+              </div>
+            </header>
+            <main />
+            <footer>
+              <div>
+                Footer
+              </div>
+            </footer>
+          </div>
+        </div>
+      `);
+  });
+
+  it('can render a simple route with children', async () => {
+    const { container } = render(
+      <Route
+        definition={Page}
+        input={{
+          header: {},
+          footer: {},
+        }}
+        intl={{ defaultLocale: 'en', locale: 'en' }}
+      >
+        <p>Content</p>
+      </Route>,
+    );
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <header>
+            <div>
+              Header
+            </div>
+          </header>
+          <main>
+            <p>
+              Content
+            </p>
+          </main>
+          <footer>
+            <div>
+              Footer
+            </div>
+          </footer>
+        </div>
+      </div>
+    `);
+  });
+
+  it('can render nested routes', async () => {
+    const { container } = render(
+      <Route
+        definition={Page}
+        input={{
+          header: {},
+          footer: {},
+        }}
+        intl={{ defaultLocale: 'en', locale: 'en' }}
+      >
+        <Route
+          definition={Content}
+          input={{
+            intro: {
+              title: 'Test',
+            },
+            body: [
+              {
+                key: 'sync',
+                input: {
+                  Content: buildHtml(`<p>Test content paragraph.</p>`),
+                },
+              },
+            ],
+          }}
+          intl={{ defaultLocale: 'en', locale: 'en' }}
+        />
+      </Route>,
+    );
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <header>
+            <div>
+              Header
+            </div>
+          </header>
+          <main>
+            <div>
+              <div>
+                <h1>
+                  Test
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Test content paragraph.
+                </p>
+              </div>
+            </div>
+          </main>
+          <footer>
+            <div>
+              Footer
+            </div>
+          </footer>
+        </div>
+      </div>
+    `);
+  });
+
+  it('assumes status 200 for async organisms by default', async () => {
+    const { container } = render(
+      <Route
+        definition={Content}
+        input={{
+          intro: {
+            title: 'Test',
+          },
+          body: [
+            {
+              key: 'async',
+              input: {
+                Content: buildHtml(`<p>Async content.</p>`),
+              },
+            },
+          ],
+        }}
+        intl={{ defaultLocale: 'en', locale: 'en' }}
+      />,
+    );
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <div>
+            <h1>
+              Test
+            </h1>
+          </div>
+          <div>
+            <p>
+              Async content.
+            </p>
+          </div>
+        </div>
+      </div>
+    `);
+  });
+
+  it('accepts hooks as input', async () => {
+    const { container } = render(
+      <Route
+        definition={Content}
+        input={{
+          intro: {
+            title: 'Test',
+          },
+          body: [
+            {
+              key: 'async',
+              input: () => [
+                {
+                  Content: buildHtml(`<p>Async content.</p>`),
+                },
+                102,
+              ],
+            },
+          ],
+        }}
+        intl={{ defaultLocale: 'en', locale: 'en' }}
+      />,
+    );
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <div>
+            <h1>
+              Test
+            </h1>
+          </div>
+          <div>
+            <p>
+              Loading ...
+            </p>
+          </div>
+        </div>
+      </div>
+    `);
+  });
+
+  it('updates organisms based on hook output', async () => {
+    await act(async () => {
+      const { container } = render(
+        <Route
+          definition={Content}
+          input={{
+            intro: {
+              title: 'Test',
+            },
+            body: [
+              {
+                key: 'async',
+                input: function useAsyncInput() {
+                  const [status, setStatus] = useState(102);
+                  useEffect(() => {
+                    setTimeout(() => setStatus(200), 50);
+                  });
+                  return [
+                    {
+                      Content: buildHtml(`<p>Async content.</p>`),
+                    },
+                    status,
+                  ];
+                },
+              },
+            ],
+          }}
+          intl={{ defaultLocale: 'en', locale: 'en' }}
+        />,
+      );
+      expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <div>
+            <h1>
+              Test
+            </h1>
+          </div>
+          <div>
+            <p>
+              Loading ...
+            </p>
+          </div>
+        </div>
+      </div>
+    `);
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <div>
+            <h1>
+              Test
+            </h1>
+          </div>
+          <div>
+            <p>
+              Async content.
+            </p>
+          </div>
+        </div>
+      </div>
+    `);
+    });
+  });
+});
+
+describe('createMapper', () => {
+  it('allows to define mapping functions for page elements', () => {
+    type SyncFragment = {
+      __typename: 'Sync';
+      html: string;
+    };
+    type AsyncFragment = {
+      __typename: 'Async';
+      html: string;
+    };
+    const map = (
+      input: SyncFragment | AsyncFragment,
+    ): RouteInput<typeof Content, 'body', 'sync' | 'async'> => ({
+      key: input.__typename === 'Sync' ? 'sync' : 'async',
+      input: {
+        Content: buildHtml(
+          `<div class="${input.__typename === 'Sync' ? 'sync' : 'async'}">${
+            input.html
+          }</div>`,
+        ),
+      },
+    });
+
+    type Input = Array<SyncFragment | AsyncFragment>;
+
+    const mapper = createMapper<Input, RouteInput<typeof Content, 'body'>>({
+      Sync: map,
+      Async: map,
+    });
+
+    const input: Input = [
+      {
+        __typename: 'Sync',
+        html: 'Sync content 1',
+      },
+      {
+        __typename: 'Async',
+        html: 'Async content 1',
+      },
+      {
+        __typename: 'Sync',
+        html: 'Sync content 2',
+      },
+      {
+        __typename: 'Async',
+        html: 'Async content 2',
+      },
+    ];
+    expect(mapper(input)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "input": Object {
+            "Content": [Function],
+          },
+          "key": "sync",
+        },
+        Object {
+          "input": Object {
+            "Content": [Function],
+          },
+          "key": "async",
+        },
+        Object {
+          "input": Object {
+            "Content": [Function],
+          },
+          "key": "sync",
+        },
+        Object {
+          "input": Object {
+            "Content": [Function],
+          },
+          "key": "async",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
@@ -4,7 +4,7 @@ import { Field, Form, Formik, FormikValues } from 'formik';
 import React, { useEffect, useState } from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Link, LinkProps } from '../types';
+import { Link, LinkProps } from '../../types';
 import {
   buildHtmlBuilder,
   buildUrl,
@@ -12,7 +12,7 @@ import {
   FormikInitialValues,
   isElement,
   isRelative,
-} from '../utils';
+} from '../';
 
 describe('isRelative', () => {
   it('returns true for a relative url', () => {

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/atomic.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/atomic.tsx
@@ -1,0 +1,306 @@
+import { isArray, isFunction, isObject, mapValues } from 'lodash';
+import React, {
+  ComponentProps,
+  JSXElementConstructor,
+  PropsWithChildren,
+  ReactNode,
+  useContext,
+} from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { Form, Html, Image, Link } from '../types';
+
+export type Primitive =
+  | number
+  | string
+  | null
+  | undefined
+  | boolean
+  | Html
+  | Link
+  | Image
+  | Form<any>;
+
+export type Struct = {
+  [key: string]: Data;
+};
+
+export type Data = Primitive | Struct | Array<Primitive> | Array<Struct>;
+
+/**
+ * Reserved property names that should not be used in layouts.
+ */
+type ReservedProperties =
+  // Standard property to pass in the react-intl configuration.
+  'intl';
+
+export type LayoutProps<TSlots extends Exclude<string, ReservedProperties>> =
+  PropsWithChildren<{
+    [Slot in TSlots]?: ReactNode;
+  }>;
+
+export type LayoutComponent = JSXElementConstructor<LayoutProps<any>>;
+
+/**
+ * A status code number that describes the state of the current request.
+ *
+ * By convention either 0 for "did nothing yet" or an appropriate HTTP status
+ * code: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+ *
+ * Popular choices and how the UI should react:
+ *
+ * 0: I didn't do anything yet -> idle state, "please enter a search request"
+ * 102: Hold on, I'm getting or updating data -> show loading indication
+ * 200: All good, here is your data -> render the UI
+ * 400: The request parameters are broken -> invalid form input?
+ * 401: Need to authorize -> display login?
+ * 403: You are not allowed to do that -> probably a problem with the UI
+ * 404: Does not exist / no results -> show "not found" or "empty list" message
+ * 500: Something broke on the backend -> we are really sorry, the error has been reported!
+ * 503: Can't even connect -> are you connected to the internet?
+ */
+export type OrganismStatus = number;
+
+const OrganismStatusContext = React.createContext<OrganismStatus>(200);
+
+export const useOrganismStatus = () => useContext(OrganismStatusContext);
+
+export const OrganismStatusProvider = ({
+  children,
+  status,
+}: PropsWithChildren<{ status: OrganismStatus }>) => (
+  <OrganismStatusContext.Provider value={status}>
+    {children}
+  </OrganismStatusContext.Provider>
+);
+
+export type Mappers<
+  TInput extends Array<{ __typename: TKey }>,
+  TOptions extends RouteInput<any, any>,
+  TKey extends string = string,
+> = Partial<{
+  [Property in TInput[number]['__typename']]: (
+    input: Extract<TInput[number], { __typename: Property }>,
+  ) => TOptions;
+}>;
+
+export function createMapper<
+  TInput extends Array<{ __typename: TKey }>,
+  TOptions extends RouteInput<any, any>,
+  TKey extends string = string,
+>(mappers: Mappers<TInput, TOptions>) {
+  return function (input: TInput) {
+    return input
+      .filter((item) => {
+        if (!mappers[item.__typename]) {
+          console.error(`No mapper defined for ${item.__typename}`);
+          return false;
+        }
+        return true;
+      })
+      .map((item) => {
+        // @ts-ignore
+        return mappers[item.__typename]!(item);
+      });
+  };
+}
+
+/**
+ * Organisms think in dictionaries where the keys are strings and the values
+ * are primitives or data structures.
+ */
+export type OrganismProps<T extends { [key: string]: any }> = {
+  [Property in keyof T]: T[Property];
+};
+
+export type RouteInput<
+  TRoute extends Route<any, any>,
+  Slot extends keyof Omit<ComponentProps<TRoute[0]>, 'children'>,
+  TKeys extends TRoute[1][Slot] extends OrganismMap
+    ? keyof TRoute[1][Slot]
+    : never = any,
+> = TRoute[1][Slot] extends OrganismMap
+  ? OrganismPropsList<TRoute[1][Slot]> extends Array<infer TItem>
+    ? TItem extends { key: TKeys; props: OrganismProps<any> }
+      ? { key: TItem['key']; input: OrganismInput<TItem['props']> }
+      : never
+    : never
+  : TRoute[1][Slot] extends OrganismComponent
+  ? OrganismInput<ComponentProps<TRoute[1][Slot]>>
+  : never;
+
+/**
+ * An organism react component.
+ */
+export type OrganismComponent = JSXElementConstructor<OrganismProps<any>>;
+
+/**
+ * A hook function that returns an organisms props and data.
+ */
+type OrganismAsyncInput<T extends OrganismProps<any>> = () => [
+  T,
+  OrganismStatus,
+];
+
+/**
+ * Organism input can either bei static props or async input.
+ */
+type OrganismInput<T extends OrganismProps<any>> = T | OrganismAsyncInput<T>;
+
+function isOrganismAsyncInput(
+  input: OrganismInput<any>,
+): input is OrganismAsyncInput<any> {
+  return isFunction(input);
+}
+
+/**
+ * Wrap any OrganismInput in a closure to make sure its async.
+ *
+ * @param input
+ */
+function toHook<T extends OrganismProps<any>>(
+  input: OrganismInput<T>,
+): OrganismAsyncInput<T> {
+  return isOrganismAsyncInput(input) ? input : () => [input, 200];
+}
+
+/**
+ * A map of organisms that can be injected into a layout slot.
+ */
+export type OrganismMap = {
+  [key: string]: OrganismComponent;
+};
+
+/**
+ * A list of organism key and prop definitions to be passed into a layout property.
+ */
+type OrganismPropsList<T extends OrganismMap> = Array<
+  {
+    [Property in keyof T]: {
+      key: Property;
+      props: ComponentProps<T[Property]>;
+    };
+  }[keyof T]
+>;
+
+/**
+ * A list of organism inputs. Turn the props into either props or hooks.
+ */
+type OrganismInputList<TList extends OrganismPropsList<any>> =
+  TList extends Array<infer TItem>
+    ? Array<
+        TItem extends { key: keyof OrganismMap; props: OrganismProps<any> }
+          ? { key: TItem['key']; input: OrganismInput<TItem['props']> }
+          : never
+      >
+    : never;
+
+/**
+ * A mapping of either Organism components or Organism maps to slots of a given
+ * layout component.
+ */
+type LayoutMap<TLayoutComponent extends LayoutComponent> = {
+  [Property in keyof Omit<ComponentProps<TLayoutComponent>, 'children'>]:
+    | OrganismComponent
+    | OrganismMap;
+};
+
+/**
+ * The organism property collection required to render a route.
+ */
+export type RouteProps<TLayoutMap extends LayoutMap<LayoutComponent>> = {
+  [Property in keyof TLayoutMap]: TLayoutMap[Property] extends OrganismMap // If the property is an OrganismMap...
+    ? // ... then the route property has to be an organism property list
+      OrganismPropsList<TLayoutMap[Property]>
+    : // ... else we are dealing with a standard organism component.
+    TLayoutMap[Property] extends OrganismComponent
+    ? OrganismProps<TLayoutMap[Property]>
+    : never;
+};
+
+/**
+ * Static or async inputs for a given route.
+ */
+type RouteInputs<TRouteProps extends RouteProps<any>> = {
+  [Property in keyof TRouteProps]: TRouteProps[Property] extends OrganismPropsList<any>
+    ? OrganismInputList<TRouteProps[Property]>
+    : TRouteProps extends OrganismProps<any>
+    ? OrganismInput<TRouteProps[Property]>
+    : never;
+};
+
+export type Route<
+  TLayoutComponent extends LayoutComponent,
+  TLayoutMap extends LayoutMap<TLayoutComponent>,
+> = [TLayoutComponent, TLayoutMap];
+
+export function route<
+  TLayoutComponent extends LayoutComponent,
+  TLayoutMap extends LayoutMap<TLayoutComponent>,
+>(
+  Component: TLayoutComponent,
+  layoutMap: TLayoutMap,
+): [TLayoutComponent, TLayoutMap] {
+  return [Component, layoutMap];
+}
+
+function withOrganismProps<T extends OrganismProps<any>>(
+  Component: JSXElementConstructor<T>,
+) {
+  return function OrganismHost(input: OrganismInput<T>, index: number) {
+    const [data, status] = toHook(input)();
+    return (
+      <OrganismStatusProvider status={status} key={index}>
+        <Component {...data} />
+      </OrganismStatusProvider>
+    );
+  };
+}
+
+function isOrganismMap(
+  input: OrganismMap | OrganismComponent,
+): input is OrganismMap {
+  return isObject(input);
+}
+
+/**
+ * Render a route.
+ *
+ * @param Route
+ * @param input
+ * @param intl
+ */
+export function Route<
+  TLayoutComponent extends LayoutComponent,
+  TLayoutMap extends LayoutMap<TLayoutComponent>,
+>({
+  definition,
+  input,
+  intl,
+  children,
+}: PropsWithChildren<{
+  definition: Route<TLayoutComponent, TLayoutMap>;
+  input: RouteInputs<RouteProps<TLayoutMap>>;
+  intl: ComponentProps<typeof IntlProvider>;
+}>) {
+  return (
+    <IntlProvider {...intl}>
+      {React.createElement(
+        definition[0],
+        mapValues(definition[1], (entry, key) => {
+          const organismProps = input[key];
+          if (isOrganismMap(entry) && isArray(organismProps)) {
+            return organismProps.map((organism, index) => {
+              return withOrganismProps(
+                entry[organism.key as keyof typeof entry],
+              )((organism as OrganismInput<any>).input, index);
+            });
+          } else if (isFunction(entry)) {
+            return withOrganismProps(entry)(input[key], 0);
+          }
+        }),
+        children,
+      )}
+    </IntlProvider>
+  );
+}

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/example-ui.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/example-ui.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { Html } from '../types';
+import { LayoutProps, OrganismProps, route, useOrganismStatus } from './atomic';
+
+export function PageLayout(props: LayoutProps<'header' | 'footer'>) {
+  return (
+    <div>
+      <header>{props.header}</header>
+      <main>{props.children}</main>
+      <footer>{props.footer}</footer>
+    </div>
+  );
+}
+
+export function ContentLayout(props: LayoutProps<'intro' | 'body'>) {
+  return (
+    <div>
+      <div>{props.intro}</div>
+      <div>{props.body}</div>
+    </div>
+  );
+}
+
+export function Header() {
+  return <div>Header</div>;
+}
+
+export function Footer() {
+  return <div>Footer</div>;
+}
+
+export function ContentHeader(props: OrganismProps<{ title: string }>) {
+  return <h1>{props.title}</h1>;
+}
+
+export function SyncContent(props: OrganismProps<{ Content: Html }>) {
+  return <props.Content />;
+}
+
+export function AsyncContent(props: OrganismProps<{ Content: Html }>) {
+  const status = useOrganismStatus();
+  return status === 200 ? <props.Content /> : <p>Loading ...</p>;
+}
+
+export const Page = route(PageLayout, {
+  header: Header,
+  footer: Footer,
+});
+
+export const Content = route(ContentLayout, {
+  intro: ContentHeader,
+  body: {
+    sync: SyncContent,
+    async: AsyncContent,
+  },
+});

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
@@ -9,7 +9,9 @@ import parse, {
 import { stringify } from 'qs';
 import React, { ComponentProps, useEffect } from 'react';
 
-import { FormBuilderProps, Html, LinkBuilder, LinkProps } from './types';
+import { FormBuilderProps, Html, LinkBuilder, LinkProps } from '../types';
+
+export * from './atomic';
 
 export const isInternalTarget = (target?: string) =>
   typeof target === 'undefined' || target === '' || target === '_self';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,6 +1591,76 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@formatjs/ecma402-abstract@1.11.4":
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz#b962dfc4ae84361f9f08fbce411b4e4340930eda"
+  integrity sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==
+  dependencies:
+    "@formatjs/intl-localematcher" "0.2.25"
+    tslib "^2.1.0"
+
+"@formatjs/fast-memoize@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz#e6f5aee2e4fd0ca5edba6eba7668e2d855e0fc21"
+  integrity sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==
+  dependencies:
+    tslib "^2.1.0"
+
+"@formatjs/icu-messageformat-parser@2.0.19":
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.19.tgz#3a9ae986b9e42b6a833aceab010ee88e36020d26"
+  integrity sha512-8HsLm9YLyVVIDMyBJb7wmve2wGd461cUwJ470eUog5YH5ZsF4p5lgvaJ+oGKxz1mrSMNNdDHU9v/NDsS+z+ilg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    "@formatjs/icu-skeleton-parser" "1.3.6"
+    tslib "^2.1.0"
+
+"@formatjs/icu-skeleton-parser@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz#4ce8c0737d6f07b735288177049e97acbf2e8964"
+  integrity sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    tslib "^2.1.0"
+
+"@formatjs/intl-displaynames@5.4.3":
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-displaynames/-/intl-displaynames-5.4.3.tgz#e468586694350c722c7efab1a31fcde68aeaed8b"
+  integrity sha512-4r12A3mS5dp5hnSaQCWBuBNfi9Amgx2dzhU4lTFfhSxgb5DOAiAbMpg6+7gpWZgl4ahsj3l2r/iHIjdmdXOE2Q==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    "@formatjs/intl-localematcher" "0.2.25"
+    tslib "^2.1.0"
+
+"@formatjs/intl-listformat@6.5.3":
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-6.5.3.tgz#f29da613a8062dc3e4e3d847ba890c3ea745f051"
+  integrity sha512-ozpz515F/+3CU+HnLi5DYPsLa6JoCfBggBSSg/8nOB5LYSFW9+ZgNQJxJ8tdhKYeODT+4qVHX27EeJLoxLGLNg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    "@formatjs/intl-localematcher" "0.2.25"
+    tslib "^2.1.0"
+
+"@formatjs/intl-localematcher@0.2.25":
+  version "0.2.25"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz#60892fe1b271ec35ba07a2eb018a2dd7bca6ea3a"
+  integrity sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==
+  dependencies:
+    tslib "^2.1.0"
+
+"@formatjs/intl@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl/-/intl-2.1.1.tgz#288f130a15b85ec1f4d022a379a5c88b27767bcb"
+  integrity sha512-iUjBnV2XE+mS3run+Rj/96rfxvwSiCsqMrSbIWoU4dOjIYil7boZK2mCamxoz8CqiiL4VD4ym5EEDbYPWirlFA==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    "@formatjs/fast-memoize" "1.2.1"
+    "@formatjs/icu-messageformat-parser" "2.0.19"
+    "@formatjs/intl-displaynames" "5.4.3"
+    "@formatjs/intl-listformat" "6.5.3"
+    intl-messageformat "9.12.0"
+    tslib "^2.1.0"
+
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -1887,7 +1957,22 @@
     tslib "~2.3.0"
     unixify "^1.0.0"
 
-"@graphql-tools/load@^6.0.0", "@graphql-tools/load@^7", "@graphql-tools/load@^7.3.0", "@graphql-tools/load@^7.4.1":
+"@graphql-tools/load@^6.0.0":
+  version "6.2.8"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-6.2.8.tgz#16900fb6e75e1d075cad8f7ea439b334feb0b96a"
+  integrity sha512-JpbyXOXd8fJXdBh2ta0Q4w8ia6uK5FHzrTNmcvYBvflFuWly2LDTk2abbSl81zKkzswQMEd2UIYghXELRg8eTA==
+  dependencies:
+    "@graphql-tools/merge" "^6.2.12"
+    "@graphql-tools/utils" "^7.5.0"
+    globby "11.0.3"
+    import-from "3.0.0"
+    is-glob "4.0.1"
+    p-limit "3.1.0"
+    tslib "~2.2.0"
+    unixify "1.0.0"
+    valid-url "1.0.9"
+
+"@graphql-tools/load@^7.3.0", "@graphql-tools/load@^7.4.1":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.5.5.tgz#d61e5bdee59b6c8aa9631f74f0b2a70d512e5b31"
   integrity sha512-qPasit140nwTbMQbFCfZcgaS7q/0+xMQGdkMGU11rtHt6/jMgJIKDUU8/fJGKltNY3EeHlEdVtZmggZD7Rr6bA==
@@ -1912,6 +1997,15 @@
   integrity sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==
   dependencies:
     "@graphql-tools/utils" "8.6.5"
+    tslib "~2.3.0"
+
+"@graphql-tools/merge@^6.2.12":
+  version "6.2.17"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-6.2.17.tgz#4dedf87d8435a5e1091d7cc8d4f371ed1e029f1f"
+  integrity sha512-G5YrOew39fZf16VIrc49q3c8dBqQDD0ax5LYPiNja00xsXDi0T9zsEWVt06ApjtSdSF6HDddlu5S12QjeN8Tow==
+  dependencies:
+    "@graphql-tools/schema" "^8.0.2"
+    "@graphql-tools/utils" "8.0.2"
     tslib "~2.3.0"
 
 "@graphql-tools/optimize@^1.0.1":
@@ -1975,6 +2069,16 @@
     tslib "~2.2.0"
     value-or-promise "1.0.6"
 
+"@graphql-tools/schema@^8.0.2":
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.6.tgz#80cfe3eba53eb6390a60a30078d7efbdaa5cc0b7"
+  integrity sha512-7tWYRQ8hB/rv2zAtv2LtnQl4UybyJPtRz/VLKRmgi7+F5t8iYBahmmsxMDAYMWMmWMqEDiKk54TvAes+J069rQ==
+  dependencies:
+    "@graphql-tools/merge" "8.2.6"
+    "@graphql-tools/utils" "8.6.5"
+    tslib "~2.3.0"
+    value-or-promise "1.0.11"
+
 "@graphql-tools/url-loader@7.9.6", "@graphql-tools/url-loader@^7.0.11", "@graphql-tools/url-loader@^7.4.2":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.9.6.tgz#86806e23d413c75da9778acaacf23c7652db6c7e"
@@ -2024,6 +2128,13 @@
     valid-url "1.0.9"
     ws "7.4.5"
 
+"@graphql-tools/utils@8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.0.2.tgz#795a8383cdfdc89855707d62491c576f439f3c51"
+  integrity sha512-gzkavMOgbhnwkHJYg32Adv6f+LxjbQmmbdD5Hty0+CWxvaiuJq+nU6tzb/7VSU4cwhbNLx/lGu2jbCPEW1McZQ==
+  dependencies:
+    tslib "~2.3.0"
+
 "@graphql-tools/utils@8.6.5", "@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.1", "@graphql-tools/utils@^8.5.2":
   version "8.6.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.5.tgz#ac04571b03f854c7a938b2ab700516a6c6d32335"
@@ -2031,7 +2142,7 @@
   dependencies:
     tslib "~2.3.0"
 
-"@graphql-tools/utils@^7.0.0", "@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.7.0", "@graphql-tools/utils@^7.7.1", "@graphql-tools/utils@^7.8.1", "@graphql-tools/utils@^7.9.0":
+"@graphql-tools/utils@^7.0.0", "@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.5.0", "@graphql-tools/utils@^7.7.0", "@graphql-tools/utils@^7.7.1", "@graphql-tools/utils@^7.8.1", "@graphql-tools/utils@^7.9.0":
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.10.0.tgz#07a4cb5d1bec1ff1dc1d47a935919ee6abd38699"
   integrity sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==
@@ -6001,6 +6112,14 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
@@ -6321,7 +6440,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.43", "@types/react@>=16":
+"@types/react@*", "@types/react@16 || 17", "@types/react@17.0.43", "@types/react@>=16":
   version "17.0.43"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
   integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
@@ -12201,7 +12320,7 @@ debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -12833,7 +12952,6 @@ drupal-gutenberg-translations@1.1.0:
 
 "drupal-js-build@https://github.com/AmazeeLabs/drupal-js-build":
   version "1.2.0"
-  uid f766801580f10543c24ba8bfa59046a776848097
   resolved "https://github.com/AmazeeLabs/drupal-js-build#f766801580f10543c24ba8bfa59046a776848097"
   dependencies:
     babel-core "^6.26.0"
@@ -16208,6 +16326,18 @@ globby@11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+globby@11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
+  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@^11.0.0, globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
@@ -16777,7 +16907,7 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
   integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -17277,6 +17407,13 @@ import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-from@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-3.0.0.tgz#055cfec38cd5a27d8057ca51376d7d3bf0891966"
+  integrity sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==
+  dependencies:
+    resolve-from "^5.0.0"
+
 import-from@4.0.0, import-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/import-from/-/import-from-4.0.0.tgz#2710b8d66817d232e16f4166e319248d3d5492e2"
@@ -17300,7 +17437,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -17517,6 +17654,16 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+intl-messageformat@9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-9.12.0.tgz#b69d042fa7db229e799eaf3afb09f8ceadd306e7"
+  integrity sha512-5Q9j21JreB1G27/CqMYsA+pvJ19JjHyhiTSeUuvZK9BCDJGHtOLgpUUcGM+GLHiUuoVMKVeeX1smamiVHQrSKQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    "@formatjs/fast-memoize" "1.2.1"
+    "@formatjs/icu-messageformat-parser" "2.0.19"
+    tslib "^2.1.0"
 
 into-stream@^6.0.0:
   version "6.0.0"
@@ -17862,6 +18009,13 @@ is-generator@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-generator/-/is-generator-1.0.3.tgz#c14c21057ed36e328db80347966c693f886389f3"
   integrity sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=
+
+is-glob@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-glob@4.0.3, is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
@@ -19934,11 +20088,6 @@ lodash-es@4.17.21, lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -19947,32 +20096,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -20143,11 +20270,6 @@ lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
   integrity sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.some@^4.4.0:
   version "4.6.0"
@@ -22508,7 +22630,6 @@ npm@5.1.0:
     cmd-shim "~2.0.2"
     columnify "~1.5.4"
     config-chain "~1.1.11"
-    debuglog "*"
     detect-indent "~5.0.0"
     dezalgo "~1.0.3"
     editor "~1.0.0"
@@ -22521,21 +22642,14 @@ npm@5.1.0:
     has-unicode "~2.0.1"
     hosted-git-info "~2.5.0"
     iferr "~0.1.5"
-    imurmurhash "*"
     inflight "~1.0.6"
     inherits "~2.0.3"
     ini "~1.3.4"
     init-package-json "~1.10.1"
     lazy-property "~1.0.0"
     lockfile "~1.0.3"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -22564,7 +22678,6 @@ npm@5.1.0:
     read-package-json "~2.0.9"
     read-package-tree "~5.1.6"
     readable-stream "~2.3.2"
-    readdir-scoped-modules "*"
     request "~2.81.0"
     retry "~0.10.1"
     rimraf "~2.6.1"
@@ -22584,7 +22697,6 @@ npm@5.1.0:
     unpipe "~1.0.0"
     update-notifier "~2.2.0"
     uuid "~3.1.0"
-    validate-npm-package-license "*"
     validate-npm-package-name "~3.0.0"
     which "~1.2.14"
     worker-farm "~1.3.1"
@@ -25162,6 +25274,22 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
+react-intl@^5.24.8:
+  version "5.24.8"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-5.24.8.tgz#8387205a8e125ce057fc260108b02ad00b22e9b6"
+  integrity sha512-uFBA7Fvh3XsHVn6b+jgVTk8hMBpQFvkterWwq4KHrjn8nMmLJf6lGqPawAcmhXes0q29JruCQyKX0vj+G7iokA==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.11.4"
+    "@formatjs/icu-messageformat-parser" "2.0.19"
+    "@formatjs/intl" "2.1.1"
+    "@formatjs/intl-displaynames" "5.4.3"
+    "@formatjs/intl-listformat" "6.5.3"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/react" "16 || 17"
+    hoist-non-react-statics "^3.3.2"
+    intl-messageformat "9.12.0"
+    tslib "^2.1.0"
+
 react-is@17.0.2, react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -25528,7 +25656,7 @@ readdir-enhanced@^1.5.2:
     es6-promise "^4.1.0"
     glob-to-regexp "^0.3.0"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0, readdir-scoped-modules@^1.1.0:
+readdir-scoped-modules@^1.0.0, readdir-scoped-modules@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
   integrity sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==
@@ -29735,7 +29863,7 @@ unix-crypt-td-js@1.1.4:
   resolved "https://registry.yarnpkg.com/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz#4912dfad1c8aeb7d20fa0a39e4c31918c1d5d5dd"
   integrity sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==
 
-unixify@^1.0.0:
+unixify@1.0.0, unixify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unixify/-/unixify-1.0.0.tgz#3a641c8c2ffbce4da683a5c70f03a462940c2090"
   integrity sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=
@@ -30093,7 +30221,7 @@ valid-url@1.0.9, valid-url@^1.0.9:
   resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
   integrity sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==


### PR DESCRIPTION
## Package(s) involved

* `@amazeelabs/react-framework-bridge`

## Description of changes

Add a subsystem for defining organisms and routes in storybook and map content into them from the application (Gatsby).

## Motivation and context

A clear structure for user interface components and cross-framework interoperability.

## How has this been tested?

With unit test.
