### PR TITLE
feat: periodic build

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/README.md
+++ b/packages/composer/amazeelabs/silverback_gatsby/README.md
@@ -221,7 +221,7 @@ query MainMenu {
 
 The `@menu` directive also takes an optional `max_level` argument. It can be
 used to restrict the number of levels a type will include, which in turn can
-optimize caching and Gatsby build times.  
+optimize caching and Gatsby build times.
 In many cases, the main page layout only displays the first level of menu items.
 When a new page is created and attached to the third level, Gatsby will still
 re-render all pages, because the menu that is used in the header changed. By
@@ -295,3 +295,22 @@ access control and use it for the "Preview" environment on Gatsby cloud, so
 unpublished content can be previewed. Another sensible case would be to create a
 "build" user that has access to published content and block anonymous access to
 Drupal entirely.
+
+## Trigger a build
+
+There are multiple ways to trigger a Gatsby build:
+- on entity save
+- via the Drupal UI or Drush.
+
+### On entity save
+
+On the _Build_ tab of the schema configuration, check the _Trigger a build on entity save_ checkbox.
+
+### Drupal UI
+
+On the same _Build_ tab, click the _Gatsby Build_ button.
+
+### Drush
+
+This command can be configured in the system cron.
+`drush silverback-gatsby:build [server_id]`

--- a/packages/composer/amazeelabs/silverback_gatsby/drush.services.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/drush.services.yml
@@ -4,5 +4,6 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@plugin.manager.graphql.schema'
+      - '@silverback_gatsby.update_trigger'
     tags:
       - { name: drush.command }

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.links.task.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.links.task.yml
@@ -1,0 +1,5 @@
+entity.graphql_server.build_form:
+  route_name: entity.graphql_server.build_form
+  base_route: entity.graphql_server.edit_form
+  title: Build
+  weight: -1

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
@@ -31,3 +31,26 @@ function silverback_gatsby_entity_update(EntityInterface $entity) {
 function silverback_gatsby_entity_delete(EntityInterface $entity) {
   _silverback_gatsby_entity_event($entity);
 }
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function silverback_gatsby_entity_type_alter(array &$entity_types) {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
+  foreach ($entity_types as $entity_type) {
+    if ($entity_type->id() === 'graphql_server') {
+      if (!$entity_type->hasHandlerClass('build')) {
+        $entity_type->setHandlerClass(
+          'build',
+          Drupal\silverback_gatsby\GraphQL\Build::class
+        );
+      }
+      if (!$entity_type->getFormClass('build')) {
+        $entity_type->setFormClass(
+          'build',
+          Drupal\silverback_gatsby\GraphQL\Build::class
+        );
+      }
+    }
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.permissions.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.permissions.yml
@@ -1,0 +1,2 @@
+trigger a gatsby build:
+  title: 'Trigger a Gatsby Build'

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.routing.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.routing.yml
@@ -1,0 +1,9 @@
+entity.graphql_server.build_form:
+  path: '/admin/config/graphql/servers/build/{graphql_server}'
+  defaults:
+    _entity_form: 'graphql_server.build'
+    _title: 'Build'
+  requirements:
+    _permission: 'administer graphql configuration+trigger a gatsby build'
+  options:
+    _admin_route: TRUE

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.services.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.services.yml
@@ -10,7 +10,10 @@ services:
 
   silverback_gatsby.update_trigger:
     class: Drupal\silverback_gatsby\GatsbyUpdateTrigger
-    arguments: ['@http_client', '@messenger', '@entity_type.manager']
+    arguments:
+      - '@http_client'
+      - '@messenger'
+      - '@entity_type.manager'
 
   silverback_gatsby.update_tracker:
     class: Drupal\silverback_gatsby\GatsbyUpdateTracker

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Commands/SilverbackGatsbyCommands.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Commands/SilverbackGatsbyCommands.php
@@ -4,6 +4,7 @@ namespace Drupal\silverback_gatsby\Commands;
 
 use Drupal\Component\Plugin\PluginManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\silverback_gatsby\GatsbyUpdateTriggerInterface;
 use Drupal\silverback_gatsby\GraphQL\ComposableSchema;
 use Drush\Commands\DrushCommands;
 
@@ -22,11 +23,17 @@ class SilverbackGatsbyCommands extends DrushCommands {
 
   protected EntityTypeManagerInterface $entityTypeManager;
   protected PluginManagerInterface $schemaPluginManager;
+  protected GatsbyUpdateTriggerInterface $updateTrigger;
 
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, PluginManagerInterface $schemaPluginManager) {
+  public function __construct(
+    EntityTypeManagerInterface $entityTypeManager,
+    PluginManagerInterface $schemaPluginManager,
+    GatsbyUpdateTriggerInterface $updateTrigger
+  ) {
     parent::__construct();
     $this->entityTypeManager = $entityTypeManager;
     $this->schemaPluginManager = $schemaPluginManager;
+    $this->updateTrigger = $updateTrigger;
   }
 
   /**
@@ -64,4 +71,19 @@ class SilverbackGatsbyCommands extends DrushCommands {
       file_put_contents($path, implode("\n", $definition));
     }
   }
+
+  /**
+   * Trigger a Gatsby build for a given GraphQL server.
+   *
+   * @param string $server
+   *   The server id.
+   *
+   * @command silverback-gatsby:build
+   * @aliases sgb
+   * @usage silverback-gatsby:build [server_id]
+   */
+  public function triggerBuild($server) {
+    $this->updateTrigger->triggerLatestBuild($server);
+  }
+
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateHandler.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateHandler.php
@@ -81,6 +81,11 @@ class GatsbyUpdateHandler {
           }
         }
 
+        // If the configuration is not set, assume TRUE.
+        $buildOnSave = TRUE;
+        if (array_key_exists('build_trigger_on_save', $config[$schema_id])) {
+          $buildOnSave = $config[$schema_id]['build_trigger_on_save'] === 1;
+        }
         foreach ($schema->getExtensions() as $extension) {
           if ($extension instanceof SilverbackGatsbySchemaExtension) {
             foreach ($extension->getFeeds() as $feed) {
@@ -89,7 +94,7 @@ class GatsbyUpdateHandler {
                 && $updates = $feed->investigateUpdate($context, $account)
               ) {
                 foreach ($updates as $update) {
-                  $this->gatsbyUpdateTracker->track($server->id(), $update->type, $update->id);
+                  $this->gatsbyUpdateTracker->track($server->id(), $update->type, $update->id, $buildOnSave);
                 }
               }
             }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateHandler.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateHandler.php
@@ -82,9 +82,9 @@ class GatsbyUpdateHandler {
         }
 
         // If the configuration is not set, assume TRUE.
-        $buildOnSave = TRUE;
+        $trigger = TRUE;
         if (array_key_exists('build_trigger_on_save', $config[$schema_id])) {
-          $buildOnSave = $config[$schema_id]['build_trigger_on_save'] === 1;
+          $trigger = $config[$schema_id]['build_trigger_on_save'] === 1;
         }
         foreach ($schema->getExtensions() as $extension) {
           if ($extension instanceof SilverbackGatsbySchemaExtension) {
@@ -94,7 +94,7 @@ class GatsbyUpdateHandler {
                 && $updates = $feed->investigateUpdate($context, $account)
               ) {
                 foreach ($updates as $update) {
-                  $this->gatsbyUpdateTracker->track($server->id(), $update->type, $update->id, $buildOnSave);
+                  $this->gatsbyUpdateTracker->track($server->id(), $update->type, $update->id, $trigger);
                 }
               }
             }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTracker.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTracker.php
@@ -39,7 +39,7 @@ class GatsbyUpdateTracker implements GatsbyUpdateTrackerInterface {
   /**
    * {@inheritDoc}
    */
-  public function track(string $server, string $type, string $id, bool $buildOnSave = TRUE) : int {
+  public function track(string $server, string $type, string $id, bool $trigger = TRUE) : int {
     if (isset($this->tracked[$server]) && isset($this->tracked[$server][$type]) && in_array($id,$this->tracked[$server][$type])) {
       return $this->latestBuild($server);
     }
@@ -51,7 +51,7 @@ class GatsbyUpdateTracker implements GatsbyUpdateTrackerInterface {
       'uid' => $this->currentUser->id(),
       'timestamp' => time(),
     ])->execute();
-    if ($buildOnSave) {
+    if ($trigger) {
       $this->trigger->trigger($server, $buildId);
     }
     return $buildId;

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTracker.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTracker.php
@@ -39,7 +39,7 @@ class GatsbyUpdateTracker implements GatsbyUpdateTrackerInterface {
   /**
    * {@inheritDoc}
    */
-  public function track(string $server, string $type, string $id) : int {
+  public function track(string $server, string $type, string $id, bool $buildOnSave = TRUE) : int {
     if (isset($this->tracked[$server]) && isset($this->tracked[$server][$type]) && in_array($id,$this->tracked[$server][$type])) {
       return $this->latestBuild($server);
     }
@@ -51,7 +51,9 @@ class GatsbyUpdateTracker implements GatsbyUpdateTrackerInterface {
       'uid' => $this->currentUser->id(),
       'timestamp' => time(),
     ])->execute();
-    $this->trigger->trigger($server, $buildId);
+    if ($buildOnSave) {
+      $this->trigger->trigger($server, $buildId);
+    }
     return $buildId;
   }
 

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTriggerInterface.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTriggerInterface.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\silverback_gatsby;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 interface GatsbyUpdateTriggerInterface {
 
   /**
@@ -13,6 +15,20 @@ interface GatsbyUpdateTriggerInterface {
    *   The build id.
    */
   public function trigger(string $server, int $id) : void;
+
+  /**
+   * Trigger a build for a given server based on latest build id.
+   *
+   * Compares the latest build id with the one on the frontend to not
+   * trigger unnecessary builds.
+   *
+   * @param string $server
+   *   The server id.
+   *
+   * @return TranslatableMarkup
+   *   The resut message.
+   */
+  public function triggerLatestBuild(string $server) : TranslatableMarkup;
 
   /**
    * Send out notifications about potential updates to all Gatsby servers.

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GraphQL/Build.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GraphQL/Build.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Drupal\silverback_gatsby\GraphQL;
+
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\HtmlCommand;
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Form\SubformState;
+use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\graphql\Plugin\SchemaPluginManager;
+use Drupal\silverback_gatsby\GatsbyUpdateTriggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Gatsby build specific configuration of the schema.
+ *
+ * @package Drupal\silverback_gatsby\GraphQL
+ */
+class Build extends EntityForm {
+
+  /**
+   * The schema plugin manager.
+   *
+   * @var \Drupal\graphql\Plugin\SchemaPluginManager
+   */
+  protected $schemaManager;
+
+  /**
+   * The Gatsby update trigger.
+   *
+   * @var \Drupal\silverback_gatsby\GatsbyUpdateTriggerInterface
+   */
+  protected $updateTrigger;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * ServerForm constructor.
+   *
+   * @param \Drupal\graphql\Plugin\SchemaPluginManager $schemaManager
+   *   The schema plugin manager.
+   *
+   * @codeCoverageIgnore
+   */
+  public function __construct(
+    SchemaPluginManager $schemaManager,
+    GatsbyUpdateTriggerInterface $updateTrigger,
+    AccountProxyInterface $currentUser
+  ) {
+    $this->schemaManager = $schemaManager;
+    $this->updateTrigger = $updateTrigger;
+    $this->currentUser = $currentUser;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @codeCoverageIgnore
+   */
+  public static function create(ContainerInterface $container): self {
+    return new static(
+      $container->get('plugin.manager.graphql.schema'),
+      $container->get('silverback_gatsby.update_trigger'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(
+    array $form,
+    FormStateInterface $form_state
+  ) {
+    $form = parent::buildForm($form, $form_state);
+
+    $form['trigger_build'] = [
+      '#type' => 'button',
+      '#value' => $this->t('Gatsby Build'),
+      '#required' => FALSE,
+      '#ajax' => [
+        'callback' => [$this, 'gatsbyBuild'],
+      ],
+      '#suffix' => '<span class="gatsby-build-message"></span>',
+    ];
+
+    /** @var \Drupal\graphql\Entity\ServerInterface $server */
+    $server = $this->entity;
+    $schema = $server->get('schema');
+    $form['actions']['#access'] = $this->currentUser->hasPermission('administer graphql configuration');
+    $form['schema_configuration'] = [
+      '#type' => 'container',
+      '#access' => $this->currentUser->hasPermission('administer graphql configuration'),
+      '#prefix' => '<div id="edit-schema-configuration-plugin-wrapper">',
+      '#suffix' => '</div>',
+      '#tree' => TRUE,
+    ];
+
+    /** @var \Drupal\graphql\Plugin\SchemaPluginInterface $instance */
+    $instance = $schema ? $this->schemaManager->createInstance($schema) : NULL;
+    if ($instance instanceof PluginFormInterface && $instance instanceof ConfigurableInterface) {
+      $instance->setConfiguration($server->get('schema_configuration')[$schema] ?? []);
+      $form['schema_configuration'][$schema] = [
+        '#type' => 'fieldset',
+        '#title' => $this->t('Build configuration'),
+        '#tree' => TRUE,
+      ];
+      $form['schema_configuration'][$schema] += $instance->buildConfigurationForm([], $form_state);
+    }
+    return $form;
+  }
+
+  /**
+   * Gatsby build.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   *   AjaxResponse.
+   */
+  public function gatsbyBuild(array $form, FormStateInterface $form_state) {
+    $response = new AjaxResponse();
+    $buildMessage = $this->updateTrigger->triggerLatestBuild($this->entity->id());
+    $response->addCommand(new HtmlCommand('.gatsby-build-message', $buildMessage));
+    return $response;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitForm($form, $form_state);
+    $server = $this->entity;
+    $schema = $server->get('schema');
+    /** @var \Drupal\graphql\Plugin\SchemaPluginInterface $instance */
+    $instance = $this->schemaManager->createInstance($schema);
+    if ($instance instanceof PluginFormInterface && $instance instanceof ConfigurableInterface) {
+      $state = SubformState::createForSubform($form['schema_configuration'][$schema], $form, $form_state);
+      $instance->submitConfigurationForm($form['schema_configuration'][$schema], $state);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $save_result = parent::save($form, $form_state);
+    $this->messenger()->addMessage($this->t('Saved the %label server.', [
+      '%label' => $this->entity->label(),
+    ]));
+
+    $form_state->setRedirect('entity.graphql_server.collection');
+    return $save_result;
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/GatsbyUpdateTrackerTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/GatsbyUpdateTrackerTest.php
@@ -88,6 +88,13 @@ class GatsbyUpdateTrackerTest extends KernelTestBase {
     );
   }
 
+  public function testDeferredBuild() {
+    $this->tracker->track('foo', 'Page', '1', FALSE);
+    $this->assertEquals(1, $this->tracker->latestBuild('foo'));
+    _drupal_shutdown_function();
+    $this->checkTotalNotifications(0);
+  }
+
   public function testInvalidDiff() {
     $this->tracker->track('foo', 'Page', '1');
     $this->tracker->track('foo', 'Page', '2');


### PR DESCRIPTION
## Package(s) involved

silverback_gatsby (Composer package)

## Description of changes

- Makes the build on entity save optional
- Adds a Drush command that triggers the Gatsby build
- Adds a Gatsby Build button
- Moves build specific configuration in its own tab

## Motivation and context

Feature request

## Related Issue(s)

#1068 

## How has this been tested?

- Locally, manual test
- Unit test for `GatsbyUpdateTrackerTest::testDeferredBuild()`