### PR TITLE
fix: add timeout to graphql executor

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
@@ -20,5 +20,6 @@ export const createQueryExecutor = (
         : {}),
       ...(authKey ? { 'api-key': authKey } : {}),
     },
+    timeout: 60_000,
   });
 };


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/gatsby-source-silverback`

## Description of changes

Added a one minute timeout to GraphQL requests.

If a request cannot be finished in the given time, `gatsby build` will fail. At least this is the behavior I saw locally when simulated endless requests.

## Motivation and context

If a request gets stuck for some reason, the build never finishes.

## How has this been tested?

Tested locally. Works.
