### PR TITLE
fix(gutenberg): ignore blocks without a blockName

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/EditorBlocksProcessor.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/EditorBlocksProcessor.php
@@ -4,7 +4,7 @@
 class EditorBlocksProcessor {
   static function processsIgnoredBlocks(array $blocks, array $ignored) {
     $processed = [];
-    foreach ($blocks as $block) {
+    foreach (array_filter($blocks, fn ($block) => !!$block['blockName']) as $block) {
       if (in_array($block['blockName'], $ignored)) {
         foreach ((static::processsIgnoredBlocks($block['innerBlocks'] ?? [], $ignored)) as $child) {
           $processed[] = $child;


### PR DESCRIPTION
can happen when there are multiple \r\n character in the document

## Package(s) involved

<!-- type the name of the package(s) involved in this pull request -->

## Description of changes

<!-- a brief summary of your code changes -->

## Motivation and context

<!-- why is this PR necessary? is someone experiencing bugs or is a new feature being implemented? -->

## Related Issue(s)

<!-- make sure you link with either an `#issue-number` or directly with `[link-text](url)` -->

## How has this been tested?

<!-- locally? written tests? -->
