### PR TITLE
Allow nested elements in H2

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
@@ -106,6 +106,32 @@ describe('buildHtmlBuilder', () => {
     `);
   });
 
+  it('adds classes and ids to h2 elements', () => {
+    const Html = buildHtml(
+      '<main><h2>Test <strong>strong</strong></h2></main>',
+    );
+    render(
+      <Html
+        classNames={{
+          h2: 'foo',
+        }}
+      />,
+    );
+    expect(screen.getByRole('main')).toMatchInlineSnapshot(`
+      <main>
+        <h2
+          class="foo"
+          id="test-strong"
+        >
+          Test 
+          <strong>
+            strong
+          </strong>
+        </h2>
+      </main>
+    `);
+  });
+
   it('applies framework-specific link components', () => {
     const Html = buildHtml('<main><a href="/test">Test</a></main>');
     render(<Html />);


### PR DESCRIPTION
If an h2 element contains nested elements (eg. inline formatting), it would completely skip processing provided by `buildHtml`.

This PR fixes that.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)