### PR TITLE
feat(publisher): add metadata and Publisher url to notification

### DIFF
--- a/packages/npm/@amazeelabs/publisher/README.md
+++ b/packages/npm/@amazeelabs/publisher/README.md
@@ -1,8 +1,18 @@
 # Publisher
 
-## Get Slack notifications
+## Slack notifications
 
-To be notified in case of failure set these environment variables:
+To be notified in case of failure.
 
-- `PUBLISHER_SLACK_WEBHOOK="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"`
-- `PUBLISHER_SLACK_CHANNEL="#project-ci-channel"`
+### Mandatory environment variables
+
+- Slack Webhook ([documentation](https://api.slack.com/messaging/webhooks))
+  `PUBLISHER_SLACK_WEBHOOK="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"`
+- Slack Channel `PUBLISHER_SLACK_CHANNEL="#project-ci-channel"`
+
+### Optional environment variables
+
+- Publisher url, without a trailing slash. Adds a link to the status page, to
+  the notification message. `PUBLISHER_URL="https://build.project.com"`
+- Project and Environment (Lagoon only). Adds `LAGOON_PROJECT` and
+  `LAGOON_ENVIRONMENT` to the notification message.

--- a/packages/npm/@amazeelabs/publisher/src/server/notify.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server/notify.ts
@@ -9,16 +9,38 @@ import { BuildState, GatewayState } from '../states';
 const slackWebhookUrl: string = process.env.PUBLISHER_SLACK_WEBHOOK || '';
 const slackChannel: string = process.env.PUBLISHER_SLACK_CHANNEL || '';
 const slackWebhook = new IncomingWebhook(slackWebhookUrl);
+const publisherUrl: string = process.env.PUBLISHER_URL || '';
+const lagoonProject: string = process.env.LAGOON_PROJECT || '';
+const lagoonEnvironment: string = process.env.LAGOON_ENVIRONMENT || '';
+
+const processMessage = (notificationText: string) => {
+  let result: string = notificationText;
+
+  if (publisherUrl !== '') {
+    const publisherStatusLink: string = `<${publisherUrl}/___status/|Status>`;
+    result = `${result}. ${publisherStatusLink}`;
+  }
+  if (lagoonEnvironment !== '') {
+    const formattedEnvironment: string = '`' + lagoonEnvironment + '`';
+    result = `${formattedEnvironment} ${result}`;
+  }
+  if (lagoonProject !== '') {
+    const formattedProject: string = `*[${lagoonProject}]*`;
+    result = `${formattedProject} ${result}`;
+  }
+
+  return result;
+};
 
 const notify = async (
-  text: string,
+  notificationText: string,
 ): Promise<IncomingWebhookResult | IncomingWebhookSendError | string> => {
   if (slackWebhookUrl === '' || slackChannel === '') {
     return 'Slack webhook and channel are not configured yet.';
   } else {
     return await slackWebhook.send({
       username: 'Publisher Bot',
-      text: text,
+      text: processMessage(notificationText),
       channel: slackChannel,
       icon_emoji: ':robot_face:',
     });
@@ -27,7 +49,7 @@ const notify = async (
 
 export const gatewayStateNotify = (state: GatewayState): void => {
   if (state === GatewayState.Error) {
-    notify('😱 Gateway error');
+    notify('🛑 Gateway error');
   }
 };
 


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

Add optional environment variables support
- Publisher URL
- Lagoon project and environment

## Motivation and context

- Get a link to the build status page to identify the gateway or build error
- Get metadata for more context

## Related Issue(s)

https://github.com/AmazeeLabs/silverback-mono/issues/1115

## How has this been tested?

Manually, on a project.
