### PR TITLE
feat: allow React components in organism props

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/atomic.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/atomic.tsx
@@ -17,6 +17,7 @@ export type Primitive =
   | undefined
   | boolean
   | Date
+  | React.FC
   | Html
   | Link
   | Image


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/react-framework-bridge`

## How has this been tested?

Not tested.
