### PR TITLE
fix(gutenberg): fix language context document resolution

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/EditorBlockMedia.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/EditorBlockMedia.php
@@ -43,8 +43,9 @@ class EditorBlockMedia extends DataProducerPluginBase {
       \Drupal::logger('graphql_gutenberg')->notice("Cannot load media by ID '{$mediaId}'");
       return NULL;
     }
-    if ($media->hasTranslation($field->getContextLanguage())) {
-      $media = $media->getTranslation($field->getContextLanguage());
+    $documentLanguage = $field->getContextValue('document_language');
+    if ($media->hasTranslation($documentLanguage)) {
+      $media = $media->getTranslation($documentLanguage);
     }
     if ($media) {
       $field->addCacheableDependency($media);

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/EditorBlocks.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/EditorBlocks.php
@@ -60,7 +60,7 @@ class EditorBlocks extends DataProducerPluginBase {
     if (!$entity instanceof EntityInterface) {
       throw new LogicException('Editor blocks can only be retrieved from Entities');
     }
-    $field->setContextLanguage($entity->language()->getId());
+    $field->setContextValue('document_language', $entity->language()->getId());
     if (!($entity instanceof TypedDataInterface) && !empty($type)) {
       $manager = $this->getTypedDataManager();
       $definition = $manager->createDataDefinition($type);


### PR DESCRIPTION

## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

Fix language context handling while parsing editor blocks.

`setContextLanguage` sets the whole execution language. use `setContextValue` instead.
