### PR TITLE
fix(gatsby): distribute update hook notifications in any case

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/FeedBase.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/FeedBase.php
@@ -101,17 +101,17 @@ abstract class FeedBase extends PluginBase implements FeedInterface {
    * applicable.
    *
    * @param mixed $context
-   * @param \Drupal\Core\Session\AccountInterface $account
+   * @param \Drupal\Core\Session\AccountInterface|null $account
    *
    * @return string[]
    *   A list of string id's to update.
    */
-  abstract function getUpdateIds($context, AccountInterface $account): array;
+  abstract function getUpdateIds($context, ?AccountInterface $account): array;
 
   /**
    * {@inheritDoc}
    */
-  public function investigateUpdate($context, AccountInterface $account) : array {
+  public function investigateUpdate($context, ?AccountInterface $account) : array {
     return array_map(
       fn ($id) => new GatsbyUpdate($this->getTypeName(), $id),
       $this->getUpdateIds($context, $account)

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/FeedInterface.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/FeedInterface.php
@@ -53,11 +53,11 @@ interface FeedInterface {
    * applicable.
    *
    * @param $context
-   * @param \Drupal\Core\Session\AccountInterface $account
+   * @param \Drupal\Core\Session\AccountInterface|null $account
    *
    * @return \Drupal\silverback_gatsby\GatsbyUpdate[]
    */
-  public function investigateUpdate($context, AccountInterface $account) : array;
+  public function investigateUpdate($context, ?AccountInterface $account) : array;
 
   /**
    * Resolve the parent value's "id" attribute.

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/EntityFeed.php
@@ -102,12 +102,12 @@ class EntityFeed extends FeedBase implements ContainerFactoryPluginInterface {
   /**
    * {@inheritDoc}
    */
-  public function getUpdateIds($context, AccountInterface $account) : array {
+  public function getUpdateIds($context, ?AccountInterface $account) : array {
     if (
       $context instanceof EntityInterface
       && $context->getEntityTypeId() === $this->type
       && ($this->bundle !== NULL && $context->bundle() === $this->bundle)
-      && $context->access('view', $account)
+      && (!$account || $context->access('view', $account))
     ) {
       if ($this->isTranslatable() && $context instanceof TranslatableInterface) {
         return array_map(function (LanguageInterface $lang) use ($context) {

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
@@ -164,7 +164,7 @@ class MenuFeed extends FeedBase implements ContainerFactoryPluginInterface {
   /**
    * {@inheritDoc}
    */
-  public function getUpdateIds($context, AccountInterface $account) : array {
+  public function getUpdateIds($context, ?AccountInterface $account) : array {
     $params = new MenuTreeParameters();
     if ($this->max_level > 0) {
       $params->maxDepth = $this->max_level;
@@ -176,7 +176,7 @@ class MenuFeed extends FeedBase implements ContainerFactoryPluginInterface {
     $menus = $this->entityTypeManager->getStorage('menu')->loadMultiple($this->menuIds());
     $relevantMenu = NULL;
     foreach($menus as $menu) {
-      if ($menu->access('view label', $account)) {
+      if (!$account || $menu->access('view label', $account)) {
         $relevantMenu = $menu;
         break;
       }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/StringTranslationFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/StringTranslationFeed.php
@@ -39,7 +39,7 @@ class StringTranslationFeed extends FeedBase {
   /**
    * {@inheritDoc}
    */
-  function getUpdateIds($context, AccountInterface $account): array {
+  function getUpdateIds($context, ?AccountInterface $account): array {
     if (!$context instanceof StringInterface) {
       return [];
     }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

Live update notifications bypass access restrictions.

## Motivation and context

Even if a node is not published, an update notification has to be
distributed.
