### PR TITLE
feat(gatsby): more flexible and explicit @menu directives

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -20,9 +20,27 @@ directive @menu(
 
   """
   GraphQL type for menu items.
-  """
-  item_type: String!
 
+  **DEPRECATED**: Explicitly define Menu item types with `resolveMenu*`
+  directives instead.
+  """
+  item_type: String
+
+  """
+  The maximum level to be fetched.
+  This can be used to optimizing caching. Most of the time only one or two
+  levels of menus are immediately visible on the page. By declaring multiple
+  types, we can generate different cache buckets, so a new menu item on a low
+  level does not require a full rebuild of every page.
+
+  """
+  max_level: Int
+) on OBJECT
+
+"""
+Resolve menu items in a menu.
+"""
+directive @resolveMenuItems(
   """
   The maximum level to be fetched.
   This can be used to optimizing caching. Most of the time only one or two
@@ -31,7 +49,27 @@ directive @menu(
   level does not require a full rebuild of every page.
   """
   max_level: Int
-) on OBJECT
+) on FIELD_DEFINITION
+
+"""
+Resolve the menu items id.
+"""
+directive @resolveMenuItemId on FIELD_DEFINITION
+
+"""
+Resolve the menu item parents id.
+"""
+directive @resolveMenuItemParentId on FIELD_DEFINITION
+
+"""
+Resolve a menu items label.
+"""
+directive @resolveMenuItemLabel on FIELD_DEFINITION
+
+"""
+Resolve the Url from within a menu item.
+"""
+directive @resolveMenuItemUrl on FIELD_DEFINITION
 
 # Directive for the "StringTranslationFeed" plugin.
 directive @stringTranslation(

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -20,9 +20,27 @@ directive @menu(
 
   """
   GraphQL type for menu items.
-  """
-  item_type: String!
 
+  **DEPRECATED**: Explicitly define Menu item types with `resolveMenu*`
+  directives instead.
+  """
+  item_type: String
+
+  """
+  The maximum level to be fetched.
+  This can be used to optimizing caching. Most of the time only one or two
+  levels of menus are immediately visible on the page. By declaring multiple
+  types, we can generate different cache buckets, so a new menu item on a low
+  level does not require a full rebuild of every page.
+
+  """
+  max_level: Int
+) on OBJECT
+
+"""
+Resolve menu items in a menu.
+"""
+directive @resolveMenuItems(
   """
   The maximum level to be fetched.
   This can be used to optimizing caching. Most of the time only one or two
@@ -31,7 +49,27 @@ directive @menu(
   level does not require a full rebuild of every page.
   """
   max_level: Int
-) on OBJECT
+) on FIELD_DEFINITION
+
+"""
+Resolve the menu items id.
+"""
+directive @resolveMenuItemId on FIELD_DEFINITION
+
+"""
+Resolve the menu item parents id.
+"""
+directive @resolveMenuItemParentId on FIELD_DEFINITION
+
+"""
+Resolve a menu items label.
+"""
+directive @resolveMenuItemLabel on FIELD_DEFINITION
+
+"""
+Resolve the Url from within a menu item.
+"""
+directive @resolveMenuItemUrl on FIELD_DEFINITION
 
 # Directive for the "StringTranslationFeed" plugin.
 directive @stringTranslation(

--- a/packages/composer/amazeelabs/silverback_gatsby/README.md
+++ b/packages/composer/amazeelabs/silverback_gatsby/README.md
@@ -166,33 +166,19 @@ type Page @entity(type: "node", bundle: "page") {
 
 ## Menus
 
-To expose Drupal menus to Gatsby, one can use the `@menu` directive. It takes a
-menu id, and a menu item type name as arguments. The latter is used to declare a
-GraphQL type in the schema that will be emitted from the menu's `items` field.
+To expose Drupal menus to Gatsby, one can use the `@menu` directive.
 
 ```graphql
-type MainMenu @menu(menu_id: "main", item_type: "MenuItem")
+type MainMenu @menu(menu_id: "main") {
+  items: [MenuItem!]! @resolveMenuItems
+}
 
 type MenuItem {
-  label: String!
-  url: String!
+  id: String! @resolveMenuItemId
+  parent: String! @resolveMenuItemId
+  label: String! @resolveMenuItemLabel
+  url: String! @resolveMenuItemUrl
 }
-```
-
-The resolvers for custom field of menu items (in this case `label` and `url`)
-still need to be provided by the schema implementation.
-
-```php
-$registry->addFieldResolver('MenuItem', 'label', $builder->compose(
-  $builder->produce('menu_tree_link')->map('element', $builder->fromParent()),
-  $builder->produce('menu_link_label')->map('link', $builder->fromParent()),
-));
-
-$registry->addFieldResolver('MenuItem', 'url', $builder->compose(
-  $builder->produce('menu_tree_link')->map('element', $builder->fromParent()),
-  $builder->produce('menu_link_url')->map('link', $builder->fromParent()),
-  $builder->produce('url_path')->map('url', $builder->fromParent()),
-));
 ```
 
 GraphQL does not allow recursive fragments, so something like this would not be
@@ -243,10 +229,10 @@ separating this into two levels, we can make sure the outer layout really only
 changes when menu levels are changed that are displayed.
 
 ```graphql
-type MainMenu @menu(menu_id: "main", item_type: "MenuItem")
+type MainMenu @menu(menu_id: "main") {...}
 # Will only include the first level and trigger updates when a first level item
 # changes.
-type LayoutMainMenu @menu(menu_id: "main", item_type: "MenuItem", max_level: 1)
+type LayoutMainMenu @menu(menu_id: "main", max_level: 1) {...}
 ```
 
 ### Menu negotiation

--- a/packages/composer/amazeelabs/silverback_gatsby/graphql/menu.directive.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/graphql/menu.directive.graphqls
@@ -13,9 +13,27 @@ directive @menu(
 
   """
   GraphQL type for menu items.
-  """
-  item_type: String!
 
+  **DEPRECATED**: Explicitly define Menu item types with `resolveMenu*`
+  directives instead.
+  """
+  item_type: String
+
+  """
+  The maximum level to be fetched.
+  This can be used to optimizing caching. Most of the time only one or two
+  levels of menus are immediately visible on the page. By declaring multiple
+  types, we can generate different cache buckets, so a new menu item on a low
+  level does not require a full rebuild of every page.
+
+  """
+  max_level: Int
+) on OBJECT
+
+"""
+Resolve menu items in a menu.
+"""
+directive @resolveMenuItems(
   """
   The maximum level to be fetched.
   This can be used to optimizing caching. Most of the time only one or two
@@ -24,4 +42,24 @@ directive @menu(
   level does not require a full rebuild of every page.
   """
   max_level: Int
-) on OBJECT
+) on FIELD_DEFINITION
+
+"""
+Resolve the menu items id.
+"""
+directive @resolveMenuItemId on FIELD_DEFINITION
+
+"""
+Resolve the menu item parents id.
+"""
+directive @resolveMenuItemParentId on FIELD_DEFINITION
+
+"""
+Resolve a menu items label.
+"""
+directive @resolveMenuItemLabel on FIELD_DEFINITION
+
+"""
+Resolve the Url from within a menu item.
+"""
+directive @resolveMenuItemUrl on FIELD_DEFINITION

--- a/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/graphql/silverback_gatsby_example.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/graphql/silverback_gatsby_example.graphqls
@@ -16,16 +16,22 @@ type Post @entity(type: "node", bundle: "blog") {
 }
 
 type MenuItem {
-  label: String!
-  url: String!
+  id: String! @resolveMenuItemId
+  parent: String @resolveMenuItemParentId
+  label: String! @resolveMenuItemLabel
+  url: String! @resolveMenuItemUrl
 }
 
 """
 All menu items, for the sitemap or being post-loaded.
 """
-type MainMenu @menu(menu_ids: ["access_denied", "main"], item_type: "MenuItem")
+type MainMenu @menu(menu_ids: ["access_denied", "main"]) {
+  items: [MenuItem!]! @resolveMenuItems
+}
 
 """
 Menu items up to level 2, to be rendered directly into the page layout.
 """
-type VisibleMainMenu @menu(menu_ids: ["access_denied", "main"], max_level: 2, item_type: "MenuItem")
+type VisibleMainMenu @menu(menu_ids: ["access_denied", "main"], max_level: 2) {
+  items: [MenuItem!]! @resolveMenuItems
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/src/Plugin/GraphQL/Schema/SilverbackGatsbyExampleSchema.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/src/Plugin/GraphQL/Schema/SilverbackGatsbyExampleSchema.php
@@ -37,17 +37,6 @@ class SilverbackGatsbyExampleSchema extends ComposableSchema {
       )
     );
 
-    $registry->addFieldResolver('MenuItem', 'label', $builder->compose(
-      $builder->produce('menu_tree_link')->map('element', $builder->fromParent()),
-      $builder->produce('menu_link_label')->map('link', $builder->fromParent()),
-    ));
-
-    $registry->addFieldResolver('MenuItem', 'url', $builder->compose(
-      $builder->produce('menu_tree_link')->map('element', $builder->fromParent()),
-      $builder->produce('menu_link_url')->map('link', $builder->fromParent()),
-      $builder->produce('url_path')->map('url', $builder->fromParent()),
-    ));
-
     return $registry;
   }
 }


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/silverback_gatsby`

## Description of changes

* Deprecated the `item_type` declaration and magic creation of `items`, `id`, and `parent` fields in favor of a more explicit way to declare menu types.
* Added directives for resolving items of a menu, urls and labels.

## Motivation and context

Make menu schemas less magic, and more declarative and therefore flexible. With this approach, we can easily change field names or use other resolvers if necessary. Also the schema syntax is not broken upfront and the schema contains the whole type definition.

Instead of:

```graphql
type MainMenu @menu(menu_id: "main", item_type: "MenuItem") {
}

type MenuItem {
   label
   url
}
```

We write:

```graphql
type MainMenu @menu(menu_id: "main") {
  items: [MenuItem!]! @resolveMenuItems
}

type MenuItem {
  id: String! @resolveMenuItemId
  parent: String @resolveMenuItemParentId
  label: String! @resolveMenuItemLabel
  url: String! @resolveMenuItemUrl
}
```

... and there is no need for extra resolvers any more.
