### PR TITLE
LinkProcessor: local hosts

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -14,3 +14,4 @@
 /dictionaries
 /markdown.xml
 /misc.xml
+/inspectionProfiles/profiles_settings.xml

--- a/packages/composer/amazeelabs/silverback_gutenberg/config/install/silverback_gutenberg.settings.yml
+++ b/packages/composer/amazeelabs/silverback_gutenberg/config/install/silverback_gutenberg.settings.yml
@@ -1,0 +1,1 @@
+local_hosts: []

--- a/packages/composer/amazeelabs/silverback_gutenberg/config/schema/silverback_gutenberg.schema.yml
+++ b/packages/composer/amazeelabs/silverback_gutenberg/config/schema/silverback_gutenberg.schema.yml
@@ -1,0 +1,11 @@
+silverback_gutenberg.settings:
+  type: config_object
+  label: 'Silverback Gutenberg settings'
+  mapping:
+    local_hosts:
+      type: sequence
+      nullable: true
+      label: 'URLs with these hosts will be turned to relative. If null, any absolute URLs will NOT be processed (BC behavior).'
+      sequence:
+        type: string
+        label: 'Host'

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/LinkProcessorTest.php
@@ -46,6 +46,10 @@ class LinkProcessorTest extends MediaKernelTestBase {
     $this->installConfig(['language']);
     ConfigurableLanguage::createFromLangcode('de')->save();
 
+    $this->config('silverback_gutenberg.settings')
+      ->set('local_hosts', null)
+      ->save();
+
     // Let LanguageServiceProvider register its path processors.
     drupal_flush_all_caches();
   }


### PR DESCRIPTION
## Package(s) involved

`silverback_gutenberg`

## Description of changes

Added `local_hosts` setting. If the setting is `null` (existing projects), the link processing behavior remains the same. If it's an array (new projects), absolute links linking "local" hosts will be turned to relative.

Example usage in `settings.php`:
```php
$config['silverback_gutenberg.settings']['local_hosts'] = [
  'example.com',
  'www.example.com',
  'stage.example.com',
];
```

## Motivation and context

Editors copy absolute URLs from browser address bar. 

## How has this been tested?

Extended unit tests. The BC behavior is tested only in the `feat` commit. I decided it makes too little sense to add a new "BC/non-BC" dimension to tests.
