### PR TITLE
fix: php fatal error because on invalid url argument

### DIFF
--- a/packages/composer/amazeelabs/silverback_external_preview/src/ExternalPreviewLink.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/src/ExternalPreviewLink.php
@@ -117,7 +117,7 @@ class ExternalPreviewLink {
    */
   public function createPreviewUrlFromPath(string $path, $external_url_type = 'preview') {
     $base_url = $external_url_type === 'preview' ? $this->getPreviewBaseUrl() : $this->getLiveBaseUrl();
-    return Url::fromUri($base_url . $path, $this->getUrlOptions($external_url_type));
+    return Url::fromUserInput($base_url . $path, $this->getUrlOptions($external_url_type));
   }
 
   /**
@@ -135,7 +135,7 @@ class ExternalPreviewLink {
     else {
       $base_url = $external_url_type === 'preview' ? $this->getPreviewBaseUrl() : $this->getLiveBaseUrl();
       $path = $entity->toUrl('canonical')->toString(TRUE)->getGeneratedUrl();
-      return Url::fromUri($base_url . $path, $this->getUrlOptions($external_url_type, $entity));
+      return Url::fromUserInput($base_url . $path, $this->getUrlOptions($external_url_type, $entity));
     }
   }
 

--- a/packages/composer/amazeelabs/silverback_external_preview/src/Field/ComputedExternalPreviewLinkItemList.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/src/Field/ComputedExternalPreviewLinkItemList.php
@@ -19,7 +19,7 @@ class ComputedExternalPreviewLinkItemList extends FieldItemList {
     }
     /** @var \Drupal\silverback_external_preview\ExternalPreviewLink $externalPreviewLink */
     $externalPreviewLink = \Drupal::service('silverback_external_preview.external_preview_link');
-    $uri = $externalPreviewLink->createPreviewUrlFromEntity($entity)->toString();
+    $uri = $externalPreviewLink->createPreviewUrlFromEntity($entity)->toUriString();
     $items = [];
     $items[] = [
       'uri' => $uri,


### PR DESCRIPTION
## Package(s) involved

silverback_external_preview

## Description of changes

Fix for a fatal error because of an invalid function argument when creating a Url object.
The error: "Auf der Website ist ein unvorhergesehener Fehler aufgetreten. Bitte versuchen Sie es später nochmal."
And from the logs table: "

InvalidArgumentException: The URI '/de/news/test-after-update' is invalid. You must use a valid URI scheme. in Drupal\Core\Url::fromUri() (Zeile 293 in /Users/vasile.chindris/Sites/nuklear9/apps/cms/web/core/lib/Drupal/Core/Url.php).
--"