### PR TITLE
Collapse HTML blocks

### DIFF
--- a/apps/silverback-drupal/generated/__tests__/queries/gatsby/content/GutenbergPage.gql.snapshot
+++ b/apps/silverback-drupal/generated/__tests__/queries/gatsby/content/GutenbergPage.gql.snapshot
@@ -31,11 +31,7 @@ exports[`gatsby/content/GutenbergPage.gql 1`] = `
             },
             {
               "__typename": "BlockHtmlParagraph",
-              "html": "\\r\\n<p>Grouped paragraph 1.</p>\\r\\n"
-            },
-            {
-              "__typename": "BlockHtmlParagraph",
-              "html": "\\r\\n<p>Grouped paragraph 2.</p>\\r\\n"
+              "html": "\\r\\n<p>Grouped paragraph 1.</p>\\r\\n\\r\\n<p>Grouped paragraph 2.</p>\\r\\n"
             },
             {
               "__typename": "BlockTwoColumns",

--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -100,6 +100,12 @@ directive @resolveEditorBlocks(
   "core/group" is ignored by default.
   """
   ignore: [String!]
+  """
+  List of block types that are treated like plain HTML without attributes, just
+  as "core/paragraph". Sequences of these blocks will be aggregated into a
+  single instance of "core/paragraph".
+  """
+  aggregate: [String!]
 ) on FIELD_DEFINITION
 
 """

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -100,6 +100,12 @@ directive @resolveEditorBlocks(
   "core/group" is ignored by default.
   """
   ignore: [String!]
+  """
+  List of block types that are treated like plain HTML without attributes, just
+  as "core/paragraph". Sequences of these blocks will be aggregated into a
+  single instance of "core/paragraph".
+  """
+  aggregate: [String!]
 ) on FIELD_DEFINITION
 
 """

--- a/packages/composer/amazeelabs/silverback_gatsby/graphql/editor_block.directive.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/graphql/editor_block.directive.graphqls
@@ -22,6 +22,12 @@ directive @resolveEditorBlocks(
   "core/group" is ignored by default.
   """
   ignore: [String!]
+  """
+  List of block types that are treated like plain HTML without attributes, just
+  as "core/paragraph". Sequences of these blocks will be aggregated into a
+  single instance of "core/paragraph".
+  """
+  aggregate: [String!]
 ) on FIELD_DEFINITION
 
 """

--- a/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/graphql/silverback_gatsby_example.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/graphql/silverback_gatsby_example.graphqls
@@ -9,13 +9,13 @@ union WithPath = Page | Post
 type Page @entity(type: "node", bundle: "page") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
-  content: [Blocks!]! @resolveEditorBlocks(path: "body.value")
+  content: [Blocks!]! @resolveEditorBlocks(path: "body.value", aggregate: ["core/paragraph", "core/list"])
 }
 
 union Blocks = Text | Figure | Columns
 union ColumnBlocks = Text | Figure
 
-type Text @editorBlock(type: "custom/text") {
+type Text @editorBlock(type: "core/paragraph") {
   content: String @resolveEditorBlockAttribute(name: "markup")
 }
 

--- a/packages/composer/amazeelabs/silverback_gatsby/src/EditorBlocksProcessor.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/EditorBlocksProcessor.php
@@ -2,7 +2,38 @@
  namespace Drupal\silverback_gatsby;
 
 class EditorBlocksProcessor {
-  static function processsIgnoredBlocks(array $blocks, array $ignored) {
+
+  static function aggregateParagraphs(array $blocks, ?array $types = ['core/paragraph']) {
+    $processed = [];
+    $content = [];
+    foreach ($blocks as $block) {
+      if (in_array($block['blockName'], $types)) {
+        $content[] = $block['innerHTML'];
+      }
+      else {
+        if (count($content)) {
+          $processed[] = [
+            'blockName' => 'core/paragraph',
+            'innerHTML' => implode('', $content),
+          ];
+          $content = [];
+        }
+        if ($block['innerBlocks']) {
+          $block['innerBlocks'] = static::aggregateParagraphs($block['innerBlocks'], $types);
+        }
+        $processed[] = $block;
+      }
+    }
+    if (count($content)) {
+      $processed[] = [
+        'blockName' => 'core/paragraph',
+        'innerHTML' => implode('', $content),
+      ];
+    }
+    return $processed;
+  }
+
+  static function processsIgnoredBlocks(array $blocks, ?array $ignored) {
     $processed = [];
     foreach (array_filter($blocks, fn ($block) => !!$block['blockName']) as $block) {
       if (in_array($block['blockName'], $ignored)) {

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/EditorBlocks.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/EditorBlocks.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\silverback_gatsby\Plugin\GraphQL\DataProducer;
 
+use Drupal\Core\Annotation\ContextDefinition;
+use Drupal\Core\Annotation\Translation;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Render\RenderContext;
@@ -42,6 +44,10 @@ use Drupal\typed_data\Exception\LogicException;
  *     "ignored" = @ContextDefinition("any",
  *       label = @Translation("Ignored block types"),
  *       required = FALSE
+ *     ),
+ *     "aggregated" = @ContextDefinition("any",
+ *       label = @Translation("Aggregated into core/paragraph"),
+ *       required = FALSE
  *     )
  *   }
  * )
@@ -55,6 +61,7 @@ class EditorBlocks extends DataProducerPluginBase {
     $entity,
     $type,
     $ignored,
+    $aggregated,
     FieldContext $field
   ) {
     if (!$entity instanceof EntityInterface) {
@@ -106,7 +113,7 @@ class EditorBlocks extends DataProducerPluginBase {
 
     $field->setContextValue('ignored_editor_blocks', $ignored);
 
-    return EditorBlocksProcessor::processsIgnoredBlocks($result, $ignored);
+    return EditorBlocksProcessor::aggregateParagraphs(EditorBlocksProcessor::processsIgnoredBlocks($result, $ignored), $aggregated);
   }
 
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
@@ -509,7 +509,8 @@ class SilverbackGatsbySchemaExtension extends SdlSchemaExtensionPluginBase
             'type' => $builder->callback(
               fn(EntityInterface $entity) => $entity->getTypedData()->getDataDefinition()->getDataType()
             ),
-            'ignored' => $builder->fromValue($definition['arguments']['ignore'] ?? [])
+            'ignored' => $builder->fromValue($definition['arguments']['ignore'] ?? []),
+            'aggregated' => $builder->fromValue($definition['arguments']['aggregate'] ?? ['core/paragraph'])
           ]));
           break;
 

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EditorBlocksTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EditorBlocksTest.php
@@ -58,12 +58,18 @@ class EditorBlocksTest extends EntityFeedTestBase {
     $media->save();
 
     $serializer = new BlockSerializer();
-    $blocks = [[
-      'blockName' => 'custom/text',
-      'innerContent' => ['<p>A test paragraph</p>', '<p>Another test paragraph</p>'],
+    $blocks = [
+      [
+      'blockName' => 'core/paragraph',
+      'innerContent' => ['<p>A test paragraph</p>'],
       'attrs' => [],
       'innerBlocks' => [],
-    ],
+    ], [
+        'blockName' => 'core/list',
+        'innerContent' => ['<p>Another test paragraph</p>'],
+        'attrs' => [],
+        'innerBlocks' => [],
+      ],
       [
         'blockName' => 'core/group',
         'attrs' => [],
@@ -83,13 +89,13 @@ class EditorBlocksTest extends EntityFeedTestBase {
             'attrs' => [],
             'innerBlocks' => [
               [
-                'blockName' => 'custom/text',
+                'blockName' => 'core/paragraph',
                 'innerContent' => ['<p>First column</p>'],
                 'attrs' => [],
                 'innerBlocks' => [],
               ],
               [
-                'blockName' => 'custom/text',
+                'blockName' => 'core/paragraph',
                 'innerContent' => ['<p>Second column</p>'],
                 'attrs' => [],
                 'innerBlocks' => [],
@@ -142,9 +148,6 @@ class EditorBlocksTest extends EntityFeedTestBase {
               [
                 '__typename' => 'Text',
               ],
-              [
-                '__typename' => 'Text',
-              ],
             ],
             '_original_typename' => 'Columns',
           ],
@@ -170,9 +173,6 @@ class EditorBlocksTest extends EntityFeedTestBase {
           [
             '__typename' => 'Columns',
             'columns' => [
-              [
-                '__typename' => 'Text',
-              ],
               [
                 '__typename' => 'Text',
               ],

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Unit/EditorBlocksProcessorTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Unit/EditorBlocksProcessorTest.php
@@ -78,4 +78,59 @@ class EditorBlocksProcessorTest extends UnitTestCase {
     );
   }
 
+  public function testTextAggregation() {
+    $input = [
+      [
+        'blockName' => 'core/paragraph',
+        'innerHTML' => '<p>A</p>',
+      ],
+      [
+        'blockName' => 'core/paragraph',
+        'innerHTML' => '<p>B</p>',
+      ],
+      [
+        'blockName' => 'custom/a',
+        'innerBlocks' => [
+
+          [
+            'blockName' => 'core/paragraph',
+            'innerHTML' => '<p>C</p>',
+          ],
+          [
+            'blockName' => 'core/list',
+            'innerHTML' => '<p>D</p>',
+          ],
+        ]
+      ],
+      [
+        'blockName' => 'core/paragraph',
+        'innerHTML' => '<p>E</p>',
+      ],
+    ];
+
+    $expected = [
+      [
+        'blockName' => 'core/paragraph',
+        'innerHTML' => '<p>A</p><p>B</p>',
+      ],
+      [
+        'blockName' => 'custom/a',
+        'innerBlocks' => [
+          [
+            'blockName' => 'core/paragraph',
+            'innerHTML' => '<p>C</p><p>D</p>',
+          ],
+        ]
+      ],
+      [
+        'blockName' => 'core/paragraph',
+        'innerHTML' => '<p>E</p>',
+      ],
+    ];
+    $this->assertEquals(
+      $expected,
+      EditorBlocksProcessor::aggregateParagraphs($input, ['core/paragraph', 'core/list']),
+    );
+  }
+
 }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

* Multiple subsequent `core/paragraph` blocks are now concatenated into one with content of the whole chain.
* Allows to define which other block types are treated the same way (e.g. `core/list` or `core/table`). those will effectively be merged into a `core/paragraph` block

## Motivation and context

* reduce unnecessary document complexity and parsing operations
* align with expectations in the frontend that "free text area" is one block, not one for every line
* simplify spacing of html content blocks in the frontend

## How has this been tested?

* unit tests
* GraphQL kernel tests