### PR TITLE
feat: add write-cache command

### DIFF
--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/WriteCache.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/WriteCache.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AmazeeLabs\Silverback\Commands;
+
+use Alchemy\Zippy\Zippy;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class WriteCache extends SilverbackCommand {
+
+  protected function configure(): void {
+    parent::configure();
+    $this->setName('write-cache');
+    $this->setDescription('Write current site state to the install cache.');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    parent::execute($input, $output);
+    $public = 'web/sites/default/files';
+    $zipCache = Setup::zipCache();
+    $zippy = Zippy::load();
+    $zipCacheExists = $this->fileSystem->exists($zipCache);
+    if ($zipCacheExists) {
+      $output->writeln("<info>Updating $zipCache...</>");
+      $this->fileSystem->remove($zipCache);
+    }
+    else {
+      $output->writeln("<info>Creating $zipCache...</>");
+    }
+    $zippy->create($zipCache, ['files' => $public], TRUE);
+    $output->writeln("<info>Cache has been written.</>");
+    return 0;
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/SilverbackCli.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/SilverbackCli.php
@@ -6,6 +6,7 @@ use AmazeeLabs\Silverback\Commands\SnapshotRestore;
 use AmazeeLabs\Silverback\Commands\Setup;
 use AmazeeLabs\Silverback\Commands\SnapshotCreate;
 use AmazeeLabs\Silverback\Commands\Teardown;
+use AmazeeLabs\Silverback\Commands\WriteCache;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -18,6 +19,7 @@ class SilverbackCli extends Application {
     $this->add(new Teardown($fileSystem));
     $this->add(new SnapshotCreate($fileSystem));
     $this->add(new SnapshotRestore($fileSystem));
+    $this->add(new WriteCache($fileSystem));
   }
 
 }


### PR DESCRIPTION
## Package(s) involved

`silverback-cli`

## Description of changes

A new command to write current Drupal state into `install-cache.zip`.

## Motivation and context

The default content import takes too long.

So now we put the default content into the install cache. And a usual `drupal-install` script looks something like this
```
silverback setup --profile minimal && content:import && silverback update-cache
``` 

And the usual setup will be faster, because we have [Do not reimport existing entities](https://www.drupal.org/project/default_content/issues/2698425) patch in our `proxy-default-content` package.

## How has this been tested?

On a project.
