### PR TITLE
graphql_directives: entity reference plugins

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -12,9 +12,15 @@
   <component name="PhpProjectSharedConfiguration" php_language_level="8.1">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
   <component name="PhpUnit">
     <phpunit_settings>
       <PhpUnitSettings configuration_file_path="$PROJECT_DIR$/apps/silverback-drupal/phpunit.xml.dist" custom_loader_path="$PROJECT_DIR$/apps/silverback-drupal/vendor/autoload.php" phpunit_phar_path="" use_configuration_file="true" />
     </phpunit_settings>
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="transferred" value="true" />
   </component>
 </project>

--- a/apps/silverback-drupal/generated/extra.composed.graphqls
+++ b/apps/silverback-drupal/generated/extra.composed.graphqls
@@ -6,6 +6,18 @@ directive @arg(name: String!) on FIELD_DEFINITION | UNION | INTERFACE
 
 """
 Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
+"""
+directive @resolveEntityReference(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
+"""
+directive @resolveEntityReferenceRevisions(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+
+"""
+Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
 """
 directive @lang(code: String) on FIELD_DEFINITION | UNION | INTERFACE

--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -6,6 +6,18 @@ directive @arg(name: String!) on FIELD_DEFINITION | UNION | INTERFACE
 
 """
 Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
+"""
+directive @resolveEntityReference(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
+"""
+directive @resolveEntityReferenceRevisions(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+
+"""
+Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
 """
 directive @lang(code: String) on FIELD_DEFINITION | UNION | INTERFACE
@@ -235,7 +247,7 @@ type Page @entity(type: "node", bundle: "page") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
   body: String @resolveProperty(path: "field_body.0.processed")
-  paragraphs: [PageParagraphs!]! @resolveEntityReferenceRevisions(field: "field_paragraphs", single: false)
+  paragraphs: [PageParagraphs!]! @resolveEntityReferenceRevisions(field: "field_paragraphs")
 }
 
 union PageParagraphs = ParagraphText | ParagraphReferences
@@ -245,8 +257,8 @@ type ParagraphText {
 }
 
 type ParagraphReferences {
-  references: [Article]! @resolveEntityReference(field: "field_references", single: false)
-  singleReference: GutenbergPage @resolveEntityReference(field: "field_single_reference", single: true)
+  references: [Article]! @resolveEntityReference(field: "field_references")
+  singleReference: GutenbergPage @resolveEntityReference(field: "field_single_reference") @seek(pos: 0)
 }
 
 type GutenbergPage @entity(type: "node", bundle: "gutenberg_page") {
@@ -265,8 +277,8 @@ type Article @entity(type: "node", bundle: "article") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
   body: String @resolveProperty(path: "field_body.0.processed")
-  tags: [Tag]! @resolveEntityReference(field: "field_tags", single: false)
-  image: Image @resolveEntityReference(field: "field_image", single: true)
+  tags: [Tag]! @resolveEntityReference(field: "field_tags")
+  image: Image @resolveEntityReference(field: "field_image") @seek(pos: 0)
   template: String @isTemplate
 }
 
@@ -346,10 +358,6 @@ directive @isTemplate on FIELD_DEFINITION
 DEPRECATED, use @isTemplate
 """
 directive @template on FIELD_DEFINITION
-
-directive @resolveEntityReference(field: String!, single: Boolean!) on FIELD_DEFINITION
-
-directive @resolveEntityReferenceRevisions(field: String!, single: Boolean!) on FIELD_DEFINITION
 
 directive @entity(type: String!, bundle: String, access: Boolean) on OBJECT
 

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -6,6 +6,18 @@ directive @arg(name: String!) on FIELD_DEFINITION | UNION | INTERFACE
 
 """
 Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
+"""
+directive @resolveEntityReference(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
+"""
+directive @resolveEntityReferenceRevisions(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+
+"""
+Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
 """
 directive @lang(code: String) on FIELD_DEFINITION | UNION | INTERFACE
@@ -235,7 +247,7 @@ type Page @entity(type: "node", bundle: "page") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
   body: String @resolveProperty(path: "field_body.0.processed")
-  paragraphs: [PageParagraphs!]! @resolveEntityReferenceRevisions(field: "field_paragraphs", single: false)
+  paragraphs: [PageParagraphs!]! @resolveEntityReferenceRevisions(field: "field_paragraphs")
 }
 
 union PageParagraphs = ParagraphText | ParagraphReferences
@@ -245,8 +257,8 @@ type ParagraphText {
 }
 
 type ParagraphReferences {
-  references: [Article]! @resolveEntityReference(field: "field_references", single: false)
-  singleReference: GutenbergPage @resolveEntityReference(field: "field_single_reference", single: true)
+  references: [Article]! @resolveEntityReference(field: "field_references")
+  singleReference: GutenbergPage @resolveEntityReference(field: "field_single_reference") @seek(pos: 0)
 }
 
 type GutenbergPage @entity(type: "node", bundle: "gutenberg_page") {
@@ -265,8 +277,8 @@ type Article @entity(type: "node", bundle: "article") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
   body: String @resolveProperty(path: "field_body.0.processed")
-  tags: [Tag]! @resolveEntityReference(field: "field_tags", single: false)
-  image: Image @resolveEntityReference(field: "field_image", single: true)
+  tags: [Tag]! @resolveEntityReference(field: "field_tags")
+  image: Image @resolveEntityReference(field: "field_image") @seek(pos: 0)
   template: String @isTemplate
 }
 
@@ -346,10 +358,6 @@ directive @isTemplate on FIELD_DEFINITION
 DEPRECATED, use @isTemplate
 """
 directive @template on FIELD_DEFINITION
-
-directive @resolveEntityReference(field: String!, single: Boolean!) on FIELD_DEFINITION
-
-directive @resolveEntityReferenceRevisions(field: String!, single: Boolean!) on FIELD_DEFINITION
 
 directive @entity(type: String!, bundle: String, access: Boolean) on OBJECT
 

--- a/apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/graphql/silverback_gatsby_test.graphqls
+++ b/apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/graphql/silverback_gatsby_test.graphqls
@@ -23,7 +23,7 @@ type Page @entity(type: "node", bundle: "page") {
   title: String! @resolveProperty(path: "title.value")
   body: String @resolveProperty(path: "field_body.0.processed")
   paragraphs: [PageParagraphs!]!
-    @resolveEntityReferenceRevisions(field: "field_paragraphs", single: false)
+    @resolveEntityReferenceRevisions(field: "field_paragraphs")
 }
 
 union PageParagraphs = ParagraphText | ParagraphReferences
@@ -33,10 +33,10 @@ type ParagraphText {
 }
 
 type ParagraphReferences {
-  references: [Article]!
-    @resolveEntityReference(field: "field_references", single: false)
+  references: [Article]! @resolveEntityReference(field: "field_references")
   singleReference: GutenbergPage
-    @resolveEntityReference(field: "field_single_reference", single: true)
+    @resolveEntityReference(field: "field_single_reference")
+    @seek(pos: 0)
 }
 
 type GutenbergPage @entity(type: "node", bundle: "gutenberg_page") {
@@ -59,8 +59,8 @@ type Article @entity(type: "node", bundle: "article") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
   body: String @resolveProperty(path: "field_body.0.processed")
-  tags: [Tag]! @resolveEntityReference(field: "field_tags", single: false)
-  image: Image @resolveEntityReference(field: "field_image", single: true)
+  tags: [Tag]! @resolveEntityReference(field: "field_tags")
+  image: Image @resolveEntityReference(field: "field_image") @seek(pos: 0)
   template: String @isTemplate
 }
 

--- a/apps/silverback-gatsby/generated/schema.graphql
+++ b/apps/silverback-gatsby/generated/schema.graphql
@@ -671,11 +671,11 @@ type DrupalMainMenu implements Node {
   remoteTypeName: String!
   translations: [DrupalMainMenu!]!
   remoteId: String!
+  items: [DrupalMenuItem!]!
   _original_typename: String!
   drupalId: String!
   defaultTranslation: Boolean!
   langcode: String!
-  items: [DrupalMenuItem!]!
   translation(langcode: String!): DrupalMainMenu!
   id: ID!
   parent: Node
@@ -685,22 +685,22 @@ type DrupalMainMenu implements Node {
 
 type DrupalMenuItem {
   remoteTypeName: String!
+  id: String!
+  parent: String
   label: String!
   url: String!
   _original_typename: String!
-  id: String!
-  parent: String!
 }
 
 type DrupalFirstLevelMainMenu implements Node {
   remoteTypeName: String!
   translations: [DrupalFirstLevelMainMenu!]!
   remoteId: String!
+  items: [DrupalMenuItem!]!
   _original_typename: String!
   drupalId: String!
   defaultTranslation: Boolean!
   langcode: String!
-  items: [DrupalMenuItem!]!
   translation(langcode: String!): DrupalFirstLevelMainMenu!
   id: ID!
   parent: Node
@@ -758,9 +758,9 @@ type Query {
   allDrupalGutenbergPage(filter: DrupalGutenbergPageFilterInput, sort: DrupalGutenbergPageSortInput, skip: Int, limit: Int): DrupalGutenbergPageConnection!
   drupalWebform(remoteTypeName: StringQueryOperatorInput, remoteId: StringQueryOperatorInput, path: StringQueryOperatorInput, url: StringQueryOperatorInput, title: StringQueryOperatorInput, _original_typename: StringQueryOperatorInput, drupalId: StringQueryOperatorInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): DrupalWebform
   allDrupalWebform(filter: DrupalWebformFilterInput, sort: DrupalWebformSortInput, skip: Int, limit: Int): DrupalWebformConnection!
-  drupalMainMenu(remoteTypeName: StringQueryOperatorInput, translations: DrupalMainMenuFilterListInput, remoteId: StringQueryOperatorInput, _original_typename: StringQueryOperatorInput, drupalId: StringQueryOperatorInput, defaultTranslation: BooleanQueryOperatorInput, langcode: StringQueryOperatorInput, items: DrupalMenuItemFilterListInput, translation: DrupalMainMenuFilterInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): DrupalMainMenu
+  drupalMainMenu(remoteTypeName: StringQueryOperatorInput, translations: DrupalMainMenuFilterListInput, remoteId: StringQueryOperatorInput, items: DrupalMenuItemFilterListInput, _original_typename: StringQueryOperatorInput, drupalId: StringQueryOperatorInput, defaultTranslation: BooleanQueryOperatorInput, langcode: StringQueryOperatorInput, translation: DrupalMainMenuFilterInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): DrupalMainMenu
   allDrupalMainMenu(filter: DrupalMainMenuFilterInput, sort: DrupalMainMenuSortInput, skip: Int, limit: Int): DrupalMainMenuConnection!
-  drupalFirstLevelMainMenu(remoteTypeName: StringQueryOperatorInput, translations: DrupalFirstLevelMainMenuFilterListInput, remoteId: StringQueryOperatorInput, _original_typename: StringQueryOperatorInput, drupalId: StringQueryOperatorInput, defaultTranslation: BooleanQueryOperatorInput, langcode: StringQueryOperatorInput, items: DrupalMenuItemFilterListInput, translation: DrupalFirstLevelMainMenuFilterInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): DrupalFirstLevelMainMenu
+  drupalFirstLevelMainMenu(remoteTypeName: StringQueryOperatorInput, translations: DrupalFirstLevelMainMenuFilterListInput, remoteId: StringQueryOperatorInput, items: DrupalMenuItemFilterListInput, _original_typename: StringQueryOperatorInput, drupalId: StringQueryOperatorInput, defaultTranslation: BooleanQueryOperatorInput, langcode: StringQueryOperatorInput, translation: DrupalFirstLevelMainMenuFilterInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): DrupalFirstLevelMainMenu
   allDrupalFirstLevelMainMenu(filter: DrupalFirstLevelMainMenuFilterInput, sort: DrupalFirstLevelMainMenuSortInput, skip: Int, limit: Int): DrupalFirstLevelMainMenuConnection!
   drupalGatsbyStringTranslation(remoteTypeName: StringQueryOperatorInput, remoteId: StringQueryOperatorInput, _original_typename: StringQueryOperatorInput, drupalId: StringQueryOperatorInput, source: StringQueryOperatorInput, context: StringQueryOperatorInput, translations: DrupalGatsbyStringTranslationTranslationFilterListInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): DrupalGatsbyStringTranslation
   allDrupalGatsbyStringTranslation(filter: DrupalGatsbyStringTranslationFilterInput, sort: DrupalGatsbyStringTranslationSortInput, skip: Int, limit: Int): DrupalGatsbyStringTranslationConnection!
@@ -5294,11 +5294,11 @@ input DrupalMainMenuFilterInput {
   remoteTypeName: StringQueryOperatorInput
   translations: DrupalMainMenuFilterListInput
   remoteId: StringQueryOperatorInput
+  items: DrupalMenuItemFilterListInput
   _original_typename: StringQueryOperatorInput
   drupalId: StringQueryOperatorInput
   defaultTranslation: BooleanQueryOperatorInput
   langcode: StringQueryOperatorInput
-  items: DrupalMenuItemFilterListInput
   translation: DrupalMainMenuFilterInput
   id: StringQueryOperatorInput
   parent: NodeFilterInput
@@ -5312,11 +5312,11 @@ input DrupalMenuItemFilterListInput {
 
 input DrupalMenuItemFilterInput {
   remoteTypeName: StringQueryOperatorInput
+  id: StringQueryOperatorInput
+  parent: StringQueryOperatorInput
   label: StringQueryOperatorInput
   url: StringQueryOperatorInput
   _original_typename: StringQueryOperatorInput
-  id: StringQueryOperatorInput
-  parent: StringQueryOperatorInput
 }
 
 type DrupalMainMenuConnection {
@@ -5347,33 +5347,33 @@ enum DrupalMainMenuFieldsEnum {
   translations___translations___translations___remoteTypeName
   translations___translations___translations___translations
   translations___translations___translations___remoteId
+  translations___translations___translations___items
   translations___translations___translations____original_typename
   translations___translations___translations___drupalId
   translations___translations___translations___defaultTranslation
   translations___translations___translations___langcode
-  translations___translations___translations___items
   translations___translations___translations___id
   translations___translations___translations___children
   translations___translations___remoteId
+  translations___translations___items
+  translations___translations___items___remoteTypeName
+  translations___translations___items___id
+  translations___translations___items___parent
+  translations___translations___items___label
+  translations___translations___items___url
+  translations___translations___items____original_typename
   translations___translations____original_typename
   translations___translations___drupalId
   translations___translations___defaultTranslation
   translations___translations___langcode
-  translations___translations___items
-  translations___translations___items___remoteTypeName
-  translations___translations___items___label
-  translations___translations___items___url
-  translations___translations___items____original_typename
-  translations___translations___items___id
-  translations___translations___items___parent
   translations___translations___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___id
@@ -5392,49 +5392,49 @@ enum DrupalMainMenuFieldsEnum {
   translations___translations___internal___type
   translations___translations___internal___contentFilePath
   translations___remoteId
+  translations___items
+  translations___items___remoteTypeName
+  translations___items___id
+  translations___items___parent
+  translations___items___label
+  translations___items___url
+  translations___items____original_typename
   translations____original_typename
   translations___drupalId
   translations___defaultTranslation
   translations___langcode
-  translations___items
-  translations___items___remoteTypeName
-  translations___items___label
-  translations___items___url
-  translations___items____original_typename
-  translations___items___id
-  translations___items___parent
   translations___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
@@ -5494,17 +5494,17 @@ enum DrupalMainMenuFieldsEnum {
   translations___internal___type
   translations___internal___contentFilePath
   remoteId
+  items
+  items___remoteTypeName
+  items___id
+  items___parent
+  items___label
+  items___url
+  items____original_typename
   _original_typename
   drupalId
   defaultTranslation
   langcode
-  items
-  items___remoteTypeName
-  items___label
-  items___url
-  items____original_typename
-  items___id
-  items___parent
   translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
@@ -5512,33 +5512,33 @@ enum DrupalMainMenuFieldsEnum {
   translation___translations___translations___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
@@ -5557,49 +5557,49 @@ enum DrupalMainMenuFieldsEnum {
   translation___translations___internal___type @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___internal___contentFilePath @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
@@ -5780,11 +5780,11 @@ input DrupalFirstLevelMainMenuFilterInput {
   remoteTypeName: StringQueryOperatorInput
   translations: DrupalFirstLevelMainMenuFilterListInput
   remoteId: StringQueryOperatorInput
+  items: DrupalMenuItemFilterListInput
   _original_typename: StringQueryOperatorInput
   drupalId: StringQueryOperatorInput
   defaultTranslation: BooleanQueryOperatorInput
   langcode: StringQueryOperatorInput
-  items: DrupalMenuItemFilterListInput
   translation: DrupalFirstLevelMainMenuFilterInput
   id: StringQueryOperatorInput
   parent: NodeFilterInput
@@ -5820,33 +5820,33 @@ enum DrupalFirstLevelMainMenuFieldsEnum {
   translations___translations___translations___remoteTypeName
   translations___translations___translations___translations
   translations___translations___translations___remoteId
+  translations___translations___translations___items
   translations___translations___translations____original_typename
   translations___translations___translations___drupalId
   translations___translations___translations___defaultTranslation
   translations___translations___translations___langcode
-  translations___translations___translations___items
   translations___translations___translations___id
   translations___translations___translations___children
   translations___translations___remoteId
+  translations___translations___items
+  translations___translations___items___remoteTypeName
+  translations___translations___items___id
+  translations___translations___items___parent
+  translations___translations___items___label
+  translations___translations___items___url
+  translations___translations___items____original_typename
   translations___translations____original_typename
   translations___translations___drupalId
   translations___translations___defaultTranslation
   translations___translations___langcode
-  translations___translations___items
-  translations___translations___items___remoteTypeName
-  translations___translations___items___label
-  translations___translations___items___url
-  translations___translations___items____original_typename
-  translations___translations___items___id
-  translations___translations___items___parent
   translations___translations___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___translation___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translations___id
@@ -5865,49 +5865,49 @@ enum DrupalFirstLevelMainMenuFieldsEnum {
   translations___translations___internal___type
   translations___translations___internal___contentFilePath
   translations___remoteId
+  translations___items
+  translations___items___remoteTypeName
+  translations___items___id
+  translations___items___parent
+  translations___items___label
+  translations___items___url
+  translations___items____original_typename
   translations____original_typename
   translations___drupalId
   translations___defaultTranslation
   translations___langcode
-  translations___items
-  translations___items___remoteTypeName
-  translations___items___label
-  translations___items___url
-  translations___items____original_typename
-  translations___items___id
-  translations___items___parent
   translations___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translations___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translations___translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translations___translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___translation___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translations___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
@@ -5967,17 +5967,17 @@ enum DrupalFirstLevelMainMenuFieldsEnum {
   translations___internal___type
   translations___internal___contentFilePath
   remoteId
+  items
+  items___remoteTypeName
+  items___id
+  items___parent
+  items___label
+  items___url
+  items____original_typename
   _original_typename
   drupalId
   defaultTranslation
   langcode
-  items
-  items___remoteTypeName
-  items___label
-  items___url
-  items____original_typename
-  items___id
-  items___parent
   translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
@@ -5985,33 +5985,33 @@ enum DrupalFirstLevelMainMenuFieldsEnum {
   translation___translations___translations___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translations___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translations___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___translation___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
@@ -6030,49 +6030,49 @@ enum DrupalFirstLevelMainMenuFieldsEnum {
   translation___translations___internal___type @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translations___internal___contentFilePath @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___translations___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translations___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___label @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___url @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___items___parent @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___remoteTypeName @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___translations @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___remoteId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
+  translation___translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation____original_typename @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___drupalId @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___defaultTranslation @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___langcode @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
-  translation___translation___translation___items @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___translation___children @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")
   translation___translation___id @deprecated(reason: "Sorting on fields that need arguments to resolve is deprecated.")

--- a/apps/silverback-gatsby/src/pages/sitemap.tsx
+++ b/apps/silverback-gatsby/src/pages/sitemap.tsx
@@ -16,7 +16,7 @@ export const query = graphql`
 
 type TreeInput = {
   id: string;
-  parent: string;
+  parent?: string;
   label: string;
   url: string;
 };

--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -311,6 +311,22 @@ Various menu item properties.
 - `@resolveMenuItemLabel`
 - `@resolveMenuItemUrl`
 
+### `@resolveEntityReference` & `@resolveEntityReferenceRevisions`
+
+Resolve referenced entities attached to a given `field`. Will attempt to
+retrieve translations matching the current host entity.
+
+```graphql
+type Query {
+  post(id: String!): Post @loadEntity(type: "node", id: "$id") @lang
+}
+
+type Post {
+  title: String! @resolveEntityLabel
+  related: [Post!]! @resolveEntityReference(field: "field_related")
+}
+```
+
 ## Extending
 
 To add custom directives, create a module and add new Plugins in the

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/EntityReference.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/EntityReference.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\Directive;
+
+
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\Core\TypedData\TranslatableInterface;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+
+/**
+ * @Directive(
+ *   id = "resolveEntityReference",
+ *   arguments = {
+ *     "field" = "String!"
+ *   }
+ * )
+ */
+class EntityReference extends PluginBase implements DirectiveInterface {
+
+  public function buildResolver(ResolverBuilder $builder, array $arguments): ResolverInterface {
+    return $builder->produce('entity_reference')
+      ->map('entity', $builder->fromParent())
+      ->map('language', $builder->callback(
+        fn(TranslatableInterface $value) => $value->language()->getId()
+      ))
+      ->map('field', $builder->fromValue($arguments['field']));
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/EntityReferenceRevisions.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/EntityReferenceRevisions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\Directive;
+
+
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\Core\TypedData\TranslatableInterface;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+
+/**
+ * @Directive(
+ *   id = "resolveEntityReferenceRevisions",
+ *   arguments = {
+ *     "field" = "String!"
+ *   }
+ * )
+ */
+class EntityReferenceRevisions extends PluginBase implements DirectiveInterface {
+
+  public function buildResolver(ResolverBuilder $builder, array $arguments): ResolverInterface {
+    return $builder->produce('entity_reference_revisions')
+      ->map('entity', $builder->fromParent())
+      ->map('language', $builder->callback(
+        fn(TranslatableInterface $value) => $value->language()->getId()
+      ))
+      ->map('field', $builder->fromValue($arguments['field']));
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/references/.graphqlconfig
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/references/.graphqlconfig
@@ -1,0 +1,5 @@
+{
+  "name": "Directives Test - References",
+  "schemaPath": "./schema.graphqls",
+  "includes": ["./directives.graphqls"]
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/references/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/references/schema.graphqls
@@ -1,0 +1,11 @@
+type Query {
+  article(nid: String!, lang: String!): Article
+    @loadEntity(type: "node", id: "$nid")
+    @resolveEntityTranslation(lang: "$lang")
+}
+
+type Article {
+  title: String! @resolveEntityLabel
+  references: [Article!]! @resolveEntityReference(field: "references")
+  revisions: [Article!]! @resolveEntityReferenceRevisions(field: "revisions")
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/EntitiesTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/EntitiesTest.php
@@ -5,7 +5,6 @@ namespace Drupal\Tests\graphql_directives\Kernel;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\graphql\Entity\Server;
 use Drupal\node\Entity\NodeType;
 use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
 use Drupal\Tests\graphql_directives\Traits\GraphQLDirectivesTestTrait;

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/EntityReferenceTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/EntityReferenceTest.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Drupal\Tests\graphql_directives\Kernel;
+
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql_directives\Traits\GraphQLDirectivesTestTrait;
+
+class EntityReferenceTest extends GraphQLTestBase {
+
+  use GraphQLDirectivesTestTrait;
+
+  public static $modules = [
+    'graphql_directives',
+    'node',
+    'field',
+    'entity_reference',
+    'entity_reference_revisions',
+  ];
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->setupDirectableSchema(__DIR__ . '/../../assets/references');
+    NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+      'translatable' => TRUE,
+    ])->save();
+
+    $this->container->get('content_translation.manager')->setEnabled(
+      'node',
+      'article',
+      TRUE
+    );
+
+    FieldStorageConfig::create([
+      'field_name' => 'references',
+      'type' => 'entity_reference',
+      'entity_type' => 'node',
+      'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED,
+      'settings' => [
+        'target_type' => 'node',
+      ],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'references',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+      'label' => 'References',
+      'settings' => [
+        'handler' => 'default',
+        'handler_settings' => [],
+      ],
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'revisions',
+      'type' => 'entity_reference_revisions',
+      'entity_type' => 'node',
+      'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED,
+      'settings' => [
+        'target_type' => 'node',
+      ],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'revisions',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+      'label' => 'Revisions',
+      'settings' => [
+        'handler' => 'default',
+        'handler_settings' => [],
+      ],
+    ])->save();
+  }
+
+  public function testEntityReference() {
+    $reference = Node::create([
+      'title' => 'Reference',
+      'type' => 'article',
+      'langcode' => 'en',
+    ]);
+    $reference->save();
+
+    $host = Node::create([
+      'type' => 'article',
+      'title' => 'Host',
+      'langcode' => 'en',
+      'references' => [$reference],
+    ]);
+    $host->save();
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($host);
+    $metadata->addCacheableDependency($reference);
+    $metadata->addCacheContexts(['static:language:en']);
+    $this->assertResults(
+      'query ($nid: String!) { article(nid: $nid, lang: "en") { title references { title } } }',
+      [
+        'nid' => $host->id(),
+        'lang' => 'en',
+      ], [
+      'article' => [
+        'title' => 'Host',
+        'references' => [
+          [
+            'title' => 'Reference',
+          ],
+        ],
+      ],
+    ], $metadata);
+  }
+
+  public function testTranslatedEntityReference() {
+    $reference = Node::create([
+      'title' => 'Reference',
+      'type' => 'article',
+    ]);
+    $reference->save();
+    $reference->addTranslation('de', [
+      'title' => 'Reference (de)',
+    ])->save();
+
+    $host = Node::create([
+      'type' => 'article',
+      'title' => 'Host',
+      'references' => [$reference],
+    ]);
+    $host->save();
+    $host->addTranslation('de', [
+      'title' => 'Host (de)',
+      'references' => [$reference],
+    ])->save();
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($host);
+    $metadata->addCacheableDependency($reference);
+    $metadata->addCacheContexts(['static:language:de']);
+    $this->assertResults(
+      'query ($nid: String!) { article(nid: $nid, lang: "de") { title references { title } } }',
+      [
+        'nid' => $host->id(),
+        'lang' => 'de',
+      ], [
+      'article' => [
+        'title' => 'Host (de)',
+        'references' => [
+          [
+            'title' => 'Reference (de)',
+          ],
+        ],
+      ],
+    ], $metadata);
+  }
+
+  public function testUntranslatedEntityReference() {
+    $reference = Node::create([
+      'title' => 'Reference',
+      'type' => 'article',
+    ]);
+    $reference->save();
+
+    $host = Node::create([
+      'type' => 'article',
+      'title' => 'Host',
+      'references' => [$reference],
+    ]);
+    $host->save();
+    $host->addTranslation('de', [
+      'title' => 'Host (de)',
+      'references' => [$reference],
+    ])->save();
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($host);
+    $metadata->addCacheableDependency($reference);
+    $metadata->addCacheContexts(['static:language:de']);
+    $this->assertResults(
+      'query ($nid: String!) { article(nid: $nid, lang: "de") { title references { title } } }',
+      [
+        'nid' => $host->id(),
+        'lang' => 'de',
+      ], [
+      'article' => [
+        'title' => 'Host (de)',
+        'references' => [
+          [
+            'title' => 'Reference',
+          ],
+        ],
+      ],
+    ], $metadata);
+  }
+
+  public function testUntranslatedEntityReferee() {
+    $reference = Node::create([
+      'title' => 'Reference',
+      'type' => 'article',
+    ]);
+    $reference->save();
+    $reference->addTranslation('de', [
+      'title' => 'Reference (de)',
+    ])->save();
+
+    $host = Node::create([
+      'type' => 'article',
+      'title' => 'Host',
+      'references' => [$reference],
+    ]);
+    $host->save();
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($host);
+    $metadata->addCacheableDependency($reference);
+    $metadata->addCacheContexts(['static:language:en']);
+    $this->assertResults(
+      'query ($nid: String!) { article(nid: $nid, lang: "en") { title references { title } } }',
+      [
+        'nid' => $host->id(),
+        'lang' => 'de',
+      ], [
+      'article' => [
+        'title' => 'Host',
+        'references' => [
+          [
+            'title' => 'Reference',
+          ],
+        ],
+      ],
+    ], $metadata);
+  }
+
+  public function testRevisionedEntityReference() {
+    $reference = Node::create([
+      'title' => 'Reference',
+      'type' => 'article',
+    ]);
+    $reference->save();
+
+    $host = Node::create([
+      'type' => 'article',
+      'title' => 'Host',
+      'references' => [$reference],
+      'revisions' => [$reference],
+    ]);
+    $host->save();
+
+    $reference->setNewRevision();
+    $reference->set('title', 'Reference (rev)');
+    $reference->save();
+
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($host);
+    $metadata->addCacheableDependency($reference);
+    $metadata->addCacheContexts(['static:language:en']);
+    $this->assertResults(
+      'query ($nid: String!) { article(nid: $nid, lang: "en") { title references { title } revisions { title } } }',
+      [
+        'nid' => $host->id(),
+        'lang' => 'en',
+      ], [
+      'article' => [
+        'title' => 'Host',
+        'references' => [
+          [
+            'title' => 'Reference (rev)',
+          ],
+        ],
+        'revisions' => [
+          [
+            'title' => 'Reference',
+          ],
+        ],
+      ],
+    ], $metadata);
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/graphql/silverback_gatsby.base.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/graphql/silverback_gatsby.base.graphqls
@@ -24,20 +24,6 @@ DEPRECATED, use @isTemplate
 """
 directive @template on FIELD_DEFINITION
 
-################################################################################
-# Directives for automatic resolvers.
-################################################################################
-
-directive @resolveEntityReference(
-  field: String!
-  single: Boolean!
-) on FIELD_DEFINITION
-
-directive @resolveEntityReferenceRevisions(
-  field: String!
-  single: Boolean!
-) on FIELD_DEFINITION
-
 # Directive for the "EntityFeed" plugin.
 directive @entity(type: String!, bundle: String, access: Boolean) on OBJECT
 

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
@@ -200,10 +200,7 @@ class SilverbackGatsbySchemaExtension extends DirectableSchemaExtensionPluginBas
       }
       foreach ($definition->fields as $field) {
         foreach ($field->directives as $fieldDirective) {
-          $list = [
-            'resolveEntityReference',
-            'resolveEntityReferenceRevisions',
-          ];
+          $list = [];
           if (in_array($fieldDirective->name->value, $list, TRUE)) {
             $graphQlPath = $definition->name->value . '.' . $field->name->value;
             $name = $fieldDirective->name->value;
@@ -394,49 +391,6 @@ class SilverbackGatsbySchemaExtension extends DirectableSchemaExtensionPluginBas
       [$type, $field] = explode('.', $path);
       $registry->addFieldResolver($type, $field, $resolver);
     };
-    foreach ($this->getResolveDirectives($ast) as $path => $definition) {
-      switch ($definition['name']) {
-
-        case 'resolveEntityReference':
-          $resolverMultiple = $builder->defaultValue(
-            $builder->produce('entity_reference')
-              ->map('entity', $builder->fromParent())
-              ->map('language', $builder->callback(
-                fn(TranslatableInterface $value) => $value->language()->getId()
-              ))
-              ->map('field', $builder->fromValue($definition['arguments']['field'])),
-            $builder->fromValue([])
-          );
-          if ($definition['arguments']['single']) {
-            $addResolver($path, $builder->compose(
-              $resolverMultiple,
-              $builder->callback(fn(array $values) => reset($values) ?: NULL)
-            ));
-          }
-          else {
-            $addResolver($path, $resolverMultiple);
-          }
-          break;
-
-        case 'resolveEntityReferenceRevisions':
-          $resolverMultiple = $builder->defaultValue(
-            $builder->produce('entity_reference_revisions')
-              ->map('entity', $builder->fromParent())
-              ->map('field', $builder->fromValue($definition['arguments']['field'])),
-            $builder->fromValue([])
-          );
-          if ($definition['arguments']['single']) {
-            $addResolver($path, $builder->compose(
-              $resolverMultiple,
-              $builder->callback(fn(array $values) => reset($values) ?: NULL)
-            ));
-          }
-          else {
-            $addResolver($path, $resolverMultiple);
-          }
-          break;
-      }
-    }
 
     $currentUser = $builder->produce('current_user_entity');
     $addResolver('Query.currentUser', $currentUser);

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/SchemaExtension/SilverbackGatsbySchemaExtension.php
@@ -187,49 +187,6 @@ class SilverbackGatsbySchemaExtension extends DirectableSchemaExtensionPluginBas
   }
 
   /**
-   * @see SilverbackGatsbySchemaExtension::$resolvers
-   */
-  protected function getResolveDirectives(DocumentNode $ast): array {
-    if (isset($this->resolvers)) {
-      return $this->resolvers;
-    }
-    $this->resolvers = [];
-    foreach ($ast->definitions->getIterator() as $definition) {
-      if (!($definition instanceof ObjectTypeDefinitionNode)) {
-        continue;
-      }
-      foreach ($definition->fields as $field) {
-        foreach ($field->directives as $fieldDirective) {
-          $list = [];
-          if (in_array($fieldDirective->name->value, $list, TRUE)) {
-            $graphQlPath = $definition->name->value . '.' . $field->name->value;
-            $name = $fieldDirective->name->value;
-            $this->resolvers[$graphQlPath] = [
-              'name' => $name,
-              'arguments' => [],
-            ];
-            foreach ($fieldDirective->arguments->getIterator() as $arg) {
-              /** @var \GraphQL\Language\AST\ArgumentNode $arg */
-              if ($arg->value instanceof ListValueNode) {
-                $this->resolvers[$graphQlPath]['arguments'][$arg->name->value] = [];
-                foreach ($arg->value->values->getIterator() as $value) {
-                  if ($value instanceof StringValueNode) {
-                    $this->resolvers[$graphQlPath]['arguments'][$arg->name->value][] = $value->value;
-                  }
-                }
-              }
-              else {
-                $this->resolvers[$graphQlPath]['arguments'][$arg->name->value] = $arg->value->value;
-              }
-            }
-          }
-        }
-      }
-    }
-    return $this->resolvers;
-  }
-
-  /**
    * Build the automatic schema definition for a given Feed.
    */
   protected function getSchemaDefinitions(DocumentNode $ast, FeedInterface $feed) : string {


### PR DESCRIPTION
## Package(s) involved

* `amazeelabs/graphql_directives`
* `amazeelabs/silverback_gatsby`

## Description of changes

Move `@resolveEntityReference` and `@resolveEntityReferenceRevisions`
directives to plugins.

## Motivation and context

Make these directives chainable.

## Related Issue(s)

#1169

## How has this been tested?

- [ ] Unit tests
- [x] Kernel tests
- [ ] Integration tests
