### PR TITLE
feat(#1203): inject rehype plugins

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/README.md
+++ b/packages/npm/@amazeelabs/react-framework-bridge/README.md
@@ -251,6 +251,40 @@ const Html = buildHtml(
 />
 ```
 
+By adding custom
+[unified plugins](https://unifiedjs.com/learn/guide/create-a-plugin/), the UI
+component has even more control over rendering of the HTML.
+
+```tsx
+/**
+ * Inject arrows at the end of links that are alone within a paragraph.
+ */
+const arrowLinks: Plugin = () => (tree) => {
+  visit(
+    tree,
+    'element',
+    modifyChildren((node) => {
+      if (
+        isElement(node, 'p') &&
+        node.children.length === 1 &&
+        isElement(node.children[0], 'a')
+      ) {
+        node.children[0].children.push({
+          type: 'element',
+          tagName: 'span',
+          properties: {
+            className: ['arrow'],
+          },
+          children: [],
+        });
+      }
+    }),
+  );
+};
+
+<Html plugins={[arrowLinks]} />;
+```
+
 ## Storybook actions integration
 
 The `buildLink` and `buildForm` functions integrate with

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/types.ts
@@ -2,6 +2,7 @@ import { FormikConfig, FormikFormProps, FormikValues } from 'formik';
 import { Element } from 'hast';
 import { stringify } from 'qs';
 import React, { ComponentType, PropsWithChildren } from 'react';
+import { Pluggable } from 'unified';
 
 export type Html = React.VFC<{
   classNames?: {
@@ -12,6 +13,7 @@ export type Html = React.VFC<{
       | keyof JSX.IntrinsicElements
       | ComponentType<{ node: Element } & JSX.IntrinsicElements[TagName]>;
   }>;
+  plugins?: Pluggable[];
 }> & {
   initialHtmlString: string;
 };

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
@@ -109,12 +109,17 @@ const rehypeAddClasses: Plugin<[{ [key: string]: string }], Element> =
 export const buildHtmlBuilder =
   (buildLink: LinkBuilder) =>
   (input: string): Html => {
-    const Element: Html = function MockHtml({ classNames, components }) {
+    const Element: Html = function MockHtml({
+      classNames,
+      components,
+      plugins,
+    }) {
       return unified()
         .use(rehypeParse, { fragment: true })
         .use(rehypeAddClasses, classNames || {})
         .use(rehypeSlug)
         .use(rehypeTailwindLists)
+        .use(plugins || [])
         .use(rehypeReact, {
           Fragment,
           createElement,


### PR DESCRIPTION
Allow `Html` components to accept additional rehype plugins.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)