### PR TITLE
feat: preview url for unpublished entities

### DIFF
--- a/packages/composer/amazeelabs/silverback_external_preview/modules/silverback_external_preview_example/silverback_external_preview_example.module
+++ b/packages/composer/amazeelabs/silverback_external_preview/modules/silverback_external_preview_example/silverback_external_preview_example.module
@@ -2,6 +2,8 @@
 
 use Drupal\file\Entity\File;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Url;
 use Drupal\silverback_external_preview\ExternalPreviewLink;
 
 // Example to add a query parameter
@@ -30,4 +32,12 @@ function silverback_external_preview_example_silverback_external_preview_url_alt
     $url = $externalPreviewUrl->createPreviewUrlFromPath('/');
   }
 
+}
+
+// Example to rewrite based on custom path rules.
+function silverback_external_preview_example_silverback_external_preview_entity_url_alter(ContentEntityInterface $entity, Url &$url) {
+  $uri = $url->getUri();
+  $altered_uri = preg_replace('/home-[a-z]*$/', '', $uri);
+  $altered_url_string = str_replace($uri, $altered_uri, $url->toString());
+  $url = Url::fromUri($altered_url_string);
 }

--- a/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.api.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.api.php
@@ -1,6 +1,8 @@
 <?php
 
-use \Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
 
 function hook_silverback_external_preview_url_alter(RouteMatchInterface $routeMatch, &$url) {
   // For example, turn $url into a direct file link.
@@ -11,4 +13,8 @@ function hook_silverback_external_preview_url_alter(RouteMatchInterface $routeMa
     $file = File::load($fid);
     $url = $file->createFileUrl();
   }
+}
+
+function hook_silverback_external_preview_entity_url_alter(ContentEntityInterface $entity, Url &$url) {
+  // Alters entity preview url.
 }

--- a/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
+++ b/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
@@ -2,7 +2,6 @@
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Url;
-use Drupal\silverback_external_preview\ExternalPreviewLink;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -14,7 +13,7 @@ use Drupal\silverback_external_preview\Field\ComputedExternalPreviewLinkItemList
 function silverback_external_preview_toolbar() {
 
   $toolbar_items = [];
-  /* @var ExternalPreviewLink */
+  /** @var \Drupal\silverback_external_preview\ExternalPreviewLink $externalPreviewLink */
   $externalPreviewLink = Drupal::service('silverback_external_preview.external_preview_link');
   if (getenv('EXTERNAL_PREVIEW_BASE_URL')) {
     $routeMatch = Drupal::routeMatch();
@@ -23,8 +22,8 @@ function silverback_external_preview_toolbar() {
     // Only add the toolbar item if we have a preview URL returned
     $params = $routeMatch->getParameters()->all();
     $entity = array_pop($params);
-    if($entity instanceof ContentEntityInterface){
-      $id = $url ? $entity->getEntityTypeId() . ':' . $entity->id() . ':'. $entity->get('langcode')->value : null;
+    if ($entity instanceof ContentEntityInterface){
+      $id = $url ? $externalPreviewLink->getEntityTempStoreId($entity) : NULL;
     }
     $toolbar_items['silverback_external_preview'] = [
       '#type' => 'toolbar_item',

--- a/packages/composer/amazeelabs/silverback_external_preview/src/Plugin/Field/FieldFormatter/ExternalPreviewIframeFormatter.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/src/Plugin/Field/FieldFormatter/ExternalPreviewIframeFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\silverback_external_preview\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\link\Plugin\Field\FieldFormatter\LinkFormatter;
@@ -113,12 +114,21 @@ class ExternalPreviewIframeFormatter extends LinkFormatter {
         '#theme' => 'silverback_external_preview_iframe',
         '#preview_url' => $previewUrl,
         '#live_url' => $liveUrl,
-        '#view_live_link' => !$externalPreviewLink->isNodeRevisionRoute() && $settings['view_live_link'],
+        '#view_live_link' => $this->viewLiveLink($entity, $settings) ,
         '#width' => $settings['width'],
         '#height' => $settings['height'],
       ];
     }
     return $elements;
+  }
+
+  private function viewLiveLink(ContentEntityInterface $entity, array $settings) {
+    /** @var \Drupal\silverback_external_preview\ExternalPreviewLink $externalPreviewLink */
+    $externalPreviewLink = \Drupal::service('silverback_external_preview.external_preview_link');
+    return
+      !$externalPreviewLink->isNodeRevisionRoute() &&
+      !$externalPreviewLink->isUnpublished($entity) &&
+      $settings['view_live_link'];
   }
 
   private function isPublisherRunning(string $preview_base_url) {


### PR DESCRIPTION
## Package(s) involved

`silverback_external_preview`

## Description of changes

1. Adds preview url for unpublished entities to be used by the iframe formatter
2. Adds `hook_silverback_external_preview_entity_url_alter()`
3. Fixes an issue for entities that have no langcode

## Motivation and context

1. View unpublished entities with the iframe preview
2. Alter entity url can be used when there are custom rewrite rules, so the same logic can be applied in the hook
3. The langcode bug can occur when entities have no langcode or the langcode is empty, it happened on a project when deleting a language neutral redirect. 

Possible follow-up: use unified method to alter the preview from the toolbar by using the entity link from the route context.

## How has this been tested?

Manually.