### PR TITLE
Improve data fetching

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -32,6 +32,7 @@ export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
     auth_user: Joi.string().optional(),
     auth_pass: Joi.string().optional(),
     auth_key: Joi.string().optional(),
+    query_concurrency: Joi.number().optional(),
   });
 
 const getForwardedHeaders = (url: URL) => ({

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -20,7 +20,7 @@ import { createSourcingConfig } from './helpers/create-sourcing-config';
 import { createTranslationQueryField } from './helpers/create-translation-query-field';
 import { drupalFeeds } from './helpers/drupal-feeds';
 import { fetchNodeChanges } from './helpers/fetch-node-changes';
-import { apiUrl, Options, validOptions } from './utils';
+import { Options, validOptions } from './utils';
 
 export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
   Joi,
@@ -48,15 +48,12 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
     return;
   }
 
-  const executor = createQueryExecutor(
-    apiUrl(options),
-    options.auth_user,
-    options.auth_pass,
-    options.auth_key,
-    options.drupal_external_url
+  const executor = createQueryExecutor({
+    ...options,
+    headers: options.drupal_external_url
       ? getForwardedHeaders(new URL(options.drupal_external_url))
       : undefined,
-  );
+  });
   // TODO: Accept configuration and fragment overrides from plugin settings.
   const config = await createSourcingConfig(gatsbyApi, executor);
   const context = createSourcingContext(config);
@@ -138,25 +135,12 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       return;
     }
 
-    const executor = createQueryExecutor(
-      apiUrl(options),
-      options.auth_user,
-      options.auth_pass,
-      options.auth_key,
-    );
+    const executor = createQueryExecutor(options);
     // TODO: Accept configuration and fragment overrides from plugin settings.
     const config = await createSourcingConfig(args, executor);
     await createToolkitSchemaCustomization(config);
 
