### PR TITLE
chore: added the children attribute to the Link component

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
@@ -37,6 +37,7 @@ export type Link<Query extends Parameters<typeof stringify>[0] = {}> =
     activeClassName?: string;
     query?: Query;
     fragment?: string;
+    children?: React.ReactNode;
   }> & {
     navigate: (opts?: { query?: Query; fragment?: string }) => void;
     href: string;


### PR DESCRIPTION
## Package(s) involved

@amazeelabs/react-frameworkd-bridge

## Description of changes

After updating eslint, in one of the projects, I get this error:

```
src/components/molecules/Attachments.tsx:29:16 - error TS2322: Type '{ children: Element[]; className: string; }' is not assignable to type 'IntrinsicAttributes & { className?: string | undefined; activeClassName?: string | undefined; query?: {} | undefined; fragment?: string | undefined; }'.
  Property 'children' does not exist on type 'IntrinsicAttributes & { className?: string | undefined; activeClassName?: string | undefined; query?: {} | undefined; fragment?: string | undefined; }'.

29               <Link className="ring-orange-500 ring-offset-[#fef7ec] flex focus:outline-none focus-visible:ring-2 ring-offset-8">
```
A similar issue and its fix is highlighted here: https://bobbyhadz.com/blog/react-property-children-does-not-exist-on-type