### PR TITLE
Special characters in Gatsby page paths

### DIFF
--- a/apps/silverback-drupal/web/modules/custom/silverback_default_content/content/node/4a9fccff-5a62-4235-99d8-9d32ae2eb137.yml
+++ b/apps/silverback-drupal/web/modules/custom/silverback_default_content/content/node/4a9fccff-5a62-4235-99d8-9d32ae2eb137.yml
@@ -1,0 +1,46 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 4a9fccff-5a62-4235-99d8-9d32ae2eb137
+  bundle: page
+  default_langcode: en
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Path with special chars: /page-ä/!@$^&*(){}[]:"|;''<>,.3/`~-='
+  created:
+    -
+      value: 1660040140
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: '/page-ä/!@$^&*(){}[]:"|;''<>,.3/`~-='
+      langcode: en
+  external_preview_link:
+    -
+      uri: 'http://localhost:8000/en/page-%C3%A4/%21%40%24%5E%26%2A%28%29%7B%7D%5B%5D%3A%22%7C%3B%27%3C%3E%2C.3/%60~-%3D?preview=1'
+      title: 'Preview Path with special chars: /page-ä/!@$^&amp;*(){}[]:&quot;|;&#039;&lt;&gt;,.3/`~-='
+      options: {  }
+  content_translation_source:
+    -
+      value: und
+  content_translation_outdated:
+    -
+      value: false

--- a/apps/silverback-gatsby/src/pages/index.tsx
+++ b/apps/silverback-gatsby/src/pages/index.tsx
@@ -10,24 +10,26 @@ import { Row } from '../util/Row';
 
 const IndexPage: React.FC<PageProps> = () => {
   const {
-    drupalPage: somePage,
+    allDrupalPage: { nodes: pages },
     allDrupalArticle: { nodes: articles },
     allDrupalGutenbergPage: { nodes: gutenbergPages },
     allDrupalWebform: { nodes: webforms },
   } = useStaticQuery<IndexPageQuery>(graphql`
     query IndexPage {
-      drupalPage {
-        id
-        translations {
-          langcode
-          path
-          title
-          body
-        }
-        childrenImagesFromHtml {
-          urlOriginal
-          localImage {
-            ...ImageSharpFixed
+      allDrupalPage(filter: { title: { eq: "A page" } }) {
+        nodes {
+          id
+          translations {
+            langcode
+            path
+            title
+            body
+          }
+          childrenImagesFromHtml {
+            urlOriginal
+            localImage {
+              ...ImageSharpFixed
+            }
           }
         }
       }
@@ -63,6 +65,7 @@ const IndexPage: React.FC<PageProps> = () => {
       }
     }
   `);
+  const somePage = pages[0];
 
   const imageSets: ImageSet[] = [];
   for (const childImage of somePage?.childrenImagesFromHtml || []) {
@@ -79,7 +82,7 @@ const IndexPage: React.FC<PageProps> = () => {
   const intl = useIntl();
   return (
     <>
-      <b>Some page. Just one Page node. Without a dedicated site page.</b>
+      <b>A page. Just one Page node. Without a dedicated site page.</b>
       <table>
         <tr>
           <Row>

--- a/apps/silverback-gatsby/src/pages/index.tsx
+++ b/apps/silverback-gatsby/src/pages/index.tsx
@@ -83,40 +83,30 @@ const IndexPage: React.FC<PageProps> = () => {
       <table>
         <tr>
           <Row>
-            {
-              intl.formatMessage({
-                defaultMessage: 'ID',
-              })
-            }
+            {intl.formatMessage({
+              defaultMessage: 'ID',
+            })}
           </Row>
           <Row>
-            {
-              intl.formatMessage({
-                defaultMessage: 'Title',
-                description: "table title"
-              })
-            }
+            {intl.formatMessage({
+              defaultMessage: 'Title',
+              description: 'table title',
+            })}
           </Row>
           <Row>
-            {
-              intl.formatMessage({
-                defaultMessage: 'Language',
-              })
-            }
+            {intl.formatMessage({
+              defaultMessage: 'Language',
+            })}
           </Row>
           <Row>
-            {
-              intl.formatMessage({
-                defaultMessage: 'Path',
-              })
-            }
+            {intl.formatMessage({
+              defaultMessage: 'Path',
+            })}
           </Row>
           <Row>
-            {
-              intl.formatMessage({
-                defaultMessage: 'Body',
-              })
-            }
+            {intl.formatMessage({
+              defaultMessage: 'Body',
+            })}
           </Row>
         </tr>
         {somePage?.translations.map((page) => (

--- a/packages/tests/silverback-gatsby/playwright-tests/pre-created-content.spec.ts
+++ b/packages/tests/silverback-gatsby/playwright-tests/pre-created-content.spec.ts
@@ -44,4 +44,10 @@ test('@gatsby-both other pre-created content', async ({ page }) => {
   await page.click('a:text-is("Gutenberg page")');
   await expect(page.locator('a:text-is("German")')).not.toBeVisible();
   await expect(page.locator('a:text-is("French")')).not.toBeVisible();
+
+  // Check the page with special chars in the path alias.
+  await page.goto(gatsby.baseUrl + '/en/page-ä/!@$^&*(){}[]:"|;\'<>,.3/`~-=');
+  await expect(page.locator('body')).toContainText(
+    'This is a stub page for DrupalPage',
+  );
 });


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

Make it possible to have Gatsby pages with special characters in URL. For example:
- `/page/🎉`
- ``/page-ä/!@$^&*(){}[]:"|;'<>,.3/`~-=`` 🙈

This would be a breaking change if URLs with special chars ever worked before 😅 

There are some edge cases I tried to handle. I posted all my findings and asked for support: https://github.com/gatsbyjs/gatsby/discussions/36345

## How has this been tested?

Added an integration test.
