### PR TITLE
feat(gatsby): option to use redirects for csr pages

### DIFF
--- a/packages/composer/amazeelabs/silverback_cdn_redirect/config/schema/silverback_cdn_redirect.schema.yml
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/config/schema/silverback_cdn_redirect.schema.yml
@@ -14,6 +14,9 @@ silverback_cdn_redirect.settings:
     netlify_password:
       type: string
       label: 'The global password for Netlify.'
+    csr_redirect:
+      type: string
+      label: 'Handle CSR pages with redirects instead of rewrites.'
     missing_translation_redirect_entity_types:
       type: sequence
       label: 'Entity type IDs for which the missing translation redirect should be performed.'

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
@@ -126,11 +126,15 @@ class CdnRedirectController extends ControllerBase {
         [, $type] = explode('.', $url->getRouteName());
         $parameters = $url->getRouteParameters();
         if ($type && isset($parameters[$type]) && $id = $parameters[$type]) {
-          $path = false;
+          $templatePath = false;
           $context = ['entity_type' => $type, 'entity_id' => $id];
-          $this->moduleHandler->alter('silverback_cdn_csr_template_path', $path, $context);
+          $this->moduleHandler->alter('silverback_cdn_csr_template_path', $templatePath, $context);
+          if ($settings->get('csr_redirect') && $templatePath) {
+            $location = $baseUrl . $templatePath . '?id=' . $id;
+            return new TrustedRedirectResponse($location);
+          }
 
-          if ($path && $response = $this->rewriteToCDN($baseUrl . $path, 200)) {
+          else if ($templatePath && $response = $this->rewriteToCDN($baseUrl . $templatePath, 200)) {
             return $response;
           }
         }

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/tests/src/Kernel/CdnRedirectTest.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/tests/src/Kernel/CdnRedirectTest.php
@@ -142,6 +142,33 @@ class CdnRedirectTest extends KernelTestBase {
     $this->assertRewrite('/test', 200, 'Page template');
   }
 
+  public function testCSRRedirectNode() {
+    $this->config('silverback_cdn_redirect.settings')
+      ->set('csr_redirect', true)
+      ->save();
+    $node = Node::create([
+      'title' => 'Test',
+      'type' => 'page',
+    ]);
+    $node->save();
+
+    $this->assertRedirect('/node/' . $node->id(), 302, 'http://example.com/___csr/page?id=' . $node->id());
+  }
+
+  public function testAliasedCSRRedirectNode() {
+    $this->config('silverback_cdn_redirect.settings')
+      ->set('csr_redirect', true)
+      ->save();
+    $node = Node::create([
+      'title' => 'Test',
+      'type' => 'page',
+      'path' => ['alias' => '/test'],
+    ]);
+    $node->save();
+
+    $this->assertRedirect('/test', 302, 'http://example.com/___csr/page?id=' . $node->id());
+  }
+
   public function testRedirect() {
     $redirect = Redirect::create();
     $redirect->setSource('to/frontpage');


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_cdn_redirect`

## Description of changes

Added a `csr_redirect` option that will cause the system to return a redirect to the CSR template instead of rewriting to it.

## Motivation and context

Bypass routing issues caused by Gatsby.

## How has this been tested?

Kernel tests.
