### PR TITLE
Context support for mappers

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/atomic.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/atomic.test.tsx
@@ -458,7 +458,7 @@ describe('createMapper', () => {
       },
     ];
 
-    expect(mapper(input)).toMatchInlineSnapshot(`
+    expect(mapper(input, 'some other context')).toMatchInlineSnapshot(`
       Array [
         Object {
           "input": Object {
@@ -477,12 +477,12 @@ describe('createMapper', () => {
     expect(mappingFunction).toHaveBeenCalledTimes(2);
     expect(mappingFunction).toHaveBeenNthCalledWith(1, input[0], {
       items: [input[0], input[2]],
-      payload: 'some context',
+      payload: 'some other context',
       index: 0,
     });
     expect(mappingFunction).toHaveBeenNthCalledWith(2, input[2], {
       items: [input[0], input[2]],
-      payload: 'some context',
+      payload: 'some other context',
       index: 1,
     });
   });

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/atomic.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/atomic.tsx
@@ -103,7 +103,7 @@ export function createMapper<
   TKey extends string = string,
   TContext extends any = any,
 >(mappers: Mappers<TContext, TInput, TOptions>, context?: TContext) {
-  return function (input: TInput) {
+  return function (input: TInput, contextOverride?: TContext) {
     const filtered = input.filter((item) => {
       if (isUndefined(item)) {
         return false;
@@ -118,7 +118,7 @@ export function createMapper<
       // @ts-ignore
       return mappers[item.__typename]!(item, {
         items: filtered,
-        payload: context,
+        payload: contextOverride || context,
         index,
       });
     });


### PR DESCRIPTION
Add context support to the `createMapper` helper. An optional second parameter defines a context payload that will be passed to each mapping function, along with the total item list and the current index.

That should simplify some scenarios that are currently solved with pre-processing lists or higher order functions to provide context values.

For details please refer to the new test cases.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)