### PR TITLE
graphql-directives: schema extension support

### DIFF
--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -177,3 +177,14 @@ class EchoDirective extends PluginBase implements DirectiveInterface {
   }
 }
 ```
+
+## Schema Extensions
+
+The module provides a `DirectableSchemaExtensionPluginBase` class that can be
+used to create schema extensions that react to directives in the parent schema
+definition. A schema extension plugin for the Drupal GraphQL module provides two
+schema definitions: one for the "base" schema and one for the actual extensions.
+In case of directable schema extension, the base schema definition should contain
+the directives while the extension schema defines the derived types and fields.
+
+For a very simple example, please refer to the `graphql_directives_test` module.

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectableSchemaExtensionPluginBase.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectableSchemaExtensionPluginBase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\graphql_directives;
+
+use Drupal\graphql\GraphQL\ResolverRegistryInterface;
+use Drupal\graphql\Plugin\GraphQL\SchemaExtension\SdlSchemaExtensionPluginBase;
+use GraphQL\Language\AST\DocumentNode;
+
+/**
+ * Base class for directable schema extension plugins.
+ *
+ * Directable schema extension plugins get access to the parent schema AST and
+ * are allowed to adjust the extension definition and resolvers accordingly.
+ */
+abstract class DirectableSchemaExtensionPluginBase extends SdlSchemaExtensionPluginBase {
+
+  private DocumentNode $parentAst;
+
+  public function setParentAst(DocumentNode $ast) {
+    $this->parentAst = $ast;
+  }
+
+  abstract protected function getDirectableExtensionDefinition(DocumentNode $ast): string;
+  abstract protected function registerDirectableResolvers(DocumentNode $ast, ResolverRegistryInterface $registry): void;
+
+  /**
+   * {@inheritDoc}
+   */
+  final public function getExtensionDefinition() {
+    return $this->getDirectableExtensionDefinition($this->parentAst);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  final public function registerResolvers(ResolverRegistryInterface $registry) {
+    $this->registerDirectableResolvers($this->parentAst, $registry);
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
@@ -13,6 +13,7 @@ use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistry;
 use Drupal\graphql\Plugin\GraphQL\Schema\ComposableSchema;
 use Drupal\graphql\Plugin\SchemaExtensionPluginManager;
+use Drupal\graphql_directives\DirectableSchemaExtensionPluginBase;
 use Drupal\graphql_directives\DirectivePrinter;
 use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use GraphQL\Language\AST\NodeList;
@@ -226,6 +227,19 @@ class DirectableSchema extends ComposableSchema {
       'schema_definition' => 'schema.graphqls',
       'extensions' => [],
     ];
+  }
+
+  /**
+   *
+   */
+  public function getSchemaDocument(array $extensions = []) {
+    $document = parent::getSchemaDocument($extensions);
+    foreach($extensions as $extension) {
+      if ($extension instanceof DirectableSchemaExtensionPluginBase) {
+        $extension->setParentAst($document);
+      }
+    }
+    return $document;
   }
 
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/Kernel/DirectableSchemaTest.php
@@ -7,7 +7,10 @@ use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 
 class DirectableSchemaTest extends GraphQLTestBase {
 
-  public static $modules = ['graphql_directives'];
+  public static $modules = [
+    'graphql_directives',
+    'graphql_directives_test',
+  ];
 
   protected function setUp(): void {
     parent::setUp();
@@ -29,7 +32,10 @@ class DirectableSchemaTest extends GraphQLTestBase {
       'endpoint'=> '/graphql/directives-test',
       'schema' => 'directable',
       'schema_configuration'=> [
-        'directable' => ['schema_definition' => __DIR__ . '/../assets/schema.graphqls'],
+        'directable' => [
+          'schema_definition' => __DIR__ . '/../assets/schema.graphqls',
+          'extensions' => ['test_directable' => 'test_directable']
+        ],
       ],
     ]);
   }
@@ -62,5 +68,14 @@ class DirectableSchemaTest extends GraphQLTestBase {
       '{ interface { ... on A { y } ... on B { z } } }', [],
       ['interface' => [['y' => 'A'], ['z' => 'B']]]
     );
+  }
+
+  function testExtension() {
+    $this->assertResults('{ listArticle { title } }', [], [
+      'listArticle' => [
+        ['title' => 'One'],
+        ['title' => 'Two'],
+      ],
+    ]);
   }
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/schema.graphqls
@@ -32,3 +32,7 @@ type B implements TestInterface @type(id: "b") {
   type: String! @prop(key: "type")
   z: String! @prop(key: "z")
 }
+
+type Article @test_directable {
+  title: String! @prop(key: "title")
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/modules/graphql_directives_test/graphql/test_directable.base.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/modules/graphql_directives_test/graphql/test_directable.base.graphqls
@@ -1,0 +1,1 @@
+directive @test_directable on OBJECT

--- a/packages/composer/amazeelabs/graphql_directives/tests/modules/graphql_directives_test/graphql_directives_test.info.yml
+++ b/packages/composer/amazeelabs/graphql_directives/tests/modules/graphql_directives_test/graphql_directives_test.info.yml
@@ -1,0 +1,6 @@
+name: GraphQL Directives Test
+type: module
+description: 'Test plugin implementations for GraphQL Directives.'
+dependencies:
+  - graphql_directives:graphql_directives
+core_version_requirement: ^8.8.0 || ^9.0

--- a/packages/composer/amazeelabs/graphql_directives/tests/modules/graphql_directives_test/src/Plugin/GraphQL/SchemaExtension/TestDirectable.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/modules/graphql_directives_test/src/Plugin/GraphQL/SchemaExtension/TestDirectable.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\graphql_directives_test\Plugin\GraphQL\SchemaExtension;
+
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql\GraphQL\ResolverRegistryInterface;
+use Drupal\graphql_directives\DirectableSchemaExtensionPluginBase;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+
+/**
+ * @SchemaExtension(
+ *   id = "test_directable",
+ *   name = "Test directable",
+ * )
+ */
+class TestDirectable extends DirectableSchemaExtensionPluginBase {
+
+  protected function getDirectableExtensionDefinition(DocumentNode $ast): string {
+    $doc = [];
+    foreach ($ast->definitions as $definition) {
+      if ($definition instanceof ObjectTypeDefinitionNode) {
+        foreach ($definition->directives as $directive) {
+          if ($directive->name->value === 'test_directable') {
+            $type = $definition->name->value;
+            $doc[] = "extend type Query { list$type :[$type!]! }";
+          }
+        }
+      }
+    }
+    return implode("\n", $doc);
+  }
+
+  protected function registerDirectableResolvers(DocumentNode $ast, ResolverRegistryInterface $registry): void {
+    $builder = new ResolverBuilder();
+    foreach ($ast->definitions as $definition) {
+      if ($definition instanceof ObjectTypeDefinitionNode) {
+        foreach ($definition->directives as $directive) {
+          if ($directive->name->value === 'test_directable') {
+            $registry->addFieldResolver('Query', 'list' . $definition->name->value, $builder->fromValue([
+              [ 'title' => 'One'],
+              [ 'title' => 'Two'],
+            ]));
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql_directives`

## Description of changes

Add support for schema extensions that react to directives in the main
schema.

## Motivation and context

Example: Automatically provide gatsby listing fields based on `@entity`
directivs in the schema.

## Related Issue(s)

#1169

## How has this been tested?

* unit tests
* kernel tests

