### PR TITLE
fix: only redirect to path alias if the response is 200

### DIFF
--- a/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
@@ -63,7 +63,7 @@ class CdnRedirectController extends ControllerBase {
         ($parts['path'] ?? '') .
         (isset($parts['query']) ? "?{$parts['query']}" : '');
       $responseCode = $response->getStatusCode();
-    } else {
+    } elseif ($response->getStatusCode() === 200) {
       // If the returned response is not a redirect, we still want to check if
       // there is a path alias for the current path. If it exists, then we
       // should redirect to it.


### PR DESCRIPTION
## Package(s) involved

silverback_cdn_redirect

## Motivation and context

There was a bug on a project: It was redirecting to frontpage in case if response is 404.

## How has this been tested?

Locally.
