### PR TITLE
Add `_original_typename` field to all types

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -270,6 +270,26 @@ directive @resolveEntityReferenceRevisions(
   single: Boolean!
 ) on FIELD_DEFINITION
 
+extend type Query { _original_typename: String! }
+extend type Image { _original_typename: String! }
+extend type Tag { _original_typename: String! }
+extend type Page { _original_typename: String! }
+extend type ParagraphText { _original_typename: String! }
+extend type ParagraphReferences { _original_typename: String! }
+extend type GutenbergPage { _original_typename: String! }
+extend type Webform { _original_typename: String! }
+extend type Article { _original_typename: String! }
+extend type BlockTwoColumns { _original_typename: String! }
+extend type BlockColumn { _original_typename: String! }
+extend type BlockHtmlParagraph { _original_typename: String! }
+extend type BlockHtmlList { _original_typename: String! }
+extend type BlockHtmlQuote { _original_typename: String! }
+extend type BlockImage { _original_typename: String! }
+extend type BlockTeaser { _original_typename: String! }
+extend type MenuItem { _original_typename: String! }
+extend type MainMenu { _original_typename: String! }
+extend type FirstLevelMainMenu { _original_typename: String! }
+extend type GatsbyStringTranslation { _original_typename: String! }
 extend type Query {
   drupalBuildId: Int!
   drupalFeedInfo: [Feed!]!

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -270,6 +270,26 @@ directive @resolveEntityReferenceRevisions(
   single: Boolean!
 ) on FIELD_DEFINITION
 
+extend type Query { _original_typename: String! }
+extend type Image { _original_typename: String! }
+extend type Tag { _original_typename: String! }
+extend type Page { _original_typename: String! }
+extend type ParagraphText { _original_typename: String! }
+extend type ParagraphReferences { _original_typename: String! }
+extend type GutenbergPage { _original_typename: String! }
+extend type Webform { _original_typename: String! }
+extend type Article { _original_typename: String! }
+extend type BlockTwoColumns { _original_typename: String! }
+extend type BlockColumn { _original_typename: String! }
+extend type BlockHtmlParagraph { _original_typename: String! }
+extend type BlockHtmlList { _original_typename: String! }
+extend type BlockHtmlQuote { _original_typename: String! }
+extend type BlockImage { _original_typename: String! }
+extend type BlockTeaser { _original_typename: String! }
+extend type MenuItem { _original_typename: String! }
+extend type MainMenu { _original_typename: String! }
+extend type FirstLevelMainMenu { _original_typename: String! }
+extend type GatsbyStringTranslation { _original_typename: String! }
 extend type Query {
   drupalBuildId: Int!
   drupalFeedInfo: [Feed!]!

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/queries/editor.gql
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/queries/editor.gql
@@ -3,15 +3,18 @@ fragment BlockPage on Page {
   content {
     __typename
     ... on Text {
+      _original_typename
       content
     }
     ... on Figure {
+      _original_typename
       caption
       image {
         alt
       }
     }
     ... on Columns {
+      _original_typename
       columns {
         __typename
       }
@@ -21,10 +24,12 @@ fragment BlockPage on Page {
 
 query {
   en:loadPage(id: "1:en") {
+    _original_typename
     ...BlockPage
   }
 
   de:loadPage(id: "1:de") {
+    _original_typename
     ...BlockPage
   }
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EditorBlocksTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EditorBlocksTest.php
@@ -123,44 +123,64 @@ class EditorBlocksTest extends EntityFeedTestBase {
       'en' => [
         'title' => 'Editor test',
         'content' => [
-          ['__typename' => 'Text', 'content' => '<p>A test paragraph</p><p>Another test paragraph</p>'],
+          [
+            '__typename' => 'Text',
+            'content' => '<p>A test paragraph</p><p>Another test paragraph</p>',
+            '_original_typename' => 'Text',
+          ],
           [
             '__typename' => 'Figure',
             'caption' => 'This is the caption',
             'image' => [
               'alt' => 'Screaming hairy armadillo'
-            ]
+            ],
+            '_original_typename' => 'Figure',
           ],
-          ['__typename' => 'Columns', 'columns' => [
-            [
-              '__typename' => 'Text',
+          [
+            '__typename' => 'Columns',
+            'columns' => [
+              [
+                '__typename' => 'Text',
+              ],
+              [
+                '__typename' => 'Text',
+              ],
             ],
-            [
-              '__typename' => 'Text',
-            ],
-          ]],
+            '_original_typename' => 'Columns',
+          ],
         ],
+        '_original_typename' => 'Page',
       ],
       'de' => [
         'title' => 'Editor test DE',
         'content' => [
-          ['__typename' => 'Text', 'content' => '<p>A test paragraph</p><p>Another test paragraph</p>'],
+          [
+            '__typename' => 'Text',
+            'content' => '<p>A test paragraph</p><p>Another test paragraph</p>',
+            '_original_typename' => 'Text',
+          ],
           [
             '__typename' => 'Figure',
             'caption' => 'This is the caption',
             'image' => [
               'alt' => 'Screaming hairy armadillo DE'
-            ]
+            ],
+            '_original_typename' => 'Figure',
           ],
-          ['__typename' => 'Columns', 'columns' => [
-            [
-              '__typename' => 'Text',
+          [
+            '__typename' => 'Columns',
+            'columns' => [
+              [
+                '__typename' => 'Text',
+              ],
+              [
+                '__typename' => 'Text',
+              ],
             ],
-            [
-              '__typename' => 'Text',
-            ],
-          ]],
+            '_original_typename' => 'Columns'
+          ],
         ],
+        '_original_typename' => 'Page',
       ],
     ], $metadata);
   }


### PR DESCRIPTION
Add an `_original_typename` field to each GraphQL type in a schema using the `SilverbackGatsbySchemaExtension`. It can be used to retrieve the original type in an environment that alters type names to avoid naming conflicts (e.g. Gatsby).

The following two queries should return the same:

```graphql
# Executed against the original endpoint.
fragment Page on Page {
  __typename
}
```

```graphql
# Executed against a federated endpoint.
fragment Page on DrupalPage {
  __typename:_original_typename
}
```

## CAVEAT

The `__typename` field is special, since it can be used on union types before they are resolved. `__original_typename` can't do that. This means `__typename` checks can't be added to the whole union at once, but have to be declared on each object fragment.

For example this:

```graphql
fragment Image on Image {
  url
}

fragment Text on Text {
  text
}

fragment Page on Page {
  content {
    __typename
    ...Image
    ...Text
  }
}
```

... has to turn into this ...

```graphql
fragment Image on Image {
  __typename
  url
}

fragment Text on Text {
  __typename
  text
}

fragment Page  on Page {
  content {
    ...Image
    ...Text
  }
}
```

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)