### PR TITLE
feat(gatsby)!: add page path to CSR template

### DIFF
--- a/packages/composer/amazeelabs/silverback_cdn_redirect/tests/src/Kernel/CdnRedirectTest.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/tests/src/Kernel/CdnRedirectTest.php
@@ -116,7 +116,7 @@ class CdnRedirectTest extends KernelTestBase {
   public function testCSRNode() {
     $this->mockHttpClient
       ->request('GET', 'http://example.com/___csr')
-      ->willReturn(new Response(200, [], 'Page template ___PAGE_TYPE___ ___PAGE_ID___'));
+      ->willReturn(new Response(200, [], 'Page template "___PAGE_TYPE___" "___PAGE_ID___" "___PAGE_PATH___"'));
 
     $node = Node::create([
       'title' => 'Test',
@@ -124,13 +124,16 @@ class CdnRedirectTest extends KernelTestBase {
     ]);
     $node->save();
 
-    $this->assertRewrite('/node/' . $node->id(), 200,  'Page template node:page '. $node->id());
+    $type = json_encode('node:page');
+    $id = json_encode((string) $node->id());
+    $path = json_encode('/node/' . $node->id());
+    $this->assertRewrite('/node/' . $node->id(), 200, "Page template {$type} {$id} {$path}");
   }
 
   public function testAliasedCSRNode() {
     $this->mockHttpClient
       ->request('GET', 'http://example.com/___csr')
-      ->willReturn(new Response(200, [], 'Page template ___PAGE_TYPE___ ___PAGE_ID___'));
+      ->willReturn(new Response(200, [], 'Page template "___PAGE_TYPE___" "___PAGE_ID___" "___PAGE_PATH___"'));
 
     $node = Node::create([
       'title' => 'Test',
@@ -139,7 +142,10 @@ class CdnRedirectTest extends KernelTestBase {
     ]);
     $node->save();
 
-    $this->assertRewrite('/test', 200, 'Page template node:page '. $node->id());
+    $type = json_encode('node:page');
+    $id = json_encode((string) $node->id());
+    $path = json_encode('/test');
+    $this->assertRewrite('/test', 200, "Page template {$type} {$id} {$path}");
   }
 
   public function testRedirect() {


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_cdn_redirect`

## Motivation and context

```ts
  args.actions.createPage({
    path: '/___csr',
    matchPath: '/*', // <= 😱 
    component: path.resolve(path.resolve(__dirname, 'src/templates/csr.tsx')),
  });
```

The `matchPath` option makes Gatsby rewrite `/___csr` path to the actual page path. Yet it also kills cdn-redirect completely. Every page unknown to Gatsby becomes a CSR page, 404 pages and other redirects are gone.

## Description of changes

Now we provided the actual page path to CSR templates and can use it from there to override the URL without using `matchPath`.

## How has this been tested?

Extended existing tests.
