### PR TITLE
graphql_directives: initialise module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 on:
-  pull_request:
-    branches:
-      - development
+  - pull_request
 jobs:
   test:
     name: Test

--- a/.idea/runConfigurations/Drupal__Clean.xml
+++ b/.idea/runConfigurations/Drupal__Clean.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Drupal: Clean" type="js.build_tools.npm" folderName="Drupal">
+    <package-json value="$PROJECT_DIR$/apps/silverback-drupal/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="clear" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/apps/silverback-drupal/composer.json
+++ b/apps/silverback-drupal/composer.json
@@ -20,6 +20,7 @@
     ],
     "require": {
         "amazeelabs/default-content": "@dev",
+        "amazeelabs/graphql_directives": "@dev",
         "amazeelabs/proxy-drupal-core": "@dev",
         "amazeelabs/proxy-gutenberg": "@dev",
         "amazeelabs/silverback-cli": "@dev",

--- a/apps/silverback-drupal/composer.lock
+++ b/apps/silverback-drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f988e1bdb5842b297fefa8295f7c2f7",
+    "content-hash": "e685328ac82cfa7fcf759fa86c7f575d",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -100,6 +100,31 @@
             }
         },
         {
+            "name": "amazeelabs/graphql_directives",
+            "version": "1.0.0",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/composer/amazeelabs/graphql_directives",
+                "reference": "5c7813cd0bc08cba48481b32d7fe3f6e42cca356"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^10"
+                    }
+                }
+            },
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Directive based GraphQL schemas for Drupal.",
+            "homepage": "https://silverback.netlify.app",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "amazeelabs/proxy-default-content",
             "version": "1.1.5",
             "dist": {
@@ -164,11 +189,11 @@
         },
         {
             "name": "amazeelabs/proxy-gutenberg",
-            "version": "1.1.15",
+            "version": "1.1.16",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/proxy-gutenberg",
-                "reference": "689cdc7cf7ef5d26e7d875b16f7eca692944f43b"
+                "reference": "08661694d61dd7adfbbbd3c1b2b4d547cb5f0b05"
             },
             "require": {
                 "cweagans/composer-patches": "^1.7.3",
@@ -276,11 +301,11 @@
         },
         {
             "name": "amazeelabs/silverback_gatsby",
-            "version": "1.28.0",
+            "version": "1.28.1",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_gatsby",
-                "reference": "feda5340c0b65561d17ca0d916353565d3210415"
+                "reference": "80a1594d62b0e4bee1f64287593921c58a5c483e"
             },
             "type": "drupal-module",
             "extra": {
@@ -318,11 +343,11 @@
         },
         {
             "name": "amazeelabs/silverback_gutenberg",
-            "version": "1.6.11",
+            "version": "1.6.12",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_gutenberg",
-                "reference": "92fcef8fa617114add1d21012164a1e9b13d1309"
+                "reference": "185b217018c627907e6cf58edabd8a9bb8b91c86"
             },
             "require": {
                 "drupal/gutenberg": "^2.4"
@@ -3107,20 +3132,17 @@
         },
         {
             "name": "drupal/cypress",
-            "version": "2.3.74",
+            "version": "2.3.76",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/drupal/cypress",
-                "reference": "917117d061e0ecd4ac09aedad19836aa55eaf041"
+                "reference": "cf46e50844d1104f1a4eed832eb9e092bde39075"
             },
             "require": {
                 "alchemy/zippy": "^1.0.0",
                 "drupal/test_session": "^1.0.0",
                 "drush/drush": ">=10.6.2",
                 "ext-json": "*"
-            },
-            "require-dev": {
-                "drupal/cypress-dev": "*"
             },
             "type": "drupal-module",
             "extra": {
@@ -12081,6 +12103,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "amazeelabs/default-content": 20,
+        "amazeelabs/graphql_directives": 20,
         "amazeelabs/proxy-drupal-core": 20,
         "amazeelabs/proxy-gutenberg": 20,
         "amazeelabs/silverback-cli": 20,
@@ -12103,5 +12126,5 @@
     "platform-overrides": {
         "php": "8.1.13"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -1,3 +1,3 @@
 # GraphQL Directives
 
-A directive-based approach to GraphQL schema implementations.
+A directive-based approach to GraphQL schema implementations. Provides a 'Directable' schema plugin that loads a GraphQL schema definition file and implements it using directive plugins.

--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -1,0 +1,3 @@
+# GraphQL Directives
+
+A directive-based approach to GraphQL schema implementations.

--- a/packages/composer/amazeelabs/graphql_directives/composer.json
+++ b/packages/composer/amazeelabs/graphql_directives/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "amazeelabs/graphql_directives",
+  "type": "drupal-module",
+  "version": "1.0.0",
+  "description": "Directive based GraphQL schemas for Drupal.",
+  "homepage": "https://silverback.netlify.app",
+  "license": "GPL-2.0+",
+  "extra": {
+    "drush": {
+      "services": {
+        "drush.services.yml": "^10"
+      }
+    }
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/config/schema/graphql_directives.schema.yml
+++ b/packages/composer/amazeelabs/graphql_directives/config/schema/graphql_directives.schema.yml
@@ -1,0 +1,10 @@
+graphql.schema.directable:
+  type: mapping
+  label: 'Directable schema'
+  mapping:
+    directable:
+      type: mapping
+      mapping:
+        schema_definition:
+          label: Schema definition
+          type: string

--- a/packages/composer/amazeelabs/graphql_directives/graphql_directives.info.yml
+++ b/packages/composer/amazeelabs/graphql_directives/graphql_directives.info.yml
@@ -1,0 +1,6 @@
+name: GraphQL Directives
+description: Directive-based GraphQL schema system.
+type: module
+dependencies:
+  - graphql:graphql
+core_version_requirement: ^8.8.0 || ^9.0

--- a/packages/composer/amazeelabs/graphql_directives/package.json
+++ b/packages/composer/amazeelabs/graphql_directives/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@-amazeelabs/graphql_directives",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "version": "sync-composer-version",
+    "test:unit": "cd ../../../../apps/silverback-drupal && vendor/phpunit/phpunit/phpunit web/modules/contrib/graphql_directives"
+  },
+  "devDependencies": {
+    "@amazeelabs/sync-composer-version": "^1.1.2"
+  },
+  "author": "Amazee Labs <development@amazeelabs.com>",
+  "publishConfig": {
+    "access": "public",
+    "registry": "http://localhost:4873",
+    "repository": "git@github.com:AmazeeLabs/graphql_directives.git",
+    "branch": "main"
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\Schema;
+
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\graphql\GraphQL\ResolverRegistry;
+use Drupal\graphql\Plugin\GraphQL\Schema\SdlSchemaPluginBase;
+
+/**
+ * @Schema(
+ *   id = "directable",
+ *   name = "Directable schema"
+ * )
+ */
+class DirectableSchema extends SdlSchemaPluginBase implements ConfigurableInterface, PluginFormInterface {
+  use StringTranslationTrait;
+
+  /**
+   * Retrieves the raw schema definition string.
+   *
+   * @return string
+   *   The schema definition.
+   *
+   * @throws \Exception
+   */
+  protected function getSchemaDefinition() {
+    $file = $this->configuration['schema_definition'];
+    if (!file_exists($file)) {
+      throw new \Exception(sprintf('Schema definition file %s does not exist.', $file));
+    }
+
+    return file_get_contents($file) ?: NULL;
+  }
+
+  public function getResolverRegistry() {
+    return new ResolverRegistry();
+  }
+
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['schema_definition'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Schema definition'),
+      '#default_value' => $this->configuration['schema_definition'],
+      '#description' => $this->t('Path to the schema definition file. Relative to webroot.'),
+    ];
+    return $form;
+  }
+
+  public function getConfiguration() {
+    return $this->configuration;
+  }
+
+  public function setConfiguration(array $configuration) {
+    $this->configuration = $configuration;
+  }
+
+  public function defaultConfiguration() {
+    return ['schema_definition' => 'schema.graphqls'];
+  }
+
+  public function validateConfigurationForm(
+    array &$form,
+    FormStateInterface $form_state
+  ) {
+    // Nothing to do here.
+  }
+
+  public function submitConfigurationForm(
+    array &$form,
+    FormStateInterface $form_state
+  ) {
+    // Nothing to do here.
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\Tests\graphql_directives\Kernel;
+
+use Drupal\graphql\Entity\Server;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+
+class DirectableSchemaTest extends GraphQLTestBase {
+
+  public static $modules = ['graphql_directives'];
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig('graphql_directives');
+    $this->server = Server::create([
+      'status' => true,
+      'name' => 'directives_test',
+      'label' => 'Directives Test',
+      'endpoint'=> '/graphql/directives-test',
+      'schema' => 'directable',
+      'schema_configuration'=> [
+        'directable' => ['schema_definition' => __DIR__ . '/../assets/schema.graphqls'],
+      ],
+    ]);
+  }
+
+  function testSchemaLoading() {
+    $this->assertResults('{ foo }', [], ['foo' => null]);
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
@@ -1,0 +1,3 @@
+type Query {
+  foo: String
+}


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql`

## Description of changes

A drupal module that allows to implement graphql schemas with pluggable
directives.

## Motivation and context

* increase maintainability of `amazeelabs/silverback_gatsby`
* reduce amount of php code in client projects
* increase php code reusability by better composability

## Related Issue(s)

#1169

## How has this been tested?

* unit tests
* kernel tests
