### PR TITLE
feat(gatsby): user login status

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -299,6 +299,12 @@ extend type GatsbyStringTranslation { _original_typename: String! }
 extend type Query {
   drupalBuildId: Int!
   drupalFeedInfo: [Feed!]!
+  currentUser: User!
+}
+
+type User {
+  id: String
+  name: String
 }
 
 extend type Query {

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -299,6 +299,12 @@ extend type GatsbyStringTranslation { _original_typename: String! }
 extend type Query {
   drupalBuildId: Int!
   drupalFeedInfo: [Feed!]!
+  currentUser: User!
+}
+
+type User {
+  id: String
+  name: String
 }
 
 extend type Query {

--- a/packages/composer/amazeelabs/silverback_gatsby/graphql/silverback_gatsby.extension.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/graphql/silverback_gatsby.extension.graphqls
@@ -1,4 +1,10 @@
 extend type Query {
   drupalBuildId: Int!
   drupalFeedInfo: [Feed!]!
+  currentUser: User!
+}
+
+type User {
+  id: String
+  name: String
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/CurrentUserEntity.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/CurrentUserEntity.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\User\CurrentUser;
+use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
+
+/**
+ * @DataProducer(
+ *   id = "current_user_entity",
+ *   name = @Translation("Current User Entity"),
+ *   description = @Translation("Returns the current authenticated user. Extends the core current_user, to return the User entity instead of the AccountProxy."),
+ *   produces = @ContextDefinition("User",
+ *     label = @Translation("User")
+ *   )
+ * )
+ */
+class CurrentUserEntity extends CurrentUser {
+
+  /**
+   * Returns the current user.
+   *
+   * @param \Drupal\graphql\GraphQL\Execution\FieldContext $field_context
+   *   Field context.
+   *
+   * @return \Drupal\user\UserInterface
+   *   The current user.
+   */
+  public function resolve(FieldContext $field_context): UserInterface {
+    // Response must be cached based on current user as a cache context,
+    // otherwise a new user would become a previous user.
+    $field_context->addCacheableDependency($this->currentUser);
+    $user = NULL;
+    if ($this->currentUser instanceof AccountProxyInterface) {
+      $user = User::load($this->currentUser->id());
+    }
+    return $user;
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
@@ -674,6 +674,14 @@ class SilverbackGatsbySchemaExtension extends SdlSchemaExtensionPluginBase
 
       }
     }
+
+    $currentUser = $builder->produce('current_user_entity');
+    $addResolver('Query.currentUser', $currentUser);
+
+    $entityId = $builder->produce('entity_id')->map('entity', $builder->fromParent());
+    $entityLabel = $builder->callback(fn(EntityInterface $value) => $value->label());
+    $addResolver('User.id', $entityId);
+    $addResolver('User.name', $entityLabel);
   }
 
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/queries/current-user.gql
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/queries/current-user.gql
@@ -1,0 +1,6 @@
+{
+  currentUser {
+    id
+    name
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/CurrentUserTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/CurrentUserTest.php
@@ -8,8 +8,9 @@ class CurrentUserTest extends EntityFeedTestBase {
   function testAnonymousUser() {
     $query = $this->getQueryFromFile('current-user.gql');
     $metadata = $this->defaultCacheMetaData();
-    $metadata->addCacheTags(['node_list']);
+    $metadata->setCacheMaxAge(0);
     $anonymous = User::load(0);
+    $metadata->addCacheTags($anonymous->getCacheTags());
     $this->setCurrentUser($anonymous);
     $this->assertResults($query, [], [
       'currentUser' => [

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/CurrentUserTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/CurrentUserTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\Tests\silverback_gatsby\Kernel;
+
+use Drupal\user\Entity\User;
+
+class CurrentUserTest extends EntityFeedTestBase {
+  function testAnonymousUser() {
+    $query = $this->getQueryFromFile('current-user.gql');
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheTags(['node_list']);
+    $anonymous = User::load(0);
+    $this->setCurrentUser($anonymous);
+    $this->assertResults($query, [], [
+      'currentUser' => [
+        'id' => '0',
+        'name' => null,
+      ],
+    ], $metadata);
+  }
+
+  function testAuthenticatedUser() {
+    $query = $this->getQueryFromFile('current-user.gql');
+    $testuser = $this->createUser([], 'test');
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->setCacheMaxAge(0);
+    $metadata->addCacheTags($testuser->getCacheTags());
+    $this->setCurrentUser($testuser);
+    $this->assertResults($query, [], [
+      'currentUser' => [
+        'id' => $testuser->id(),
+        'name' => $testuser->name->value,
+      ],
+    ], $metadata);
+  }
+}


### PR DESCRIPTION
Provide a graphql field that exposes the current users id and name.

## Package(s) involved

`amazeelabsl/silverback_gatsby`

## Description of changes

Add default graphql fields for retrieving the current user login status.

## Motivation and context

Determine in the frontend if the current user is logged in.

## Related Issue(s)

#1067 

## How has this been tested?

<!-- locally? written tests? -->
