### PR TITLE
graphql_directives: improve developer experience

### DIFF
--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -17,7 +17,8 @@ schema definition path to the created schema file.
 
 Directive definitions will be automatically prepended to the schema. To support
 IDE's with autocompletion and syntax checking, there is a `drush` command to
-generate a schema file with all directives.
+generate a schema file with all directives and information where they are
+implemented.
 
 ```shell
 drush graphql:directives >> directives.graphqls
@@ -51,6 +52,7 @@ use Drupal\graphql_directives\DirectiveInterface;
 /**
 * @Directive(
 *   id="echo",
+*   description="Return the same string that you put in.",
 *   arguments = {
 *     "input" = "String!",
 *   }

--- a/packages/composer/amazeelabs/graphql_directives/drush.services.yml
+++ b/packages/composer/amazeelabs/graphql_directives/drush.services.yml
@@ -1,0 +1,7 @@
+services:
+  graphql_directives.commands:
+    class: \Drupal\graphql_directives\Commands
+    arguments:
+      - '@graphql_directives.printer'
+    tags:
+      - { name: drush.command }

--- a/packages/composer/amazeelabs/graphql_directives/src/Annotation/Directive.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Annotation/Directive.php
@@ -17,6 +17,13 @@ class Directive extends Plugin {
   public string $id;
 
   /**
+   * The directive description.
+   *
+   * @var string
+   */
+  public string $description;
+
+  /**
    * The directives argument definitions.
    *
    * @var array

--- a/packages/composer/amazeelabs/graphql_directives/src/Commands.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Commands.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\graphql_directives;
+
+use Drush\Commands\DrushCommands;
+
+class Commands extends DrushCommands {
+
+  protected DirectivePrinter $directivePrinter;
+
+  public function __construct(DirectivePrinter $directivePrinter) {
+    parent::__construct();
+    $this->directivePrinter = $directivePrinter;
+  }
+
+  /**
+   * Print graphql directives.
+   *
+   * @command graphql:directives
+   * @aliases gd
+   */
+  public function schemaExport($folder = '../generated') {
+    print $this->directivePrinter->printDirectives();
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
@@ -35,10 +35,26 @@ class DirectivePrinter {
         }
       }
 
+      $description = isset($definition['description'])
+        ? [$definition['description']]
+        : [];
+
+      if (isset($definition['provider']) || isset($definition['class'])) {
+        $description[] = '';
+      }
+
+      if (isset($definition['provider'])) {
+        $description[] = sprintf('Provided by the "%s" module.', $definition['provider']);
+      }
+
+      if (isset($definition['class'])) {
+        $description[] = sprintf('Implemented in "%s".', $definition['class']);
+      }
+
       $dir = new DirectiveDefinitionNode([
         'name' => new NameNode(['value' => $definition['id']]),
-        'description' => isset($definition['description'])
-          ? new StringValueNode(['value' => $definition['description'], 'block' => TRUE])
+        'description' => count($description)
+          ? new StringValueNode(['value' => implode("\n", $description), 'block' => TRUE])
           : NULL,
         'arguments' => new NodeList($arguments),
         'locations' => new NodeList([

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
@@ -7,6 +7,7 @@ use GraphQL\Language\AST\DirectiveDefinitionNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\NameNode;
 use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Language\DirectiveLocation;
 use GraphQL\Language\Printer;
 use GraphQL\Language\Parser;
@@ -36,6 +37,9 @@ class DirectivePrinter {
 
       $dir = new DirectiveDefinitionNode([
         'name' => new NameNode(['value' => $definition['id']]),
+        'description' => isset($definition['description'])
+          ? new StringValueNode(['value' => $definition['description'], 'block' => TRUE])
+          : NULL,
         'arguments' => new NodeList($arguments),
         'locations' => new NodeList([
           new NameNode(['value' => DirectiveLocation::FIELD_DEFINITION]),

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Value.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Value.php
@@ -10,6 +10,7 @@ use Drupal\graphql_directives\DirectiveInterface;
 /**
  * @Directive(
  *   id = "value",
+ *   description = "Provide a static value as JSON string.",
  *   arguments = {
  *     "json" = "String!",
  *   }

--- a/packages/composer/amazeelabs/graphql_directives/tests/Unit/DirectivePrinterTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Unit/DirectivePrinterTest.php
@@ -86,4 +86,34 @@ class DirectivePrinterTest extends UnitTestCase {
     );
   }
 
+  public function testProviderInfo() {
+    $directiveManager = $this->prophesize(PluginManagerInterface::class);
+    $directiveManager->getDefinitions()->willReturn([
+      'value' => [
+        'id' => 'value',
+        'description' => 'Provide a static json value.',
+        'arguments' => [
+          'json' => 'String!',
+          'function' => 'String',
+        ],
+        'class' => 'Drupal\graphql_directives\Plugin\GraphQL\Directive\Value',
+        'provider' => 'graphql_directives',
+      ],
+    ]);
+    $printer = new DirectivePrinter($directiveManager->reveal());
+
+    $this->assertEquals(
+      implode("\n", [
+        '"""',
+        'Provide a static json value.',
+        '',
+        'Provided by the "graphql_directives" module.',
+        'Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".',
+        '"""',
+        'directive @value(json: String!, function: String) on FIELD_DEFINITION',
+      ]),
+      $printer->printDirectives()
+    );
+  }
+
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/Unit/DirectivePrinterTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Unit/DirectivePrinterTest.php
@@ -21,6 +21,27 @@ class DirectivePrinterTest extends UnitTestCase {
       $printer->printDirectives()
     );
   }
+  public function testCommentedDirective() {
+    $directiveManager = $this->prophesize(PluginManagerInterface::class);
+    $directiveManager->getDefinitions()->willReturn([
+      'todo' => [
+        'id' => 'todo',
+        'description' => 'Mark a field as not implemented.',
+      ],
+    ]);
+    $printer = new DirectivePrinter($directiveManager->reveal());
+    $this->assertEquals(
+      implode("\n", [
+        '"""',
+        'Mark a field as not implemented.',
+        '"""',
+        'directive @todo on FIELD_DEFINITION',
+      ]),
+      $printer->printDirectives()
+    );
+  }
+
+
   public function testDirectiveArguments() {
     $directiveManager = $this->prophesize(PluginManagerInterface::class);
     $directiveManager->getDefinitions()->willReturn([


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql_directives`

## Description of changes

Add a drush command to export directives for IDE support and annotate
export with comments.

## Motivation and context

* improve developer experience when writing graphql schemas

## Related Issue(s)

#1169

## How has this been tested?

* unit tests
* kernel tests

