### PR TITLE
feat(gatsby): menu negotiation

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -10,7 +10,13 @@ directive @menu(
   """
   The internal menu id.
   """
-  menu_id: String!
+  menu_id: String
+
+  """
+  Internal menu id's. The first one the current user has access to will be
+  picked.
+  """
+  menu_ids: [String!]
 
   """
   GraphQL type for menu items.

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -10,7 +10,13 @@ directive @menu(
   """
   The internal menu id.
   """
-  menu_id: String!
+  menu_id: String
+
+  """
+  Internal menu id's. The first one the current user has access to will be
+  picked.
+  """
+  menu_ids: [String!]
 
   """
   GraphQL type for menu items.

--- a/packages/composer/amazeelabs/silverback_gatsby/README.md
+++ b/packages/composer/amazeelabs/silverback_gatsby/README.md
@@ -249,6 +249,26 @@ type MainMenu @menu(menu_id: "main", item_type: "MenuItem")
 type LayoutMainMenu @menu(menu_id: "main", item_type: "MenuItem", max_level: 1)
 ```
 
+### Menu negotiation
+
+In some cases, the same GraphQL field might have to return different menus,
+based on the current context. A prominent use case would be a multi-site setup
+where different menus should be displayed based on the current account Gatsby is
+using to fetch data with.
+
+In this case, multiple menu id's can be passed to the `@menu` directive, and the
+resolver will pick **the first one** that is accessible to the user account.
+
+```graphql
+type MainMenu
+  @menu(menu_ids: ["site_a_main", "site_b_main"], item_type: "MenuItem")
+```
+
+It checks access for the `view label` operation on the `Menu` entity, which is
+allowed for everybody by default. The consuming project has to implement other
+mechanisms to restrict access therefore control which menus are used for which
+site.
+
 ## Configuring update notifications
 
 The last thing to do is to tell Gatsby whenever something noteworthy changes. By

--- a/packages/composer/amazeelabs/silverback_gatsby/graphql/menu.directive.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/graphql/menu.directive.graphqls
@@ -3,7 +3,13 @@ directive @menu(
   """
   The internal menu id.
   """
-  menu_id: String!
+  menu_id: String
+
+  """
+  Internal menu id's. The first one the current user has access to will be
+  picked.
+  """
+  menu_ids: [String!]
 
   """
   GraphQL type for menu items.

--- a/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/graphql/silverback_gatsby_example.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/graphql/silverback_gatsby_example.graphqls
@@ -23,9 +23,9 @@ type MenuItem {
 """
 All menu items, for the sitemap or being post-loaded.
 """
-type MainMenu @menu(menu_id: "main", item_type: "MenuItem")
+type MainMenu @menu(menu_ids: ["access_denied", "main"], item_type: "MenuItem")
 
 """
 Menu items up to level 2, to be rendered directly into the page layout.
 """
-type VisibleMainMenu @menu(menu_id: "main", max_level: 2, item_type: "MenuItem")
+type VisibleMainMenu @menu(menu_ids: ["access_denied", "main"], max_level: 2, item_type: "MenuItem")

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
@@ -1,10 +1,7 @@
 <?php
 
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\silverback_gatsby\Plugin\Gatsby\Feed\EntityFeed;
-use Drupal\system\MenuInterface;
 
 
 function _silverback_gatsby_entity_event(EntityInterface $entity) {
@@ -34,10 +31,3 @@ function silverback_gatsby_entity_update(EntityInterface $entity) {
 function silverback_gatsby_entity_delete(EntityInterface $entity) {
   _silverback_gatsby_entity_event($entity);
 }
-
-/**
- * Implements hook_ENTITY_TYPE_access().
- */
-//function silverback_gatsby_menu_access(MenuInterface $entity, $operation, AccountInterface $account) {
-//  return AccessResult::allowed();
-//}

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
@@ -1,7 +1,10 @@
 <?php
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\silverback_gatsby\Plugin\Gatsby\Feed\EntityFeed;
+use Drupal\system\MenuInterface;
 
 
 function _silverback_gatsby_entity_event(EntityInterface $entity) {
@@ -31,3 +34,10 @@ function silverback_gatsby_entity_update(EntityInterface $entity) {
 function silverback_gatsby_entity_delete(EntityInterface $entity) {
   _silverback_gatsby_entity_event($entity);
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ */
+//function silverback_gatsby_menu_access(MenuInterface $entity, $operation, AccountInterface $account) {
+//  return AccessResult::allowed();
+//}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
@@ -167,6 +167,7 @@ class MenuFeed extends FeedBase implements ContainerFactoryPluginInterface {
     foreach($menus as $menu) {
       if ($menu->access('view label', $account)) {
         $relevantMenu = $menu;
+        break;
       }
     }
 

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
@@ -16,7 +16,9 @@ use Drupal\silverback_gatsby\GraphQL\DirectiveProviderExtensionInterface;
 use Drupal\silverback_gatsby\GraphQL\ParentAwareSchemaExtensionInterface;
 use Drupal\silverback_gatsby\Plugin\FeedInterface;
 use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\AST\ListValueNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Language\Parser;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -152,7 +154,18 @@ class SilverbackGatsbySchemaExtension extends SdlSchemaExtensionPluginBase
             // Collect the directive arguments.
             foreach ($directive->arguments->getIterator() as $arg) {
               /** @var \GraphQL\Language\AST\ArgumentNode $arg */
-              $config[$arg->name->value] = $arg->value->value;
+              if ($arg->value instanceof ListValueNode) {
+                // If it's a list value, turn it into an array of values.
+                $config[$arg->name->value] = [];
+                for($i = 0; $i < $arg->value->values->count(); $i++) {
+                  if ($arg->value->values[$i] instanceof StringValueNode) {
+                    $config[$arg->name->value][] = $arg->value->values[$i]->value;
+                  }
+                }
+              }
+              else {
+                $config[$arg->name->value] = $arg->value->value;
+              }
             }
 
             // Collect the field directives.

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/MenuFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/MenuFeedTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\silverback_gatsby\Kernel;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\silverback_gatsby\GatsbyUpdate;
+use Drupal\system\Entity\Menu;
 use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 
 class MenuFeedTest extends GraphQLTestBase {
@@ -36,12 +37,17 @@ class MenuFeedTest extends GraphQLTestBase {
 
     // Set up the menu system.
     $this->installEntitySchema('menu_link_content');
+    // Create a menu nobody has access to (see `silverback_gatsby_example.module).
+    Menu::create([
+      'id' => 'access_denied',
+      'label' => 'Access denied',
+    ])->save();
   }
 
