### PR TITLE
Node grants: `gatsby_update_log` is not populated on content unpublishing

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
@@ -16,12 +16,21 @@ function silverback_gatsby_entity_insert(EntityInterface $entity) {
 }
 
 /**
+ * Implements hook_entity_presave().
+ */
+function silverback_gatsby_entity_presave(EntityInterface $entity) {
+  if (!empty($entity->original)) {
+    _silverback_gatsby_entity_event($entity->original);
+  }
+}
+
+/**
  * Implements hook_entity_update().
  */
 function silverback_gatsby_entity_update(EntityInterface $entity) {
-  $controlHandler = \Drupal::entityTypeManager()->getAccessControlHandler($entity->getEntityTypeId());
-  _silverback_gatsby_entity_event($entity->original);
-  $controlHandler->resetCache();
+  \Drupal::entityTypeManager()
+    ->getAccessControlHandler($entity->getEntityTypeId())
+    ->resetCache();
   _silverback_gatsby_entity_event($entity);
 }
 


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

Previously:
- process both `$entity->original` and `$entity` in `hook_entity_update`

Now:
- process `$entity->original` in `hook_entity_presave` while node grants are not yet updated in the database
- process `$entity` in `hook_entity_update` as previously

## Motivation and context

We've met a bug on a project. The `gatsby_update_log` table was not populated on content unpublishing. We could not reproduce it with the default content of the same type. Yet we were able to debug the issue with project database.

During unpublishing, the [access check](https://github.com/AmazeeLabs/silverback-mono/blob/4bb029d1273a0b9c295589c6c816074d5c8d6310/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php#L110) for `$entity->original` was returning false. This happened because `NodeGrantDatabaseStorage::access` reads data directly from `node_access` table, and the table is already updated at the moment when `hook_entity_update` is fired.

## How has this been tested?

Manually on the project. No additional tests added.
(❤️ goes to existing tests as they caught two bugs in the first fix implementation)