### PR TITLE
fix: add forgotten index to gatsby_update_log table

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.install
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.install
@@ -47,7 +47,71 @@ function silverback_gatsby_schema() {
       ],
     ],
     'primary key' => ['id'],
+    'indexes' => [
+      'server' => ['server'],
+    ],
   ];
 
   return $schema;
+}
+
+/**
+ * Add index to "server" field on the "gatsby_update_log" database table.
+ */
+function silverback_gatsby_update_8001() {
+  $table = 'gatsby_update_log';
+  $tableSpec = [
+    'description' => 'Table that contains logs of all system events.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique update id.',
+      ],
+      'server' => [
+        'type' => 'varchar_ascii',
+        'length' => 64,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The id of the related GraphQL server.',
+      ],
+      'type' => [
+        'type' => 'varchar_ascii',
+        'length' => 64,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The GraphQL type that changed.',
+      ],
+      'object_id' => [
+        'type' => 'varchar_ascii',
+        'length' => 64,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The id of the Graph object that changed.',
+      ],
+      'uid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'The {users}.uid of the user who triggered the update.',
+      ],
+      'timestamp' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Unix timestamp when the update happened.',
+      ],
+    ],
+    'primary key' => ['id'],
+    'indexes' => [
+      'server' => ['server'],
+    ],
+  ];
+  $index = 'server';
+  $indexFields = ['server'];
+  $schema = \Drupal::database()->schema();
+  if (!$schema->indexExists($table, $index)) {
+    $schema->addIndex($table, $index, $indexFields, $tableSpec);
+  }
 }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Motivation and context

DB queries take too long because we filter by `server` field which has no index defined:
https://github.com/AmazeeLabs/silverback-mono/blob/ae7d28633927d17a2087bebee9b79bd01c6c9c59/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTracker.php#L64-L65

## How has this been tested?

Locally, manually.