-  protected function createMenuItem(string $label, string $url, MenuLinkContentInterface $parent = null) : MenuLinkContentInterface {
+  protected function createMenuItem(string $label, string $url, MenuLinkContentInterface $parent = null, $menu = 'main') : MenuLinkContentInterface {
     $item = MenuLinkContent::create([
       'provider' => 'silverback_gatsby',
-      'menu_name' => 'main',
+      'menu_name' => $menu,
       'title' => $label,
       'link' => ['uri' => $url],
       'weight' => $this->itemCount++,
@@ -75,7 +81,7 @@ class MenuFeedTest extends GraphQLTestBase {
     $query = $this->getQueryFromFile('menus.gql');
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheContexts(['languages:language_interface']);
-    $metadata->addCacheTags(['config:system.menu.main']);
+    $metadata->addCacheTags(['config:system.menu.main', 'config:system.menu.access_denied']);
     $this->assertResults($query, [], $this->expectedResult(), $metadata);
   }
 
@@ -99,7 +105,7 @@ class MenuFeedTest extends GraphQLTestBase {
     $query = $this->getQueryFromFile('menus.gql');
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheContexts(['languages:language_interface']);
-    $metadata->addCacheTags(['config:system.menu.main']);
+    $metadata->addCacheTags(['config:system.menu.main', 'config:system.menu.access_denied']);
     $this->assertResults($query, [], $this->expectedResult([
       'loadMainMenu' => ['items' => $resultItems],
       'loadVisibleMainMenu' => ['items' => $resultItems],
@@ -126,7 +132,7 @@ class MenuFeedTest extends GraphQLTestBase {
     $query = $this->getQueryFromFile('menus.gql');
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheContexts(['languages:language_interface']);
-    $metadata->addCacheTags(['config:system.menu.main']);
+    $metadata->addCacheTags(['config:system.menu.main', 'config:system.menu.access_denied']);
     $this->assertResults($query, [], $this->expectedResult([
       'loadMainMenu' => ['items' => $resultItems],
       'loadVisibleMainMenu' => ['items' => $resultItems],
@@ -140,7 +146,7 @@ class MenuFeedTest extends GraphQLTestBase {
     $query = $this->getQueryFromFile('menus.gql');
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheContexts(['languages:language_interface']);
-    $metadata->addCacheTags(['config:system.menu.main']);
+    $metadata->addCacheTags(['config:system.menu.main', 'config:system.menu.access_denied']);
     $this->assertResults($query, [], $this->expectedResult([
       'loadMainMenu' => ['items' => [
         [
@@ -187,7 +193,7 @@ class MenuFeedTest extends GraphQLTestBase {
     $query = $this->getQueryFromFile('menus.gql');
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheContexts(['languages:language_interface']);
-    $metadata->addCacheTags(['config:system.menu.main']);
+    $metadata->addCacheTags(['config:system.menu.main', 'config:system.menu.access_denied']);
     $this->assertResults($query, [], $this->expectedResult([
       'loadMainMenu' => ['items' => [
         [


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/silverback-gatsby`

## Description of changes

Allow multiple `menu_ids` in the `@menu` directive, and pick the first one the current user account has access to. (See changes in `README.md`).

## Motivation and context

Allow the GraphQL API to negotiate between multiple menus in multisite-environments, based on access granted to the Gatsby account being used. The frontend has only to know about one "main" menu, while Drupal maintains multiple different ones.

## How has this been tested

Added a new menu with higher precedence to the unit test cases. As long as the menu is accessible, it will be picked by the GraphQL API and the tests break. By naming it `Access denied` the access hook in `silverback_gatsby_example.module` will make it inaccessible, and the next option is picked, which makes the tests pass.