### PR TITLE
Fix broken images when proxied by publisher

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/server.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server.ts
@@ -187,7 +187,10 @@ app.use(
   createProxyMiddleware(() => app.locals.isReady, {
     target: `http://127.0.0.1:${config.applicationPort}`,
     selfHandleResponse: true,
-    onProxyRes: responseInterceptor(async (responseBuffer) => {
+    onProxyRes: responseInterceptor(async (responseBuffer, proxyRes) => {
+      if (!proxyRes.headers['content-type']?.includes('text/html')) {
+        return responseBuffer;
+      }
       const response = responseBuffer.toString('utf8');
       return response
         .replace(


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/publisher`

## Description of changes

Ignore reponses that are not `text/html` when injecting the publisher status widget.

## Motivation and context

Loading images into an utf-8 string broke them, we need to bypass modification of content entirely here.
