### PR TITLE
graphql_directives: plugin system and @value directive

### DIFF
--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -1,3 +1,70 @@
 # GraphQL Directives
 
 A directive-based approach to GraphQL schema implementations. Provides a 'Directable' schema plugin that loads a GraphQL schema definition file and implements it using directive plugins.
+
+## Usage
+
+Create a GraphQL schema definition file, and annotate it with directives.
+
+```graphql
+type Query {
+  hello: String @value(json: "\"Hello world!\"")
+}
+```
+
+Configure a GraphQL server with the "Directable" schema plugin, and set the
+schema definition path to the created schema file.
+
+Directive definitions will be automatically prepended to the schema. To support
+IDE's with autocompletion and syntax checking, there is a `drush` command to
+generate a schema file with all directives.
+
+```shell
+drush graphql:directives >> directives.graphqls
+```
+
+## Directives
+
+### `@value`
+
+The `@value` directive allows you to define a static value for a field as a JSON
+encoded string.
+
+```graphql
+type Query {
+  hello: String @value(json: "\"Hello world!\"")
+}
+```
+
+## Extending
+
+To add custom directives, create a module and add new Plugins in the
+`src/Plugin/GraphQL/Directive` directory. The plugins "id" will be the handle to
+invoke it in the schema, without the `@` prefix.
+
+```php
+<?php
+namespace Drupal\my_directives\Plugin\GraphQL\Directive;
+
+use Drupal\graphql_directives\DirectiveInterface;
+
+/**
+* @Directive(
+*   id="echo",
+*   arguments = {
+*     "input" = "String!",
+*   }
+* )
+ */
+class EchoDirective extends PluginBase implements DirectiveInterface {
+  /**
+   * {@inheritdoc}
+   */
+  public function buildResolver(
+    ResolverBuilder $builder,
+    array $arguments
+  ) : ResolverInterface {
+    return $builder->fromValue($arguments['input']);
+  }
+}
+```

--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -8,7 +8,7 @@ Create a GraphQL schema definition file, and annotate it with directives.
 
 ```graphql
 type Query {
-  hello: String @value(json: "Hello world!")
+  hello: String @value(json: "\"Hello world!\"")
 }
 ```
 

--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -8,7 +8,7 @@ Create a GraphQL schema definition file, and annotate it with directives.
 
 ```graphql
 type Query {
-  hello: String @value(json: "\"Hello world!\"")
+  hello: String @value(json: "Hello world!")
 }
 ```
 

--- a/packages/composer/amazeelabs/graphql_directives/graphql_directives.services.yml
+++ b/packages/composer/amazeelabs/graphql_directives/graphql_directives.services.yml
@@ -7,3 +7,8 @@ services:
       - '@module_handler'
       - '\Drupal\graphql_directives\DirectiveInterface'
       - '\Drupal\graphql_directives\Annotation\Directive'
+
+  graphql_directives.printer:
+    class: Drupal\graphql_directives\DirectivePrinter
+    arguments:
+      - '@graphql_directives.manager'

--- a/packages/composer/amazeelabs/graphql_directives/graphql_directives.services.yml
+++ b/packages/composer/amazeelabs/graphql_directives/graphql_directives.services.yml
@@ -1,0 +1,9 @@
+services:
+  graphql_directives.manager:
+    class: Drupal\Core\Plugin\DefaultPluginManager
+    arguments:
+      - 'Plugin/GraphQL/Directive'
+      - '@container.namespaces'
+      - '@module_handler'
+      - '\Drupal\graphql_directives\DirectiveInterface'
+      - '\Drupal\graphql_directives\Annotation\Directive'

