### PR TITLE
graphql_directives: prop directive and mapping

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -9,18 +9,12 @@
   <component name="PHPCodeSnifferOptionsConfiguration">
     <option name="transferred" value="true" />
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="7.4">
+  <component name="PhpProjectSharedConfiguration" php_language_level="8.1">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
-  </component>
-  <component name="PhpStanOptionsConfiguration">
-    <option name="transferred" value="true" />
   </component>
   <component name="PhpUnit">
     <phpunit_settings>
       <PhpUnitSettings configuration_file_path="$PROJECT_DIR$/apps/silverback-drupal/phpunit.xml.dist" custom_loader_path="$PROJECT_DIR$/apps/silverback-drupal/vendor/autoload.php" phpunit_phar_path="" use_configuration_file="true" />
     </phpunit_settings>
-  </component>
-  <component name="PsalmOptionsConfiguration">
-    <option name="transferred" value="true" />
   </component>
 </project>

--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -37,6 +37,21 @@ type Query {
 }
 ```
 
+### Mapping
+
+The `@map` directive allows to map over the output of its left neighbour and
+apply all directives on the right side to each item.
+
+```graphql
+type Query {
+  # This will emit ["a", "b"].
+  map: [String!]!
+    @value(json: "[{\"x\": \"a\"},{\"x\": \"b\"}]")
+    @map
+    @prop(key: "x")
+}
+```
+
 ## Directives
 
 ### `@value`
@@ -59,6 +74,32 @@ position.
 type Query {
   # This will emit "three".
   list: String! @value(json: "[\"one\", \"two\", \"three\"]") @seek(pos: 2)
+}
+```
+
+### `@prop`
+
+Extracts a property from an object or map. The `key` argument marks the target key.
+
+```graphql
+type Query {
+  # This will emit "bar".
+  prop: String! @value(json: "{\"foo\": \"bar\"}") @prop(key: "foo")
+}
+```
+
+### `@map`
+
+Iterate over the current result list and apply the following directives to each
+item.
+
+```graphql
+type Query {
+  # This will emit ["a", "b"].
+  map: [String!]!
+    @value(json: "[{\"x\": \"a\"},{\"x\": \"b\"}]")
+    @map
+    @prop(key: "x")
 }
 ```
 

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
@@ -28,6 +28,7 @@ class DirectivePrinter {
       'description' => new StringValueNode(['value' => implode("\n", [
           'Apply all directives on the right to output on the left.'
         ]), 'block' => TRUE]),
+      'arguments' => new NodeList([]),
       'locations' => new NodeList([
         new NameNode(['value' => DirectiveLocation::FIELD_DEFINITION]),
       ]),

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
@@ -22,7 +22,17 @@ class DirectivePrinter {
 
   public function printDirectives() {
     $definitions = $this->directiveManager->getDefinitions();
-    $directives = [];
+
+    $map = new DirectiveDefinitionNode([
+      'name' => new NameNode(['value' => 'map']),
+      'description' => new StringValueNode(['value' => implode("\n", [
+          'Apply all directives on the right to output on the left.'
+        ]), 'block' => TRUE]),
+      'locations' => new NodeList([
+        new NameNode(['value' => DirectiveLocation::FIELD_DEFINITION]),
+      ]),
+    ]);
+    $directives = [Printer::doPrint($map)];
     foreach ($definitions as $definition) {
 
       $arguments = [];

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/Prop.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/Prop.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\DataProducer;
+
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+
+/**
+ * Return an item from a list at a specified position.
+ *
+ * @DataProducer(
+ *   id = "prop",
+ *   name = @Translation("Prop"),
+ *   description = @Translation("Extracts an object or map property."),
+ *   produces = @ContextDefinition("any",
+ *     label = @Translation("Value")
+ *   ),
+ *   consumes = {
+ *     "input" = @ContextDefinition("any",
+ *       label = @Translation("Input object or array"),
+ *       required = TRUE
+ *     ),
+ *     "property" = @ContextDefinition("string",
+ *       label = @Translation("Property name")
+ *     )
+ *   }
+ * )
+ */
+class Prop extends DataProducerPluginBase {
+
+  /**
+   * Resolver.
+   *
+   * @param mixed $input
+   *   The input array or object.
+   * @param string $prop
+   *   The property to extract.
+   *
+   * @return mixed
+   *   The value at the specified property.
+   */
+  public function resolve($input, $prop) {
+    if (is_array($input)) {
+      return $input[$prop] ?? NULL;
+    }
+    if (is_object($input)) {
+      return $input->{$prop} ?? NULL;
+    }
+    return NULL;
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Prop.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Prop.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\Directive;
+
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+
+/**
+ * @Directive(
+ *   id = "prop",
+ *   description = "Retrieve an object or map property.",
+ *   arguments = {
+ *     "key" = "String!",
+ *   }
+ * )
+ */
+class Prop extends PluginBase implements DirectiveInterface {
+
+  public function buildResolver(
+    ResolverBuilder $builder,
+    array $arguments
+  ): ResolverInterface {
+    return $builder->produce('prop')
+      ->map('input', $builder->fromParent())
+      ->map('property', $builder->fromValue($arguments['key']));
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
@@ -122,6 +122,7 @@ class DirectableSchema extends ComposableSchema {
         foreach($definition->fields as $field) {
           if ($field->directives) {
             $composite = new Composite([]);
+
             foreach ($field->directives as $directive) {
               if ($this->directiveManager->hasDefinition($directive->name->value)) {
                 $plugin = $this->directiveManager
@@ -133,6 +134,7 @@ class DirectableSchema extends ComposableSchema {
                   ));
               }
             }
+
             $registry->addFieldResolver(
               $definition->name->value,
               $field->name->value,

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
@@ -121,9 +121,21 @@ class DirectableSchema extends ComposableSchema {
       if ($definition instanceof ObjectTypeDefinitionNode) {
         foreach($definition->fields as $field) {
           if ($field->directives) {
+            /** @var \Drupal\graphql\GraphQL\Resolver\Composite[] $composites */
+            $composites = [];
             $composite = new Composite([]);
 
+            // Stack composites of directives on top of each other.
             foreach ($field->directives as $directive) {
+
+              // If the directive is "map" start a new stack entry.
+              if ($directive->name->value === 'map') {
+                $composites[] = $composite;
+                $composite = new Composite([]);
+                continue;
+              }
+
+              // If the directive is implemented, add it to the current composite.
               if ($this->directiveManager->hasDefinition($directive->name->value)) {
                 $plugin = $this->directiveManager
                   ->createInstance($directive->name->value);
@@ -133,6 +145,13 @@ class DirectableSchema extends ComposableSchema {
                     $parameters
                   ));
               }
+            }
+
+            // Fold the stack of composites, but adding each composite as a mapped
+            // resolver to its parent in the stack.
+            while($parent = array_pop($composites)) {
+              $parent->add($builder->map($composite));
+              $composite = $parent;
             }
 
             $registry->addFieldResolver(

--- a/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
@@ -45,4 +45,8 @@ class DirectableSchemaTest extends GraphQLTestBase {
   function testPropDirective() {
     $this->assertResults('{ prop }', [], ['prop' => 'bar']);
   }
+
+  function testMapDirective() {
+    $this->assertResults('{ map }', [], ['map' => ['a', 'b']]);
+  }
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
@@ -41,4 +41,8 @@ class DirectableSchemaTest extends GraphQLTestBase {
   function testSeekDirective() {
     $this->assertResults('{ seek }', [], ['seek' => 'two']);
   }
+
+  function testPropDirective() {
+    $this->assertResults('{ prop }', [], ['prop' => 'bar']);
+  }
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
@@ -5,4 +5,5 @@ type Query {
   bar: String @unknown
   seek: String! @value(json: "[\"one\", \"two\"]") @seek(pos: 1)
   prop: String! @value(json: "{\"foo\": \"bar\"}") @prop(key: "foo")
+  map: [String!]! @value(json: "[{\"x\": \"a\"},{\"x\": \"b\"}]") @map @prop(key: "x")
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
@@ -4,4 +4,5 @@ type Query {
   foo: String! @value(json: "\"bar\"")
   bar: String @unknown
   seek: String! @value(json: "[\"one\", \"two\"]") @seek(pos: 1)
+  prop: String! @value(json: "{\"foo\": \"bar\"}") @prop(key: "foo")
 }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql_directives`

## Description of changes

Add a `@prop` directive that extracts a single property from a map or
object. Implement a special `@map` directive that allows to map over lists and apply other directives to items.

## Motivation and context

Avoid custom resolvers and directives when dealing with lists.

## Related Issue(s)

#1170

## How has this been tested?

* kernel tests
