### PR TITLE
CSR rewrites

### DIFF
--- a/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.api.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.api.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Alter the path for the Silverback CDN CSR template.
+ *
+ * @param string $path
+ * @param mixed $context
+ *
+ * @return void
+ */
+function hook_silverback_cdn_csr_template_path_alter(&$path, $context) {
+  // Inspect the context and determine the path to the template.
+  // $entity = \Drupal::entityTypeManager()->getStorage($context['entity_type'])->load($context['entity_id']);
+  // $path = '/___csr/' . $entity->bundle();
+}

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.module
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.module
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Implements hook_silverback_cdn_csr_template_path_alter().
+ */
+function silverback_cdn_redirect_silverback_cdn_csr_template_path_alter(&$path, $context) {
+  $entity = \Drupal::entityTypeManager()->getStorage($context['entity_type'])->load($context['entity_id']);
+  $path = '/___csr/' . $entity->bundle();
+}

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.services.yml
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/silverback_cdn_redirect.services.yml
@@ -1,4 +1,10 @@
 services:
+  silverback_cdn_redirect.http_client:
+    class: GuzzleHttp\Client
+    arguments:
+       - http_errors: false
+         # We might need cookies if Netlify site is password protected.
+         cookies: true
   silverback_cdn_redirect.route_subscriber:
     class: Drupal\silverback_cdn_redirect\EventSubscriber\CdnRedirectRouteSubscriber
     tags:

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
@@ -114,7 +114,7 @@ class CdnRedirectController extends ControllerBase {
       $responseCode = 302;
 
       // Desired behavior: fetch the 404 page and return its contents.
-      $response = $this->client->get($location);
+      $response = $this->client->request('GET', $location);
       if ($response->getStatusCode() === 200) {
         return new Response($response->getBody(), 404, $cacheHeaders);
       }
@@ -122,7 +122,7 @@ class CdnRedirectController extends ControllerBase {
         $response->getStatusCode() === 401 &&
         ($password = $settings->get('netlify_password'))
       ) {
-        $response = $this->client->post($location, [
+        $response = $this->client->request('POST', $location, [
           'form_params' => [
             'password' => $password,
           ],

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/tests/src/Kernel/CdnRedirectTest.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/tests/src/Kernel/CdnRedirectTest.php
@@ -113,6 +113,35 @@ class CdnRedirectTest extends KernelTestBase {
     $this->assertRewrite('/user/login', 404, 'Not found');
   }
 
+  public function testCSRNode() {
+    $this->mockHttpClient
+      ->request('GET', 'http://example.com/___csr/page')
+      ->willReturn(new Response(200, [], 'Page template'));
+
+    $node = Node::create([
+      'title' => 'Test',
+      'type' => 'page',
+    ]);
+    $node->save();
+
+    $this->assertRewrite('/node/' . $node->id(), 200, 'Page template');
+  }
+
+  public function testAliasedCSRNode() {
+    $this->mockHttpClient
+      ->request('GET', 'http://example.com/___csr/page')
+      ->willReturn(new Response(200, [], 'Page template'));
+
+    $node = Node::create([
+      'title' => 'Test',
+      'type' => 'page',
+      'path' => ['alias' => '/test'],
+    ]);
+    $node->save();
+
+    $this->assertRewrite('/test', 200, 'Page template');
+  }
+
   public function testRedirect() {
     $redirect = Redirect::create();
     $redirect->setSource('to/frontpage');


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_cdn_redirect`

## Description of changes

Adjust the cdn redirect behaviour to rewrite entity urls to a dynamic template that is client side rendered.

## Motivation and context

Display a client side rendered page at a given path that is not part of the static build.

* display the page client side rendered while the build is not finished
* client side render high-volume content types to not statically render everything (#1151, #1067)

## How has this been tested?

Drupal kernel tests.