--- a/packages/composer/amazeelabs/graphql_directives/src/Annotation/Directive.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Annotation/Directive.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\graphql_directives\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * @Annotation
+ * Annotation for GraphQL directives.
+ */
+class Directive extends Plugin {
+  /**
+   * The directive name without the `@`.
+   *
+   * @var string
+   */
+  public string $id;
+
+  /**
+   * The directives argument definitions.
+   *
+   * @var array
+   */
+  public array $arguments;
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectiveInterface.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectiveInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\graphql_directives;
+
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+
+/**
+ * Interface definition for GraphQL directives.
+ */
+interface DirectiveInterface {
+
+  /**
+   * @param \Drupal\graphql\GraphQL\ResolverBuilder $builder
+   * @param array $arguments
+   *
+   * @return \Drupal\graphql\GraphQL\Resolver\ResolverInterface
+   */
+  public function buildResolver(
+    ResolverBuilder $builder,
+    array $arguments
+  ) : ResolverInterface;
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\graphql_directives;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use GraphQL\Language\AST\DirectiveDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
+use GraphQL\Language\AST\NameNode;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\DirectiveLocation;
+use GraphQL\Language\Printer;
+use GraphQL\Language\Parser;
+
+class DirectivePrinter {
+
+  protected PluginManagerInterface $directiveManager;
+
+  public function __construct(PluginManagerInterface $directiveManager) {
+    $this->directiveManager = $directiveManager;
+  }
+
+  public function printDirectives() {
+    $definitions = $this->directiveManager->getDefinitions();
+    $directives = [];
+    foreach ($definitions as $definition) {
+
+      $arguments = [];
+      if (isset($definition['arguments'])) {
+        foreach ($definition['arguments'] as $name => $type) {
+          $arguments[] = new InputValueDefinitionNode([
+            'name' => new NameNode(['value' => $name]),
+            'type' => Parser::parseType($type),
+          ]);
+        }
+      }
+
+      $dir = new DirectiveDefinitionNode([
+        'name' => new NameNode(['value' => $definition['id']]),
+        'arguments' => new NodeList($arguments),
+        'locations' => new NodeList([
+          new NameNode(['value' => DirectiveLocation::FIELD_DEFINITION]),
+        ]),
+      ]);
+      $directives[] = Printer::doPrint($dir);
+    }
+    return implode("\n", $directives);
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Value.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Value.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\Directive;
+
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+
+/**
+ * @Directive(
+ *   id = "value",
+ *   arguments = {
+ *     "json" = "String!",
+ *   }
+ * )
+ */
+class Value extends PluginBase implements DirectiveInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildResolver(
+    ResolverBuilder $builder,
+    array $arguments
+  ) : ResolverInterface {
+    return $builder->fromValue(json_decode($arguments['json']));
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
@@ -25,6 +25,6 @@ class DirectableSchemaTest extends GraphQLTestBase {
   }
 
   function testSchemaLoading() {
-    $this->assertResults('{ foo }', [], ['foo' => null]);
+    $this->assertResults('{ foo }', [], ['foo' => 'bar']);
   }
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
@@ -12,6 +12,16 @@ class DirectableSchemaTest extends GraphQLTestBase {
   protected function setUp(): void {
     parent::setUp();
     $this->installConfig('graphql_directives');
+
+    $path = \Drupal::moduleHandler()->getModule('graphql_directives')->getPath();
+    $directives = $this->container->get('graphql_directives.printer')
+      ->printDirectives();
+
+    file_put_contents(
+      $path . '/tests/assets/directives.graphqls',
+      $directives
+    );
+
     $this->server = Server::create([
       'status' => true,
       'name' => 'directives_test',

--- a/packages/composer/amazeelabs/graphql_directives/tests/Unit/DirectivePrinterTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Unit/DirectivePrinterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\Tests\graphql_directives\Unit;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\graphql_directives\DirectivePrinter;
+use Drupal\Tests\UnitTestCase;
+
+class DirectivePrinterTest extends UnitTestCase {
+  public function testSingleDirective() {
+    $directiveManager = $this->prophesize(PluginManagerInterface::class);
+    $directiveManager->getDefinitions()->willReturn([
+      'todo' => [
+        'id' => 'todo',
+      ],
+    ]);
+    $printer = new DirectivePrinter($directiveManager->reveal());
+
+    $this->assertEquals(
+      'directive @todo on FIELD_DEFINITION',
+      $printer->printDirectives()
+    );
+  }
+  public function testDirectiveArguments() {
+    $directiveManager = $this->prophesize(PluginManagerInterface::class);
+    $directiveManager->getDefinitions()->willReturn([
+      'value' => [
+        'id' => 'value',
+        'arguments' => [
+          'json' => 'String!',
+          'function' => 'String',
+        ],
+      ],
+    ]);
+    $printer = new DirectivePrinter($directiveManager->reveal());
+
+    $this->assertEquals(
+      'directive @value(json: String!, function: String) on FIELD_DEFINITION',
+      $printer->printDirectives()
+    );
+  }
+
+  public function testMultipleDirectives() {
+    $directiveManager = $this->prophesize(PluginManagerInterface::class);
+    $directiveManager->getDefinitions()->willReturn([
+      'value' => [
+        'id' => 'value',
+        'arguments' => [
+          'json' => 'String!',
+          'function' => 'String',
+        ],
+      ],
+      'todo' => [
+        'id' => 'todo',
+      ],
+    ]);
+    $printer = new DirectivePrinter($directiveManager->reveal());
+
+    $this->assertEquals(
+      implode("\n", [
+        'directive @value(json: String!, function: String) on FIELD_DEFINITION',
+        'directive @todo on FIELD_DEFINITION',
+      ]),
+      $printer->printDirectives()
+    );
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/.gitignore
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/.gitignore
@@ -1,0 +1,1 @@
+directives.graphqls

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
@@ -1,3 +1,7 @@
+directive @value (
+  json: String
+) on FIELD_DEFINITION
+
 type Query {
-  foo: String
+  foo: String! @value(json: "\"bar\"")
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
@@ -2,6 +2,9 @@ directive @value (
   json: String
 ) on FIELD_DEFINITION
 
+directive @unknown on FIELD_DEFINITION
+
 type Query {
   foo: String! @value(json: "\"bar\"")
+  bar: String @unknown
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
@@ -1,7 +1,3 @@
-directive @value (
-  json: String
-) on FIELD_DEFINITION
-
 directive @unknown on FIELD_DEFINITION
 
 type Query {


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql_directives`

## Description of changes

Provide a directive plugin system and implement a simple `@value` directive that emits data from a static json
string.

## Motivation and context

* simple solution for adding static values to a graphql schema
* utility for kernel tests in `graphql_directives`

## Related Issue(s)

#1169

## How has this been tested?

* Kernel tests