-    await createTranslationQueryField(
-      args,
-      createQueryExecutor(
-        apiUrl(options),
-        options.auth_user,
-        options.auth_pass,
-        options.auth_key,
-      ),
-    );
+    await createTranslationQueryField(args, createQueryExecutor(options));
     args.actions.createTypes(`
     type Query {
       drupalBuildId: Int!

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -32,7 +32,8 @@ export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
     auth_user: Joi.string().optional(),
     auth_pass: Joi.string().optional(),
     auth_key: Joi.string().optional(),
-    query_concurrency: Joi.number().optional(),
+    query_concurrency: Joi.number().optional().min(1),
+    paginator_page_size: Joi.number().optional().min(2),
   });
 
 const getForwardedHeaders = (url: URL) => ({
@@ -56,7 +57,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
       : undefined,
   });
   // TODO: Accept configuration and fragment overrides from plugin settings.
-  const config = await createSourcingConfig(gatsbyApi, executor);
+  const config = await createSourcingConfig(gatsbyApi, executor, options);
   const context = createSourcingContext(config);
 
   // Source only what was changed. If there is something in cache.
@@ -138,7 +139,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
 
     const executor = createQueryExecutor(options);
     // TODO: Accept configuration and fragment overrides from plugin settings.
-    const config = await createSourcingConfig(args, executor);
+    const config = await createSourcingConfig(args, executor, options);
     await createToolkitSchemaCustomization(config);
 
     await createTranslationQueryField(args, createQueryExecutor(options));

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-pages.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-pages.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { CreatePagesArgs, PluginOptions } from 'gatsby';
 
 import { SilverbackPageContext } from '../../types';
-import { apiUrl, validOptions } from '../utils';
+import { validOptions } from '../utils';
 import { createQueryExecutor } from './create-query-executor';
 import { drupalFeeds } from './drupal-feeds';
 
@@ -13,12 +13,7 @@ export const createPages = async (
   if (!validOptions(options)) {
     return;
   }
-  const executor = createQueryExecutor(
-    apiUrl(options),
-    options.auth_user,
-    options.auth_pass,
-    options.auth_key,
-  );
+  const executor = createQueryExecutor(options);
   const feeds = await drupalFeeds(executor);
   for (const feed of feeds) {
     if (!feed.pathFieldName) {

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
@@ -25,7 +25,9 @@ export const createQueryExecutor = (
     },
     timeout: 60_000,
   });
-  return wrapQueryExecutorWithQueue(executor, { concurrency: 10 });
+  return wrapQueryExecutorWithQueue(executor, {
+    concurrency: options.query_concurrency || 10,
+  });
 };
 
 // Copy of the default network query executor from gatsby-graphql-source-toolkit

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-query-executor.ts
@@ -3,24 +3,25 @@ import { IQueryExecutor } from 'gatsby-graphql-source-toolkit/dist/types';
 import fetch, { RequestInit } from 'node-fetch';
 import { inspect } from 'util';
 
+import { Options } from '../utils';
+
 export const createQueryExecutor = (
-  url: string,
-  authUser?: string,
-  authPass?: string,
-  authKey?: string,
-  headers?: RequestInit['headers'],
+  options: Options & {
+    headers?: RequestInit['headers'];
+  },
 ) => {
+  const url = `${new URL(options.drupal_url).origin}${options.graphql_path}`;
   const executor = createNetworkQueryExecutor(url, {
     headers: {
-      ...headers,
-      ...(authUser && authPass
+      ...options?.headers,
+      ...(options?.auth_user && options?.auth_pass
         ? {
             Authorization: `Basic ${Buffer.from(
-              `${authUser}:${authPass}`,
+              `${options.auth_user}:${options.auth_pass}`,
             ).toString('base64')}`,
           }
         : {}),
-      ...(authKey ? { 'api-key': authKey } : {}),
+      ...(options?.auth_key ? { 'api-key': options.auth_key } : {}),
     },
     timeout: 60_000,
   });

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-sourcing-config.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-sourcing-config.ts
@@ -4,17 +4,17 @@ import {
   compileNodeQueries,
   generateDefaultFragments,
   IPaginationAdapter,
-  LimitOffset,
   loadSchema,
 } from 'gatsby-graphql-source-toolkit';
 import {
   IGatsbyNodeConfig,
   IQueryExecutor,
   ISourcingConfig,
-  RemoteTypeName,
 } from 'gatsby-graphql-source-toolkit/dist/types';
 
+import { Options } from '../utils';
 import { drupalFeeds as drupalFeedsFetcher } from './drupal-feeds';
+import { createLimitOffsetPaginationAdapter } from './pagination-adapter';
 
 type UntranslatableListResultItem = {
   remoteTypeName: string;
@@ -37,8 +37,7 @@ type ITranslatablePaginationAdapter = IPaginationAdapter<
 export const createSourcingConfig = async (
   gatsbyApi: NodePluginArgs,
   execute: IQueryExecutor,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  customFragments?: Map<RemoteTypeName, string>,
+  options: Options,
 ): Promise<ISourcingConfig> => {
   const schema = await loadSchema(execute);
   const drupalFeeds = await drupalFeedsFetcher(execute);
@@ -98,7 +97,9 @@ export const createSourcingConfig = async (
   });
 
   const LimitOffsetTranslatable: ITranslatablePaginationAdapter = {
-    ...(LimitOffset as ITranslatablePaginationAdapter),
+    ...(createLimitOffsetPaginationAdapter(
+      options.paginator_page_size || 100,
+    ) as ITranslatablePaginationAdapter),
     getItems: (pageOrResult) => {
       return pageOrResult
         .map((node) => (isTranslatable(node) ? node.translations : [node]))

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/pagination-adapter.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/pagination-adapter.ts
@@ -1,0 +1,31 @@
+import { IPaginationAdapter } from 'gatsby-graphql-source-toolkit';
+
+// Copy of the default LimitOffset pagination adapter with page size
+// configurable.
+// https://github.com/gatsbyjs/gatsby-graphql-toolkit/blob/7ba8b24d8524254dc6c2853d6d014070befd9aea/src/config/pagination-adapters/limit-offset.ts
+export const createLimitOffsetPaginationAdapter = (
+  DEFAULT_PAGE_SIZE: number,
+): IPaginationAdapter<unknown[], unknown> => ({
+  name: 'LimitOffset',
+  expectedVariableNames: [`limit`, `offset`],
+  start() {
+    return {
+      variables: { limit: DEFAULT_PAGE_SIZE, offset: 0 },
+      hasNextPage: true,
+    };
+  },
+  next(state, page) {
+    const limit = Number(state.variables.limit) ?? DEFAULT_PAGE_SIZE;
+    const offset = Number(state.variables.offset) + limit;
+    return {
+      variables: { limit, offset },
+      hasNextPage: page.length === limit,
+    };
+  },
+  concat(result, page) {
+    return result.concat(page);
+  },
+  getItems(pageOrResult) {
+    return pageOrResult;
+  },
+});

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
@@ -13,6 +13,8 @@ export type Options = {
   auth_key?: string;
   // How much GraphQL queries can be executed in parallel. Defaults to 10.
   query_concurrency?: number;
+  // How many entities to fetch in a single GraphQL query. Defaults to 100.
+  paginator_page_size?: number;
 };
 
 export const validOptions = (options: {

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
@@ -16,6 +16,3 @@ export type Options = {
 export const validOptions = (options: {
   [key: string]: any;
 }): options is Options => options.drupal_url && options.graphql_path;
-
-export const apiUrl = (options: Options) =>
-  `${new URL(options.drupal_url).origin}${options.graphql_path}`;

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
@@ -11,6 +11,8 @@ export type Options = {
   auth_pass?: string;
   // Optional Key Auth.
   auth_key?: string;
+  // How much GraphQL queries can be executed in parallel. Defaults to 10.
+  query_concurrency?: number;
 };
 
 export const validOptions = (options: {


### PR DESCRIPTION
## Package(s) involved

<!-- type the name of the package(s) involved in this pull request -->

## Description of changes

Added new plugin options:
```ts
  // How much GraphQL queries can be executed in parallel. Defaults to 10.
  query_concurrency?: number;
  // How many entities to fetch in a single GraphQL query. Defaults to 100.
  paginator_page_size?: number;
```

## Motivation and context

Projects may run on slow hardware (`query_concurrency`) and have heavy entities (`paginator_page_size`).

## How has this been tested?

Locally, manually. Will be tested on a project as well.
