### PR TITLE
fix(gatsby): allow buildUrl function to create a simple / link

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
@@ -180,6 +180,9 @@ describe('buildHtmlBuilder', () => {
 });
 
 describe('buildUrl', () => {
+  it('allows to create a root url to /', () => {
+    expect(buildUrl(['/'])).toStrictEqual(`/`);
+  });
   it('concatenates segments', () => {
     expect(buildUrl(['https://fake.url/', 'a', 'b'])).toStrictEqual(
       `https://fake.url/a/b`,

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
@@ -162,7 +162,9 @@ const isTruthy = (i: string | null | undefined): i is string => Boolean(i);
 
 const stripSlashes = (segment: string, index: number) => {
   if (index === 0) {
-    return segment.replace(/^\/{2,}/g, '/').replace(/\/+$/g, '');
+    return segment === '/'
+      ? segment
+      : segment.replace(/^\/{2,}/g, '/').replace(/\/+$/g, '');
   }
 
   return segment.replace(/^\/+|\/+$/g, '');


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/react-framework-bridge`

## Description of changes

Make sure the `buildUrl` function can create link to `/`. Until now it would emit an empty url in that case, which always leads to the current page.

## Motivation and context

On a single language page, the home link goes to `/`, which did not work.