### PR TITLE
Allow content elements to be grouped

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/atomic.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/atomic.test.tsx
@@ -134,6 +134,68 @@ describe('Route rendering', () => {
     `);
   });
 
+  it('can render content groups within an organism', async () => {
+    const { container } = render(
+      <Route
+        definition={Content}
+        input={{
+          intro: {
+            title: 'Test',
+          },
+          body: [
+            {
+              key: 'group',
+              input: {
+                title: 'Test Group',
+                content: {
+                  items: [
+                    {
+                      key: 'sync',
+                      input: {
+                        Content: buildHtml(`<p>Sync content.</p>`),
+                      },
+                    },
+                    {
+                      key: 'async',
+                      input: {
+                        Content: buildHtml(`<p>Async content.</p>`),
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        }}
+        intl={{ defaultLocale: 'en', locale: 'en' }}
+      />,
+    );
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          <div>
+            <h1>
+              Test
+            </h1>
+          </div>
+          <div>
+            <div>
+              <h2>
+                Test Group
+              </h2>
+              <p>
+                Sync content.
+              </p>
+              <p>
+                Async content.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    `);
+  });
+
   it('assumes status 200 for async organisms by default', async () => {
     const { container } = render(
       <Route
@@ -183,12 +245,13 @@ describe('Route rendering', () => {
           body: [
             {
               key: 'async',
-              input: () => [
-                {
-                  Content: buildHtml(`<p>Async content.</p>`),
-                },
-                102,
-              ],
+              input: () =>
+                [
+                  {
+                    Content: buildHtml(`<p>Async content.</p>`),
+                  },
+                  102,
+                ] as [any, number],
             },
           ],
         }}
@@ -244,38 +307,38 @@ describe('Route rendering', () => {
         />,
       );
       expect(container).toMatchInlineSnapshot(`
-      <div>
-        <div>
-          <div>
-            <h1>
-              Test
-            </h1>
-          </div>
-          <div>
-            <p>
-              Loading ...
-            </p>
-          </div>
-        </div>
-      </div>
-    `);
+              <div>
+                <div>
+                  <div>
+                    <h1>
+                      Test
+                    </h1>
+                  </div>
+                  <div>
+                    <p>
+                      Loading ...
+                    </p>
+                  </div>
+                </div>
+              </div>
+          `);
       await new Promise((resolve) => setTimeout(resolve, 60));
       expect(container).toMatchInlineSnapshot(`
-      <div>
-        <div>
-          <div>
-            <h1>
-              Test
-            </h1>
-          </div>
-          <div>
-            <p>
-              Async content.
-            </p>
-          </div>
-        </div>
-      </div>
-    `);
+              <div>
+                <div>
+                  <div>
+                    <h1>
+                      Test
+                    </h1>
+                  </div>
+                  <div>
+                    <p>
+                      Async content.
+                    </p>
+                  </div>
+                </div>
+              </div>
+          `);
     });
   });
 });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/example-ui.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/example-ui.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 
 import { Html } from '../types';
-import { LayoutProps, OrganismProps, route, useOrganismStatus } from './atomic';
+import {
+  Group,
+  group,
+  LayoutProps,
+  OrganismProps,
+  route,
+  RouteInput,
+  useOrganismStatus,
+} from './atomic';
 
 export function PageLayout(props: LayoutProps<'header' | 'footer'>) {
   return (
@@ -43,6 +51,27 @@ export function AsyncContent(props: OrganismProps<{ Content: Html }>) {
   return status === 200 ? <props.Content /> : <p>Loading ...</p>;
 }
 
+export function GroupedContent(
+  props: OrganismProps<{
+    title: string;
+    content: RouteInput<typeof ContentGroup>;
+  }>,
+) {
+  return (
+    <div>
+      <h2>{props.title}</h2>
+      <Group definition={ContentGroup} input={props.content} />
+    </div>
+  );
+}
+
+export const ContentGroup = group({
+  items: {
+    sync: SyncContent,
+    async: AsyncContent,
+  },
+});
+
 export const Page = route(PageLayout, {
   header: Header,
   footer: Footer,
@@ -53,5 +82,6 @@ export const Content = route(ContentLayout, {
   body: {
     sync: SyncContent,
     async: AsyncContent,
+    group: GroupedContent,
   },
 });


### PR DESCRIPTION
Organisms can now define groups of content as inputs that can be mapped from the application just as other routes.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)