### PR TITLE
feat(gatsby): graphql fields for fetching entity revisions

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -307,6 +307,7 @@ extend type Image {
   translations: [Image!]!
 }
 
+extend type Query { loadImageRevision(id: String!, revision: String!) : Image }
 extend type Query {
   loadTag(id: String!): Tag
   queryTags(offset: Int, limit: Int): [Tag]!
@@ -316,6 +317,7 @@ extend type Tag {
   drupalId: String!
 }
 
+extend type Query { loadTagRevision(id: String!, revision: String!) : Tag }
 extend type Query {
   loadPage(id: String!): Page
   queryPages(offset: Int, limit: Int): [Page]!
@@ -328,6 +330,7 @@ extend type Page {
   translations: [Page!]!
 }
 
+extend type Query { loadPageRevision(id: String!, revision: String!) : Page }
 extend type Query {
   loadGutenbergPage(id: String!): GutenbergPage
   queryGutenbergPages(offset: Int, limit: Int): [GutenbergPage]!
@@ -340,6 +343,7 @@ extend type GutenbergPage {
   translations: [GutenbergPage!]!
 }
 
+extend type Query { loadGutenbergPageRevision(id: String!, revision: String!) : GutenbergPage }
 extend type Query {
   loadWebform(id: String!): Webform
   queryWebforms(offset: Int, limit: Int): [Webform]!
@@ -349,6 +353,7 @@ extend type Webform {
   drupalId: String!
 }
 
+extend type Query { loadWebformRevision(id: String!, revision: String!) : Webform }
 extend type Query {
   loadArticle(id: String!): Article
   queryArticles(offset: Int, limit: Int): [Article]!
@@ -361,6 +366,7 @@ extend type Article {
   translations: [Article!]!
 }
 
+extend type Query { loadArticleRevision(id: String!, revision: String!) : Article }
 extend type Query {
   loadMainMenu(id: String!): MainMenu
   queryMainMenus(offset: Int, limit: Int): [MainMenu]!

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -307,6 +307,7 @@ extend type Image {
   translations: [Image!]!
 }
 
+extend type Query { loadImageRevision(id: String!, revision: String!) : Image }
 extend type Query {
   loadTag(id: String!): Tag
   queryTags(offset: Int, limit: Int): [Tag]!
@@ -316,6 +317,7 @@ extend type Tag {
   drupalId: String!
 }
 
+extend type Query { loadTagRevision(id: String!, revision: String!) : Tag }
 extend type Query {
   loadPage(id: String!): Page
   queryPages(offset: Int, limit: Int): [Page]!
@@ -328,6 +330,7 @@ extend type Page {
   translations: [Page!]!
 }
 
+extend type Query { loadPageRevision(id: String!, revision: String!) : Page }
 extend type Query {
   loadGutenbergPage(id: String!): GutenbergPage
   queryGutenbergPages(offset: Int, limit: Int): [GutenbergPage]!
@@ -340,6 +343,7 @@ extend type GutenbergPage {
   translations: [GutenbergPage!]!
 }
 
+extend type Query { loadGutenbergPageRevision(id: String!, revision: String!) : GutenbergPage }
 extend type Query {
   loadWebform(id: String!): Webform
   queryWebforms(offset: Int, limit: Int): [Webform]!
@@ -349,6 +353,7 @@ extend type Webform {
   drupalId: String!
 }
 
+extend type Query { loadWebformRevision(id: String!, revision: String!) : Webform }
 extend type Query {
   loadArticle(id: String!): Article
   queryArticles(offset: Int, limit: Int): [Article]!
@@ -361,6 +366,7 @@ extend type Article {
   translations: [Article!]!
 }
 
+extend type Query { loadArticleRevision(id: String!, revision: String!) : Article }
 extend type Query {
   loadMainMenu(id: String!): MainMenu
   queryMainMenus(offset: Int, limit: Int): [MainMenu]!

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/queries/revisionable.gql
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/queries/revisionable.gql
@@ -1,0 +1,8 @@
+query {
+  a:loadPostRevision(id: "1", revision: "1") {
+    title
+  }
+  b:loadPostRevision(id: "1", revision: "2") {
+    title
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
@@ -295,4 +295,27 @@ class EntityFeedTest extends EntityFeedTestBase {
     ], $metadata);
   }
 
+  public function testRevisionable() {
+    $node = Node::create([
+      'type' => 'blog',
+      'title' => 'Revision 1'
+    ]);
+    $node->save();
+    $node->set('title', 'Revision 2');
+    $node->setNewRevision();
+    $node->save();
+
+    $query = $this->getQueryFromFile('revisionable.gql');
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheTags(['node:1']);
+    $this->assertResults($query, [], [
+      'a' => [
+        'title' => 'Revision 1',
+      ],
+      'b' => [
+        'title' => 'Revision 2',
+      ],
+    ], $metadata);
+  }
+
 }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

Add `load[Type]Revision` root level fields to retrieve specific revisions of an entity

## Motivation and context

Can be used to display specific revisions when loading them in the browser for preview purposes.

## Related Issue(s)

#1060 

## How has this been tested?

Kerneltests