### PR TITLE
fix: remove mergeLinkHeaders from gatsby-plugin-netlify options

### DIFF
--- a/packages/npm/@amazeelabs/recipes/recipes/add-gatsby.ts.md
+++ b/packages/npm/@amazeelabs/recipes/recipes/add-gatsby.ts.md
@@ -176,7 +176,6 @@ $$.file('gatsby-config.ts', (lines: Array<string>) => {
     {
       resolve: 'gatsby-plugin-netlify',
       options: {
-        mergeLinkHeaders: false,
         mergeCachingHeaders: false,
       },
     },


### PR DESCRIPTION
## Package(s) involved

`recipes`

## Description of changes

Remove `mergeLinkHeaders` from `gatsby-plugin-netlify` options

## Motivation and context

Throws on `add-gatsby` recipe

> "mergeLinkHeaders" is no longer supported. Gatsby no longer adds preload headers as they negatively
affect load performance

## How has this been tested?

Manually