### PR TITLE
feat(gatsby): load entities by path

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
@@ -4,9 +4,7 @@ namespace Drupal\silverback_gatsby\Plugin\GraphQL\DataProducer;
 
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\RevisionableInterface;
 use Drupal\Core\Entity\TranslatableInterface;
-use Drupal\Core\Path\PathValidator;
 use Drupal\Core\Path\PathValidatorInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -14,7 +12,6 @@ use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
 use Drupal\graphql\GraphQL\Buffers\EntityRevisionBuffer;
 use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
-use Drupal\redirect\RedirectRepository;
 use GraphQL\Deferred;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/queries/load-entity.gql
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/queries/load-entity.gql
@@ -1,0 +1,5 @@
+query ($input: String!) {
+  loadPage(id: $input) {
+    title
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
@@ -2,27 +2,27 @@
 
 namespace Drupal\Tests\silverback_gatsby\Kernel;
 
+use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\node\Entity\Node;
-use Drupal\path_alias\Entity\PathAlias;
 use Drupal\Tests\Traits\Core\PathAliasTestTrait;
-use GraphQL\Server\OperationParams;
 
 class EntityFeedTest extends EntityFeedTestBase {
   use PathAliasTestTrait;
 
   public static $modules = ['path_alias'];
 
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+
+    // Restore AliasPathProcessor tags which are removed in the parent method.
+    $container->getDefinition('path_alias.path_processor')
+      ->addTag('path_processor_inbound', ['priority' => 100])
+      ->addTag('path_processor_outbound', ['priority' => 300]);
+  }
+
   public function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('path_alias');
-
-    // For some reason, the path alias processor is not registered within the
-    // kernel test setup, so we have to manually register it.
-    /** @var \Drupal\Core\PathProcessor\InboundPathProcessorInterface $aliasProcessor */
-    $aliasProcessor = \Drupal::service('path_alias.path_processor');
-    /** @var \Drupal\Core\PathProcessor\PathProcessorManager $pathProcessorManager */
-    $pathProcessorManager = \Drupal::service('path_processor_manager');
-    $pathProcessorManager->addInbound($aliasProcessor);
   }
 
   public function testUntranslatableEntity() {


### PR DESCRIPTION
Allow to load entities by path to facilitate direct routing.

## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

The `id` argument now also allows paths, in addition to ids and uuids. If the `id` starts with a `/`, the resolver attempts to find the corresponding entity and resolves that instead. Language and revision loading remains the same, the path only replaces the id.

## Motivation and context

Load entities in the front-end by their assigned path, for preview or dynamic displays.

## Related Issue(s)

#1067 

## How has this been tested?

* Kerneltest
* Manual test in a Drupal instance
