### PR TITLE
fix: fix an issue with urls starting from a slash segment

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
@@ -183,6 +183,9 @@ describe('buildUrl', () => {
   it('allows to create a root url to /', () => {
     expect(buildUrl(['/'])).toStrictEqual(`/`);
   });
+  it('allows to create a url from segments starting with /', () => {
+    expect(buildUrl(['/', 'foo', 'bar'])).toStrictEqual(`/foo/bar`);
+  });
   it('concatenates segments', () => {
     expect(buildUrl(['https://fake.url/', 'a', 'b'])).toStrictEqual(
       `https://fake.url/a/b`,

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
@@ -177,7 +177,7 @@ export const buildUrl = (
   fragment?: string,
 ) => {
   const url = segments
-    ? segments.filter(isTruthy).map(stripSlashes).join('/')
+    ? segments.filter(isTruthy).map(stripSlashes).join('/').replace(/^\/+/, '/')
     : '';
 
   const queryString = stringify(query, {


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/react-framework-bridge`

## Description of changes

Restore the previous behavior.

## Motivation and context

Previous behavior
```typescript
buildUrl(['/', 'foo', 'bar'])) // /foo/bar
```

Behavior introduced in https://github.com/AmazeeLabs/silverback-mono/pull/1029
```typescript
buildUrl(['/', 'foo', 'bar'])) // //foo/bar
```

## How has this been tested?

New test case. Manual testing on a project.
