### PR TITLE
chore: add content_moderation_state and redirect to default content exclusion

### DIFF
--- a/packages/npm/@amazeelabs/recipes/recipes/add-drupal.ts.md
+++ b/packages/npm/@amazeelabs/recipes/recipes/add-drupal.ts.md
@@ -706,9 +706,10 @@ if (PHP_SAPI !== 'cli') {
 
 // The list of excluded content entity types.
 $excluded = [
-  // Path aliases are created automatically on the node creation. They cause
-  // troubles if exported to the default content.
+  // Created automatically on node creation. Cause troubles if exported.
+  'content_moderation_state',
   'path_alias',
+  'redirect',
 ];
 
 Export::run('{{projectName}}_default_content', $excluded);


### PR DESCRIPTION
## Package(s) involved

`recipes`

## Description of changes

Exclude `content_moderation_state` and `redirect` from default_content exporter.

## Motivation and context

Prevents `yarn prepare` to be executed properly on Drupal if content moderation is used for content entities.
Adding redirect as this might also be the expected default behaviour.

## Related Issue(s)

For content_moderation_state:
- Drupal https://www.drupal.org/project/drupal/issues/2954883
- Default content https://www.drupal.org/project/default_content/issues/2952963

## How has this been tested?

Manually on a project.