### PR TITLE
Gatsby page path

### DIFF
--- a/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
@@ -215,11 +215,13 @@ class CdnRedirectController extends ControllerBase {
   protected function replacePageMetadata(string $content, ?string $type, ?string $id, ?string $path) {
     return str_replace(
       [
+        '/___csr',
         '"___PAGE_TYPE___"',
         '"___PAGE_ID___"',
         '"___PAGE_PATH___"',
       ],
       [
+        $path ?: '',
         json_encode($type ?: ''),
         json_encode($id ?: ''),
         json_encode($path ?: ''),

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/src/Controller/CdnRedirectController.php
@@ -197,19 +197,7 @@ class CdnRedirectController extends ControllerBase {
     // Desired behavior: fetch the 404 page and return its contents.
     $response = $this->client->request('GET', $location);
     if ($response->getStatusCode() === 200) {
-      $body = str_replace(
-        [
-          '"___PAGE_TYPE___"',
-          '"___PAGE_ID___"',
-          '"___PAGE_PATH___"',
-        ],
-        [
-          json_encode((string) $type ?: ''),
-          json_encode((string) $id ?: ''),
-          json_encode((string) $path ?: ''),
-        ],
-        $response->getBody()->getContents()
-      );
+      $body = $this->replacePageMetadata($response->getBody()->getContents(), $type, $id, $path);
       return new Response($body, $statusCode, $this->cacheHeaders);
     }
     elseif (
@@ -218,21 +206,25 @@ class CdnRedirectController extends ControllerBase {
     ) {
       $response = $this->client->request('POST', $location, $this->cdnAuthParams);
       if ($response->getStatusCode() === 200) {
-        $body = str_replace(
-          [
-            '"___PAGE_TYPE___"',
-            '"___PAGE_ID___"',
-            '"___PAGE_PATH___"',
-          ],
-          [
-            json_encode((string) $type ?: ''),
-            json_encode((string) $id ?: ''),
-            json_encode((string) $path ?: ''),
-          ],
-          $response->getBody()->getContents()
-        );
+        $body = $this->replacePageMetadata($response->getBody()->getContents(), $type, $id, $path);
         return new Response($body, $statusCode, $this->cacheHeaders);
       }
     }
+  }
+
+  protected function replacePageMetadata(string $content, ?string $type, ?string $id, ?string $path) {
+    return str_replace(
+      [
+        '"___PAGE_TYPE___"',
+        '"___PAGE_ID___"',
+        '"___PAGE_PATH___"',
+      ],
+      [
+        json_encode($type ?: ''),
+        json_encode($id ?: ''),
+        json_encode($path ?: ''),
+      ],
+      $content
+    );
   }
 }

--- a/packages/composer/amazeelabs/silverback_cdn_redirect/tests/src/Kernel/CdnRedirectTest.php
+++ b/packages/composer/amazeelabs/silverback_cdn_redirect/tests/src/Kernel/CdnRedirectTest.php
@@ -148,6 +148,36 @@ class CdnRedirectTest extends KernelTestBase {
     $this->assertRewrite('/test', 200, "Page template {$type} {$id} {$path}");
   }
 
+  public function testGatsbyPagePath() {
+    $this->mockHttpClient
+      ->request('GET', 'http://example.com/___csr')
+      ->willReturn(new Response(200, [], '<script id="gatsby-script-loader">/*<![CDATA[*/window.pagePath="/___csr";window.___webpackCompilationHash="123";/*]]>*/</script>'));
+
+    $node = Node::create([
+      'title' => 'Test',
+      'type' => 'page',
+      'path' => ['alias' => '/test'],
+    ]);
+    $node->save();
+
+    $this->assertRewrite('/test', 200, '<script id="gatsby-script-loader">/*<![CDATA[*/window.pagePath="/test";window.___webpackCompilationHash="123";/*]]>*/</script>');
+  }
+
+  public function testMultilingualGatsbyPagePath() {
+    $this->mockHttpClient
+      ->request('GET', 'http://example.com/___csr')
+      ->willReturn(new Response(200, [], '<script id="gatsby-script-loader">/*<![CDATA[*/window.pagePath="/en/___csr";window.___webpackCompilationHash="123";/*]]>*/</script>'));
+
+    $node = Node::create([
+      'title' => 'Test',
+      'type' => 'page',
+      'path' => ['alias' => '/test'],
+    ]);
+    $node->save();
+    
+    $this->assertRewrite('/test', 200, '<script id="gatsby-script-loader">/*<![CDATA[*/window.pagePath="/en/test";window.___webpackCompilationHash="123";/*]]>*/</script>');
+  }
+
   public function testRedirect() {
     $redirect = Redirect::create();
     $redirect->setSource('to/frontpage');


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_cdn_redirect`

## Description of changes

Replace any occurences of `/___csr` with the actual path to assist gatsby when rendering the CSR template.

## Motivation and context

If this not replaced, Gatsby will change the current history to `___csr`.