### PR TITLE
Scroll iframe command

### DIFF
--- a/packages/composer/amazeelabs/silverback_iframe/src/WebformSubmissionForm.php
+++ b/packages/composer/amazeelabs/silverback_iframe/src/WebformSubmissionForm.php
@@ -16,14 +16,28 @@ class WebformSubmissionForm extends Original {
 
     // Pass the message to frontend.
     $request = \Drupal::request();
+    $form['#attached']['drupalSettings']['iframeCommand'] = [];
     if ($request->query->has('iframe_message')) {
-      $form['#attached']['drupalSettings']['iframeCommand'] = [
+      $form['#attached']['drupalSettings']['iframeCommand'][] = [
         'action' => 'displayMessages',
         'messages' => [$request->query->get('iframe_message')],
       ];
       $request->query->remove('iframe_message');
     }
     $form['#cache']['contexts'][] = 'url.query_args';
+
+    // @todo: there is one case which is not handled here: if the form fails
+    // validation, then the scroll command is not triggered. This is a bit
+    // trickier to implement, maybe we can do this by adding a custom form
+    // validation callback where we can check if the form already failed
+    // validation, and if yes then alter somehow the iframeCommand drupal js
+    // setting.
+    if ($form_state->isRebuilding()) {
+      $form['#attached']['drupalSettings']['iframeCommand'][] = [
+        'action' => 'scroll',
+        'scroll' => 'top',
+      ];
+    }
 
     return $form;
   }

--- a/packages/composer/amazeelabs/silverback_iframe_theme/iframeCommand.js
+++ b/packages/composer/amazeelabs/silverback_iframe_theme/iframeCommand.js
@@ -36,16 +36,21 @@
 
   // Pass the iframe command to the parent iframe.
   if (drupalSettings.iframeCommand) {
-    waitForParentIframe(function (parentIFrame) {
-      var command = drupalSettings.iframeCommand;
-      if (command.action === "redirect") {
-        command = $.extend(true, {}, command, {
-          path: removeIframeFromUrl(command.path),
+    var iframeCommands = !Array.isArray(drupalSettings.iframeCommand) ? new Array(drupalSettings.iframeCommand) : drupalSettings.iframeCommand;
+    if (iframeCommands.length > 0) {
+      waitForParentIframe(function (parentIFrame) {
+        iframeCommands.forEach(function(iframeCommand) {
+          var command = iframeCommand;
+          if (command.action === "redirect") {
+            command = $.extend(true, {}, command, {
+              path: removeIframeFromUrl(command.path),
+            });
+          }
+          parentIFrame.sendMessage(command, "*");
         });
-      }
-      parentIFrame.sendMessage(command, "*");
-    });
-    return;
+      });
+      return;
+    }
   }
 
   // Fallback behavior: get the redirect/messages from the page content.

--- a/packages/npm/@amazeelabs/silverback-iframe/src/types/iframe-command.ts
+++ b/packages/npm/@amazeelabs/silverback-iframe/src/types/iframe-command.ts
@@ -11,16 +11,23 @@ export type IframeCommandRedirect = {
 export type IframeCommandOther = {
   action: 'replaceWithMessages' | 'displayMessages';
   messages: Array<string>;
+  scroll?: string;
 };
+
+export type IframeCommandScroll = {
+  action: 'scroll';
+  scroll: string;
+}
 
 export type IframeCommand =
   | IframeCommandGetBaseUrl
   | IframeCommandRedirect
-  | IframeCommandOther;
+  | IframeCommandOther
+  | IframeCommandScroll;
 
 export const isIframeCommand = (variable: any): variable is IframeCommand => {
   if (typeof variable === 'object' && typeof variable.action === 'string') {
-    if (variable.action === 'getBaseUrl') {
+    if (['getBaseUrl', 'scroll'].includes(variable.action)) {
       return true;
     }
     if (


### PR DESCRIPTION
## Package(s) involved

@amazeelabs/silverback-iframe
amazeelabs/silverback_iframe_theme

## Description of changes

This introduces a new iframe command: **scroll**
The command can have for now just one parameter named _scroll_ which can have the value _top_ for the default implementation. Other types of scrolling can be done by passing an optional _scroll_ handler to the SilverbackIframe component, the same way like the _redirect_ handler is passed. 

The scroll command can be seen in action on multistep webforms. When navigating from one step to another, the page should scroll to the top of the form.

## Related Issue(s)

[Scroll embedded iframes to top on reload](https://amazeelabs.atlassian.net/browse/SLB-161)

## How has this been tested?

Locally, manual.
