### PR TITLE
feat: show live/preview version on node page in Drupal

### DIFF
--- a/packages/composer/amazeelabs/silverback_external_preview/modules/silverback_external_preview_example/silverback_external_preview_example.module
+++ b/packages/composer/amazeelabs/silverback_external_preview/modules/silverback_external_preview_example/silverback_external_preview_example.module
@@ -27,7 +27,7 @@ function silverback_external_preview_example_silverback_external_preview_url_alt
   if($routeMatch->getRouteName() === 'system.admin_content') {
     /* @var $externalPreviewUrl ExternalPreviewLink */
     $externalPreviewUrl = Drupal::service('silverback_external_preview.external_preview_link');
-    $url = $externalPreviewUrl->createPreviewlUrlFromPath('/');
+    $url = $externalPreviewUrl->createPreviewUrlFromPath('/');
   }
 
 }

--- a/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.info.yml
+++ b/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.info.yml
@@ -2,7 +2,7 @@ name: Silverback External Preview
 description: Provides a UI to preview pages on external websites.
 package: Silverback
 type: module
-core_version_requirement: ^8.8.0 || ^9.0
+core_version_requirement: ^8 || ^9
 dependencies:
-- path_alias:path_alias
-
+  - drupal:link
+  - drupal:path_alias

--- a/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
+++ b/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
@@ -4,6 +4,9 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Url;
 use Drupal\silverback_external_preview\ExternalPreviewLink;
 use Drupal\Component\Serialization\Json;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\silverback_external_preview\Field\ComputedExternalPreviewLinkItemList;
 
 /**
  * Implements hook_toolbar().
@@ -91,6 +94,40 @@ function silverback_external_preview_theme() {
       'sizes' => [],
     ],
   ];
+  $theme['silverback_external_preview_iframe'] = [
+    'variables' => [
+      'preview_url' => NULL,
+      'live_url' => NULL,
+      'view_live_link' => NULL,
+      'width' => NULL,
+      'height' => NULL,
+      'class' => NULL,
+    ],
+  ];
   return $theme;
 }
 
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function silverback_external_preview_entity_base_field_info(EntityTypeInterface $entity_type) {
+  $fields = [];
+  // Can be extended by other entity types when needed.
+  if ($entity_type->id() === 'node') {
+    $fields['external_preview_link'] = BaseFieldDefinition::create('link')
+      ->setName('external_preview_link')
+      ->setLabel(t('External Preview'))
+      ->setComputed(TRUE)
+      ->setTranslatable(TRUE)
+      ->setReadOnly(TRUE)
+      ->setClass(ComputedExternalPreviewLinkItemList::class)
+      ->setCardinality(1)
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayOptions('view', [
+        'label' => 'hidden',
+        'type' => 'external_preview_iframe_formatter',
+        'weight' => -5,
+      ]);
+  }
+  return $fields;
+}

--- a/packages/composer/amazeelabs/silverback_external_preview/src/ExternalPreviewLink.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/src/ExternalPreviewLink.php
@@ -3,6 +3,7 @@
 namespace Drupal\silverback_external_preview;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\RevisionableStorageInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
@@ -125,12 +126,70 @@ class ExternalPreviewLink {
    * @param ContentEntityInterface $entity
    * @param string $external_url_type
    *
-   * @return \Drupal\Core\Url
+   * @return \Drupal\Core\Url|null
    */
   public function createPreviewUrlFromEntity(ContentEntityInterface $entity, $external_url_type = 'preview') {
-    $base_url = $external_url_type === 'preview' ? $this->getPreviewBaseUrl() : $this->getLiveBaseUrl();
-    $path = $entity->toUrl('canonical')->toString(TRUE)->getGeneratedUrl();
-    return Url::fromUri($base_url . $path, $this->getUrlOptions($external_url_type, $entity));
+    if ($this->isNodeRevisionRoute()) {
+      return $this->getLatestRevisionPreviewUrlFromEntity($entity);
+    }
+    else {
+      $base_url = $external_url_type === 'preview' ? $this->getPreviewBaseUrl() : $this->getLiveBaseUrl();
+      $path = $entity->toUrl('canonical')->toString(TRUE)->getGeneratedUrl();
+      return Url::fromUri($base_url . $path, $this->getUrlOptions($external_url_type, $entity));
+    }
+  }
+
+  public function isNodeRevisionRoute() {
+    $route_name = \Drupal::routeMatch()->getRouteName();
+    $node_revision_routes = [
+      'entity.node.revision',
+      'entity.node.latest_version',
+    ];
+    return in_array($route_name, $node_revision_routes);
+  }
+
+  private function getLatestRevisionPreviewUrlFromEntity(ContentEntityInterface $entity) {
+    $entity_type_id = $entity->getEntityTypeId();
+    $storage = $this->entityTypeManager->getStorage($entity_type_id);
+    if (!$storage instanceof RevisionableStorageInterface) {
+      return NULL;
+    }
+
+    // Revision preview Url needs a UI, so assume that
+    // content moderation is installed and moderation information service
+    // is available.
+    if (!\Drupal::hasService('content_moderation.moderation_information')) {
+      return NULL;
+    }
+
+    /** @var \Drupal\content_moderation\ModerationInformationInterface $contentModerationInformation */
+    $content_moderation_information = \Drupal::service('content_moderation.moderation_information');
+    if (!$content_moderation_information->isModeratedEntity($entity)) {
+      return NULL;
+    }
+
+    $route_match = \Drupal::routeMatch();
+    if ($route_match->getRouteName() === 'entity.node.revision') {
+      /** @var \Drupal\node\NodeInterface $node_revision */
+      $revision = $route_match->getParameter('node_revision');
+      $revision_id = $revision->getRevisionId();
+    }
+    elseif ($route_match->getRouteName() === 'entity.node.latest_version') {
+      $revision_id = $storage->getLatestRevisionId($entity->id());
+    }
+    else {
+      return NULL;
+    }
+
+    return Url::fromUri(
+      $this->getPreviewBaseUrl() . '/' . $entity->bundle(),
+      [
+        'query' => [
+          'id' => $entity->id(),
+          'revision' => $revision_id,
+        ]
+      ]
+    );
   }
 
   private function getUrlOptions($external_url_type = 'preview', ContentEntityInterface $entity = NULL) {

--- a/packages/composer/amazeelabs/silverback_external_preview/src/ExternalPreviewLink.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/src/ExternalPreviewLink.php
@@ -182,7 +182,7 @@ class ExternalPreviewLink {
     }
 
     return Url::fromUri(
-      $this->getPreviewBaseUrl() . '/' . $entity->bundle(),
+      $this->getPreviewBaseUrl() . '/__preview/' . $entity->bundle(),
       [
         'query' => [
           'id' => $entity->id(),

--- a/packages/composer/amazeelabs/silverback_external_preview/src/Field/ComputedExternalPreviewLinkItemList.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/src/Field/ComputedExternalPreviewLinkItemList.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\silverback_external_preview\Field;
+
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+
+class ComputedExternalPreviewLinkItemList extends FieldItemList {
+
+  use ComputedItemListTrait;
+
+  /**
+   * @inheritDoc
+   */
+  protected function computeValue() {
+    $entity = $this->getEntity();
+    if ($entity->isNew()) {
+      return;
+    }
+    /** @var \Drupal\silverback_external_preview\ExternalPreviewLink $externalPreviewLink */
+    $externalPreviewLink = \Drupal::service('silverback_external_preview.external_preview_link');
+    $uri = $externalPreviewLink->createPreviewUrlFromEntity($entity)->toString();
+    $items = [];
+    $items[] = [
+      'uri' => $uri,
+      'title' => $this->t('Preview @label', [
+        '@label' => $entity->label(),
+      ]),
+    ];
+    foreach ($items as $delta => $item) {
+      $this->list[] = $this->createItem($delta, $item);
+    }
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_external_preview/src/Plugin/Field/FieldFormatter/ExternalPreviewIframeFormatter.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/src/Plugin/Field/FieldFormatter/ExternalPreviewIframeFormatter.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\silverback_external_preview\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\link\Plugin\Field\FieldFormatter\LinkFormatter;
+
+/**
+ * External preview Iframe formatter.
+ *
+ * @FieldFormatter(
+ *   id = "external_preview_iframe_formatter",
+ *   label = @Translation("Iframe"),
+ *   field_types = {
+ *     "link"
+ *   }
+ * )
+ */
+class ExternalPreviewIframeFormatter extends LinkFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'width' => '100%',
+      'height' => 900,
+      'class' => 'external-preview-iframe',
+      'view_live_link' => TRUE,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $elements['width'] = [
+      '#title' => $this->t('Width'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('width'),
+      '#required' => TRUE,
+    ];
+    $elements['height'] = [
+      '#title' => $this->t('Height'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('height'),
+      '#required' => TRUE,
+    ];
+    $elements['class'] = [
+      '#title' => $this->t('Class'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('class'),
+      '#required' => FALSE,
+    ];
+    $elements['view_live_link'] = [
+      '#title' => $this->t('View live link'),
+      '#type' => 'radios',
+      '#options' => [
+        TRUE => $this->t('Yes'),
+        FALSE => $this->t('No'),
+      ],
+      '#default_value' => $this->getSetting('view_live_link'),
+      '#required' => FALSE,
+    ];
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    $summary[] = $this->t('Width: @width, Height: @height, Class: @class, View live link: @view_live_link', [
+      '@width' => $this->getSetting('width'),
+      '@height' => $this->getSetting('height'),
+      '@class' => $this->getSetting('class') == '' ? 'none' : $this->getSetting('class'),
+      '@view_live_link' => $this->getSetting('view_live_link') ? $this->t('Yes') : $this->t('No'),
+    ]);
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $element = [];
+    $settings = $this->getSettings();
+    foreach ($items as $delta => $item) {
+      // Preview url, computed field value.
+      $previewUrl = $this->buildUrl($item);
+
+      // Live url.
+      $entity = $item->getEntity();
+      /** @var \Drupal\silverback_external_preview\ExternalPreviewLink $externalPreviewLink */
+      $externalPreviewLink = \Drupal::service('silverback_external_preview.external_preview_link');
+      $liveUrl = $externalPreviewLink->createPreviewUrlFromEntity($entity, 'live')->toString();
+      $element[$delta] = [
+        '#theme' => 'silverback_external_preview_iframe',
+        '#preview_url' => $previewUrl,
+        '#live_url' => $liveUrl,
+        '#view_live_link' => $settings['view_live_link'],
+        '#width' => $settings['width'],
+        '#height' => $settings['height'],
+        '#class' => $settings['class'],
+      ];
+    }
+    return $element;
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_external_preview/src/Plugin/Field/FieldFormatter/ExternalPreviewIframeFormatter.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/src/Plugin/Field/FieldFormatter/ExternalPreviewIframeFormatter.php
@@ -99,7 +99,7 @@ class ExternalPreviewIframeFormatter extends LinkFormatter {
         '#theme' => 'silverback_external_preview_iframe',
         '#preview_url' => $previewUrl,
         '#live_url' => $liveUrl,
-        '#view_live_link' => $settings['view_live_link'],
+        '#view_live_link' => !$externalPreviewLink->isNodeRevisionRoute() && $settings['view_live_link'],
         '#width' => $settings['width'],
         '#height' => $settings['height'],
         '#class' => $settings['class'],

--- a/packages/composer/amazeelabs/silverback_external_preview/templates/silverback-external-preview-iframe.html.twig
+++ b/packages/composer/amazeelabs/silverback_external_preview/templates/silverback-external-preview-iframe.html.twig
@@ -1,0 +1,6 @@
+{% if view_live_link %}
+  <div class="external-preview-iframe-link">{{ 'Live link:'|t }}
+    <a href="{{ live_url }}" target="_blank">{{ live_url }}</a>
+  </div>
+{% endif %}
+<iframe width="{{ width }}" height="{{ height }}" src="{{ preview_url }}" class="{{ class }}" allowfullscreen></iframe>


### PR DESCRIPTION
## Package(s) involved

silverback_external_preview

## Description of changes

Adds preview iframe and live link to the node view, latest revision and revision routes.

## Motivation and context/Related Issue(s)

#1062 

## How has this been tested?

Manually.
