### PR TITLE
fix: include unpublished entities in the diff

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
@@ -4,6 +4,7 @@ namespace Drupal\silverback_gatsby\Plugin\Gatsby\Feed;
 
 use Drupal\content_translation\ContentTranslationManagerInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -107,7 +108,10 @@ class EntityFeed extends FeedBase implements ContainerFactoryPluginInterface {
       $context instanceof EntityInterface
       && $context->getEntityTypeId() === $this->type
       && ($this->bundle !== NULL && $context->bundle() === $this->bundle)
-      && $context->access('view', $account)
+      &&  (
+        $context->access('view', $account) ||
+        $context instanceof EntityPublishedInterface && $context->isPublished() === FALSE
+      )
     ) {
       if ($this->isTranslatable() && $context instanceof TranslatableInterface) {
         return array_map(function (LanguageInterface $lang) use ($context) {


### PR DESCRIPTION
## Package(s) involved

`silverback_gatsby`

## Description of changes

Add, to the entity access condition, a condition that checks if the entity is publishable and if it is unpublished.

## Motivation and context

Unpublishing an entity can lead to not have it in the diff for Gatsby sourcing, so it will not increment the drupalBuildId and not be part of the changes. This can be checked with.

```
{
  drupalBuildId
  drupalFeedInfo {
    typeName
    changes(lastBuild: [last_id], currentBuild: [current_id])
  }
}
```
## How has this been tested?

Manually.