### PR TITLE
graphql_directives: seek directive and chaining

### DIFF
--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -24,6 +24,19 @@ implemented.
 drush graphql:directives >> directives.graphqls
 ```
 
+### Chaining
+
+Directives can be chained to combine reusable data producers. They are composed
+from left to right, meaning the output of the left directive is passed as parent
+value to its right neighbour.
+
+```graphql
+type Query {
+  # This will emit "three".
+  list: String! @value(json: "[\"one\", \"two\", \"three\"]") @seek(pos: 2)
+}
+```
+
 ## Directives
 
 ### `@value`
@@ -34,6 +47,18 @@ encoded string.
 ```graphql
 type Query {
   hello: String @value(json: "\"Hello world!\"")
+}
+```
+
+### `@seek`
+
+Extracts a value from a list or iterable. The `pos` argument marks the target
+position.
+
+```graphql
+type Query {
+  # This will emit "three".
+  list: String! @value(json: "[\"one\", \"two\", \"three\"]") @seek(pos: 2)
 }
 ```
 

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Seek.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Seek.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\Directive;
+
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+
+/**
+ * @Directive(
+ *   id = "seek",
+ *   description = "Seek a specific element in a list.",
+ *   arguments = {
+ *     "pos" = "Int!",
+ *   }
+ * )
+ */
+class Seek extends PluginBase implements DirectiveInterface {
+
+  public function buildResolver(
+    ResolverBuilder $builder,
+    array $arguments
+  ): ResolverInterface {
+    return $builder->produce('seek')
+      ->map('input', $builder->fromParent())
+      ->map('position', $builder->fromValue($arguments['pos']));
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
@@ -37,4 +37,8 @@ class DirectableSchemaTest extends GraphQLTestBase {
   function testSchemaLoading() {
     $this->assertResults('{ foo }', [], ['foo' => 'bar']);
   }
+
+  function testSeekDirective() {
+    $this->assertResults('{ seek }', [], ['seek' => 'two']);
+  }
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
@@ -3,4 +3,5 @@ directive @unknown on FIELD_DEFINITION
 type Query {
   foo: String! @value(json: "\"bar\"")
   bar: String @unknown
+  seek: String! @value(json: "[\"one\", \"two\"]") @seek(pos: 1)
 }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql_directives`

## Description of changes

Add a `@seek` directive that extracts a single value from a list and
implement directive chaining.

## Motivation and context

* reusable "atomic" directives that can be combined in the schema

## Related Issue(s)

#1170

## How has this been tested?

* kernel tests
* unit tests
