### PR TITLE
fix: make external preview computed field private by default

### DIFF
--- a/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
+++ b/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
@@ -28,7 +28,7 @@ function silverback_external_preview_toolbar() {
     $toolbar_items['silverback_external_preview'] = [
       '#type' => 'toolbar_item',
       '#cache' => [
-        'contexts' => ['url', 'user:role'],
+        'contexts' => ['url', 'user:roles'],
         'tags' => ['role'],
       ],
       '#wrapper_attributes' => [

--- a/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
+++ b/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
@@ -11,11 +11,11 @@ use Drupal\silverback_external_preview\Field\ComputedExternalPreviewLinkItemList
  * Implements hook_toolbar().
  */
 function silverback_external_preview_toolbar() {
-
   $toolbar_items = [];
   /** @var \Drupal\silverback_external_preview\ExternalPreviewLink $externalPreviewLink */
   $externalPreviewLink = Drupal::service('silverback_external_preview.external_preview_link');
-  if (getenv('EXTERNAL_PREVIEW_BASE_URL')) {
+  $currentUser = \Drupal::currentUser();
+  if (getenv('EXTERNAL_PREVIEW_BASE_URL') && $currentUser->hasPermission('use external preview')) {
     $routeMatch = Drupal::routeMatch();
     /* @var $url Url */
     $url = $externalPreviewLink->getPreviewUrl($routeMatch);
@@ -28,7 +28,8 @@ function silverback_external_preview_toolbar() {
     $toolbar_items['silverback_external_preview'] = [
       '#type' => 'toolbar_item',
       '#cache' => [
-        'contexts' => ['url'],
+        'contexts' => ['url', 'user:role'],
+        'tags' => ['role'],
       ],
       '#wrapper_attributes' => [
         'class' => [

--- a/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.permissions.yml
+++ b/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.permissions.yml
@@ -1,0 +1,2 @@
+use external preview:
+  title: 'Use the external preview'

--- a/packages/composer/amazeelabs/silverback_external_preview/src/Plugin/Field/FieldFormatter/ExternalPreviewIframeFormatter.php
+++ b/packages/composer/amazeelabs/silverback_external_preview/src/Plugin/Field/FieldFormatter/ExternalPreviewIframeFormatter.php
@@ -79,6 +79,15 @@ class ExternalPreviewIframeFormatter extends LinkFormatter {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
+    $elements['#cache']['contexts'] = ['user.roles'];
+    $elements['#cache']['tags'] = ['role'];
+    $currentUser = \Drupal::currentUser();
+    // Do not display the field by default as the result could be indexed
+    // by e.g. Search api.
+    if (!$currentUser->hasPermission('use external preview')) {
+      return $elements;
+    }
+
     $settings = $this->getSettings();
     // If items turns out to be empty, this denotes an error
     // on the computed field. Do not cache the output so the error


### PR DESCRIPTION
## Package(s) involved

`silverback_external_preview`

## Description of changes

Makes the external preview computed field private by default.
By extension, as we are introducing a new permission, also use it for the toolbar.
Initially, i was thinking about checking if the user is authenticated, but there could be use cases where we want to use a permission for that (e.g. webforms for authenticated users).

## Motivation and context

Can be displayed on the frontend when using entity Drupal rendering.

## Related Issue(s)

#1103 

## How has this been tested?

Manually.