### PR TITLE
fix: exclude deactivated menu links

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/GatsbyMenuLinks.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/GatsbyMenuLinks.php
@@ -52,6 +52,10 @@ class GatsbyMenuLinks extends DataProducerPluginBase {
     $items = $this->flatten($items, $max_level - 1);
 
     $items = array_filter($items, function ($item) use ($language) {
+      /** @var MenuLinkTreeElement $item */
+      if (!$item->link->isEnabled()) {
+        return false;
+      }
       // Filter out any menu items that are not accessible by the current user.
       if ($item->link instanceof InaccessibleMenuLink) {
         return false;


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Motivation and context

Noticed deactivated links being rendered on a project.

## How has this been tested?

Manually.
