### PR TITLE
feat: improved error handling for graphql requests

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
@@ -1,5 +1,7 @@
-import { createDefaultQueryExecutor } from 'gatsby-graphql-source-toolkit';
-import { RequestInit } from 'node-fetch';
+import { wrapQueryExecutorWithQueue } from 'gatsby-graphql-source-toolkit';
+import { IQueryExecutor } from 'gatsby-graphql-source-toolkit/dist/types';
+import fetch, { RequestInit } from 'node-fetch';
+import { inspect } from 'util';
 
 export const createQueryExecutor = (
   url: string,
@@ -8,7 +10,7 @@ export const createQueryExecutor = (
   authKey?: string,
   headers?: RequestInit['headers'],
 ) => {
-  return createDefaultQueryExecutor(url, {
+  const executor = createNetworkQueryExecutor(url, {
     headers: {
       ...headers,
       ...(authUser && authPass
@@ -22,4 +24,55 @@ export const createQueryExecutor = (
     },
     timeout: 60_000,
   });
+  return wrapQueryExecutorWithQueue(executor, { concurrency: 10 });
 };
+
+// Copy of the default network query executor from gatsby-graphql-source-toolkit
+// package with improved error handling.
+// https://github.com/gatsbyjs/gatsby-graphql-toolkit/blob/7ba8b24d8524254dc6c2853d6d014070befd9aea/src/config/query-executor.ts#L6-L39
+export function createNetworkQueryExecutor(
+  uri: string,
+  fetchOptions: RequestInit = {},
+): IQueryExecutor {
+  return async function execute(args) {
+    const { query, variables, operationName } = args;
+
+    let response;
+    try {
+      response = await fetch(uri, {
+        method: 'POST',
+        body: JSON.stringify({ query, variables, operationName }),
+        ...fetchOptions,
+        headers: {
+          'Content-Type': 'application/json',
+          ...fetchOptions.headers,
+        },
+      });
+    } catch (e) {
+      console.warn(
+        `Query ${operationName} failed.\n` +
+          `Query variables: ${inspect(variables)}\n` +
+          `Full query: ${inspect(query)}\n`,
+      );
+      throw e;
+    }
+    if (!response.ok) {
+      console.warn(
+        `Query ${operationName} returned status ${response.status}.\n` +
+          `Query variables: ${inspect(variables)}\n` +
+          `Full query: ${inspect(query)}\n`,
+      );
+    }
+    const result = await response.json();
+
+    if (result.data && result.errors?.length) {
+      console.warn(
+        `Query ${operationName} returned warnings:\n` +
+          `${inspect(result.errors)}\n` +
+          `Query variables: ${inspect(variables)}\n` +
+          `Full query: ${inspect(query)}\n`,
+      );
+    }
+    return result;
+  };
+}


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/gatsby-source-silverback`

## Motivation and context

When a network timeout happens we have no information to debug the issue. This is all we get:
```
"@amazeelabs/gatsby-source-silverback" threw an error while running the sourceNodes lifecycle:
network timeout at: http://localhost:8888/silverback-gatsby
  FetchError: network timeout at: http://localhost:8888/silverback-gatsby
  - index.js:1484 Timeout.<anonymous>
    [silverback-mono]/[node-fetch]/lib/index.js:1484:13
  - timers:559 listOnTimeout
    node:internal/timers:559:17
  - timers:502 processTimers
    node:internal/timers:502:7
```

## How has this been tested?

Manually. I stopped PHP with xdebug in the middle of Gatsby build. Now we should have more info:
<details>
  <summary>screenshots</summary>
  
  <img width="1136" alt="Screen Shot 2022-08-04 at 12 05 13" src="https://user-images.githubusercontent.com/989015/182814175-d1b112e8-4d7a-452f-828c-a9c3895d9266.png">
<img width="1129" alt="Screen Shot 2022-08-04 at 12 05 26" src="https://user-images.githubusercontent.com/989015/182814199-7bb0bb75-5540-4d35-a6cc-09ccc57c911e.png">
</details>

And of course we have automated tests which check that the query executor works in general. 
