### PR TITLE
graphql_directives: default value directive

### DIFF
--- a/apps/silverback-drupal/generated/extra.composed.graphqls
+++ b/apps/silverback-drupal/generated/extra.composed.graphqls
@@ -2,84 +2,84 @@
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Arg".
 """
-directive @arg(name: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
 """
-directive @resolveEntityReference(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
 """
-directive @resolveEntityReferenceRevisions(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
 """
-directive @lang(code: String) on FIELD_DEFINITION | UNION | INTERFACE
+directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemId".
 """
-directive @resolveMenuItemId on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemLabel".
 """
-directive @resolveMenuItemLabel on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemParentId".
 """
-directive @resolveMenuItemParentId on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemUrl".
 """
-directive @resolveMenuItemUrl on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
 """
-directive @resolveMenuItems(max_level: Int) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
 """
-directive @resolveEditorBlockChildren on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMarkup".
 """
-directive @resolveEditorBlockMarkup on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMedia".
 """
-directive @resolveEditorBlockMedia on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockType".
 """
-directive @resolveEditorBlockType on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Apply all directives on the right to output on the left.
 """
-directive @map on FIELD_DEFINITION
+directive @map repeatable on FIELD_DEFINITION
 
 """
 Load a given entity by it's path or type and id or uuid
@@ -87,13 +87,13 @@ Load a given entity by it's path or type and id or uuid
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLoad".
 """
-directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) on FIELD_DEFINITION | UNION | INTERFACE
+directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Mark a type as member of a generic.
 The id argument contains a string that has to match the generics resolution.
 """
-directive @type(id: String!) on OBJECT
+directive @type(id: String!) repeatable on OBJECT
 
 """
 Parse a gutenberg document into block data.
@@ -101,7 +101,12 @@ Parse a gutenberg document into block data.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlocks".
 """
-directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+
+"""
+Provide a default value for a given type.
+"""
+directive @default repeatable on UNION | SCALAR | OBJECT | INTERFACE
 
 """
 Provide a static value as JSON string.
@@ -109,7 +114,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.
@@ -117,7 +122,7 @@ Pull a specific typed-data property from an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityProperty".
 """
-directive @resolveProperty(path: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Resolve a path to an Url object.
@@ -125,7 +130,7 @@ Resolve a path to an Url object.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Route".
 """
-directive @route(path: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve a specific translation of an entity.
@@ -133,7 +138,7 @@ Retrieve a specific translation of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslation".
 """
-directive @resolveEntityTranslation(lang: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve all translations of an entity.
@@ -141,7 +146,7 @@ Retrieve all translations of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslations".
 """
-directive @resolveEntityTranslations on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an editor block attribute.
@@ -149,7 +154,7 @@ Retrieve an editor block attribute.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockAttribute".
 """
-directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities bundle.
@@ -157,7 +162,7 @@ Retrieve an entities bundle.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityBundle".
 """
-directive @resolveEntityBundle on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities id.
@@ -165,7 +170,7 @@ Retrieve an entities id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityId".
 """
-directive @resolveEntityId on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities label.
@@ -173,7 +178,7 @@ Retrieve an entities label.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLabel".
 """
-directive @resolveEntityLabel on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities type id.
@@ -181,7 +186,7 @@ Retrieve an entities type id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityType".
 """
-directive @resolveEntityType on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities url path.
@@ -189,7 +194,7 @@ Retrieve an entities url path.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityPath".
 """
-directive @resolveEntityPath on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities uuid.
@@ -197,7 +202,7 @@ Retrieve an entities uuid.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityUuid".
 """
-directive @resolveEntityUuid on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an object or map property.
@@ -205,7 +210,7 @@ Retrieve an object or map property.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop".
 """
-directive @prop(key: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve the language of an entity.
@@ -213,7 +218,7 @@ Retrieve the language of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLanguage".
 """
-directive @resolveEntityLanguage on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Seek a specific element in a list.
@@ -221,7 +226,7 @@ Seek a specific element in a list.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Seek".
 """
-directive @seek(pos: Int!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 schema {
   query: Query

--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -2,84 +2,84 @@
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Arg".
 """
-directive @arg(name: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
 """
-directive @resolveEntityReference(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
 """
-directive @resolveEntityReferenceRevisions(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
 """
-directive @lang(code: String) on FIELD_DEFINITION | UNION | INTERFACE
+directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemId".
 """
-directive @resolveMenuItemId on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemLabel".
 """
-directive @resolveMenuItemLabel on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemParentId".
 """
-directive @resolveMenuItemParentId on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemUrl".
 """
-directive @resolveMenuItemUrl on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
 """
-directive @resolveMenuItems(max_level: Int) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
 """
-directive @resolveEditorBlockChildren on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMarkup".
 """
-directive @resolveEditorBlockMarkup on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMedia".
 """
-directive @resolveEditorBlockMedia on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockType".
 """
-directive @resolveEditorBlockType on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Apply all directives on the right to output on the left.
 """
-directive @map on FIELD_DEFINITION
+directive @map repeatable on FIELD_DEFINITION
 
 """
 Load a given entity by it's path or type and id or uuid
@@ -87,13 +87,13 @@ Load a given entity by it's path or type and id or uuid
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLoad".
 """
-directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) on FIELD_DEFINITION | UNION | INTERFACE
+directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Mark a type as member of a generic.
 The id argument contains a string that has to match the generics resolution.
 """
-directive @type(id: String!) on OBJECT
+directive @type(id: String!) repeatable on OBJECT
 
 """
 Parse a gutenberg document into block data.
@@ -101,7 +101,12 @@ Parse a gutenberg document into block data.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlocks".
 """
-directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+
+"""
+Provide a default value for a given type.
+"""
+directive @default repeatable on UNION | SCALAR | OBJECT | INTERFACE
 
 """
 Provide a static value as JSON string.
@@ -109,7 +114,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.
@@ -117,7 +122,7 @@ Pull a specific typed-data property from an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityProperty".
 """
-directive @resolveProperty(path: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Resolve a path to an Url object.
@@ -125,7 +130,7 @@ Resolve a path to an Url object.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Route".
 """
-directive @route(path: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve a specific translation of an entity.
@@ -133,7 +138,7 @@ Retrieve a specific translation of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslation".
 """
-directive @resolveEntityTranslation(lang: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve all translations of an entity.
@@ -141,7 +146,7 @@ Retrieve all translations of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslations".
 """
-directive @resolveEntityTranslations on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an editor block attribute.
@@ -149,7 +154,7 @@ Retrieve an editor block attribute.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockAttribute".
 """
-directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities bundle.
@@ -157,7 +162,7 @@ Retrieve an entities bundle.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityBundle".
 """
-directive @resolveEntityBundle on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities id.
@@ -165,7 +170,7 @@ Retrieve an entities id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityId".
 """
-directive @resolveEntityId on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities label.
@@ -173,7 +178,7 @@ Retrieve an entities label.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLabel".
 """
-directive @resolveEntityLabel on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities type id.
@@ -181,7 +186,7 @@ Retrieve an entities type id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityType".
 """
-directive @resolveEntityType on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities url path.
@@ -189,7 +194,7 @@ Retrieve an entities url path.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityPath".
 """
-directive @resolveEntityPath on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities uuid.
@@ -197,7 +202,7 @@ Retrieve an entities uuid.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityUuid".
 """
-directive @resolveEntityUuid on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an object or map property.
@@ -205,7 +210,7 @@ Retrieve an object or map property.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop".
 """
-directive @prop(key: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve the language of an entity.
@@ -213,7 +218,7 @@ Retrieve the language of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLanguage".
 """
-directive @resolveEntityLanguage on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Seek a specific element in a list.
@@ -221,7 +226,7 @@ Seek a specific element in a list.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Seek".
 """
-directive @seek(pos: Int!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 schema {
   query: Query
@@ -247,7 +252,7 @@ type Page @entity(type: "node", bundle: "page") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
   body: String @resolveProperty(path: "field_body.0.processed")
-  paragraphs: [PageParagraphs!]! @resolveEntityReferenceRevisions(field: "field_paragraphs")
+  paragraphs: [PageParagraphs]! @resolveEntityReferenceRevisions(field: "field_paragraphs")
 }
 
 union PageParagraphs = ParagraphText | ParagraphReferences
@@ -264,7 +269,7 @@ type ParagraphReferences {
 type GutenbergPage @entity(type: "node", bundle: "gutenberg_page") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
-  body: [RootBlock!]! @resolveEditorBlocks(path: "body.value", ignored: ["custom\/root", "core\/columns"])
+  body: [RootBlock]! @resolveEditorBlocks(path: "body.value", ignored: ["custom\/root", "core\/columns"])
 }
 
 type Webform @entity(type: "webform", access: false) {
@@ -287,11 +292,11 @@ union RootBlock @resolveEditorBlockType = BlockTwoColumns | BlockHtmlList | Bloc
 union ContentBlock @resolveEditorBlockType = BlockHtmlList | BlockHtmlParagraph | BlockHtmlQuote | BlockImage | BlockTeaser
 
 type BlockTwoColumns @type(id: "custom\/two-columns") {
-  children: [BlockColumn!]! @resolveEditorBlockChildren
+  children: [BlockColumn]! @resolveEditorBlockChildren
 }
 
 type BlockColumn @type(id: "core\/column") {
-  children: [ContentBlock!]! @resolveEditorBlockChildren
+  children: [ContentBlock]! @resolveEditorBlockChildren
 }
 
 type BlockHtmlParagraph @type(id: "core\/paragraph") {
@@ -326,23 +331,23 @@ type MenuItem {
 }
 
 type MainMenu @menu(menu_id: "main") {
-  items: [MenuItem!]! @lang @resolveMenuItems
+  items: [MenuItem]! @lang @resolveMenuItems
 }
 
 type FirstLevelMainMenu @menu(menu_id: "main", max_level: 1) {
-  items: [MenuItem!]! @lang @resolveMenuItems(max_level: 1)
+  items: [MenuItem]! @lang @resolveMenuItems(max_level: 1)
 }
 
 type GatsbyStringTranslation @stringTranslation(contextPrefix: "gatsby")
 
 type Feed {
-  typeName: String! @prop(key: "typeName")
-  translatable: Boolean! @prop(key: "translatable")
-  singleFieldName: String! @prop(key: "singleFieldName")
-  listFieldName: String! @prop(key: "listFieldName")
-  changes(lastBuild: Int, currentBuild: Int): [String!]! @prop(key: "changes")
-  pathFieldName: String @prop(key: "pathFieldName")
-  templateFieldName: String @prop(key: "templateFieldName")
+  typeName: String!
+  translatable: Boolean!
+  singleFieldName: String!
+  listFieldName: String!
+  changes(lastBuild: Int, currentBuild: Int): [String!]!
+  pathFieldName: String
+  templateFieldName: String
 }
 
 directive @isPath on FIELD_DEFINITION

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -2,84 +2,84 @@
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Arg".
 """
-directive @arg(name: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
 """
-directive @resolveEntityReference(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
 """
-directive @resolveEntityReferenceRevisions(field: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
 """
-directive @lang(code: String) on FIELD_DEFINITION | UNION | INTERFACE
+directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemId".
 """
-directive @resolveMenuItemId on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemLabel".
 """
-directive @resolveMenuItemLabel on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemParentId".
 """
-directive @resolveMenuItemParentId on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemUrl".
 """
-directive @resolveMenuItemUrl on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
 """
-directive @resolveMenuItems(max_level: Int) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
 """
-directive @resolveEditorBlockChildren on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMarkup".
 """
-directive @resolveEditorBlockMarkup on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMedia".
 """
-directive @resolveEditorBlockMedia on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockType".
 """
-directive @resolveEditorBlockType on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Apply all directives on the right to output on the left.
 """
-directive @map on FIELD_DEFINITION
+directive @map repeatable on FIELD_DEFINITION
 
 """
 Load a given entity by it's path or type and id or uuid
@@ -87,13 +87,13 @@ Load a given entity by it's path or type and id or uuid
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLoad".
 """
-directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) on FIELD_DEFINITION | UNION | INTERFACE
+directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Mark a type as member of a generic.
 The id argument contains a string that has to match the generics resolution.
 """
-directive @type(id: String!) on OBJECT
+directive @type(id: String!) repeatable on OBJECT
 
 """
 Parse a gutenberg document into block data.
@@ -101,7 +101,12 @@ Parse a gutenberg document into block data.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlocks".
 """
-directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+
+"""
+Provide a default value for a given type.
+"""
+directive @default repeatable on UNION | SCALAR | OBJECT | INTERFACE
 
 """
 Provide a static value as JSON string.
@@ -109,7 +114,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.
@@ -117,7 +122,7 @@ Pull a specific typed-data property from an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityProperty".
 """
-directive @resolveProperty(path: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Resolve a path to an Url object.
@@ -125,7 +130,7 @@ Resolve a path to an Url object.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Route".
 """
-directive @route(path: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve a specific translation of an entity.
@@ -133,7 +138,7 @@ Retrieve a specific translation of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslation".
 """
-directive @resolveEntityTranslation(lang: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve all translations of an entity.
@@ -141,7 +146,7 @@ Retrieve all translations of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslations".
 """
-directive @resolveEntityTranslations on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an editor block attribute.
@@ -149,7 +154,7 @@ Retrieve an editor block attribute.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockAttribute".
 """
-directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities bundle.
@@ -157,7 +162,7 @@ Retrieve an entities bundle.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityBundle".
 """
-directive @resolveEntityBundle on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities id.
@@ -165,7 +170,7 @@ Retrieve an entities id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityId".
 """
-directive @resolveEntityId on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities label.
@@ -173,7 +178,7 @@ Retrieve an entities label.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLabel".
 """
-directive @resolveEntityLabel on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities type id.
@@ -181,7 +186,7 @@ Retrieve an entities type id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityType".
 """
-directive @resolveEntityType on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities url path.
@@ -189,7 +194,7 @@ Retrieve an entities url path.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityPath".
 """
-directive @resolveEntityPath on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an entities uuid.
@@ -197,7 +202,7 @@ Retrieve an entities uuid.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityUuid".
 """
-directive @resolveEntityUuid on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve an object or map property.
@@ -205,7 +210,7 @@ Retrieve an object or map property.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop".
 """
-directive @prop(key: String!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Retrieve the language of an entity.
@@ -213,7 +218,7 @@ Retrieve the language of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLanguage".
 """
-directive @resolveEntityLanguage on FIELD_DEFINITION | UNION | INTERFACE
+directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 """
 Seek a specific element in a list.
@@ -221,7 +226,7 @@ Seek a specific element in a list.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Seek".
 """
-directive @seek(pos: Int!) on FIELD_DEFINITION | UNION | INTERFACE
+directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
 
 schema {
   query: Query
@@ -247,7 +252,7 @@ type Page @entity(type: "node", bundle: "page") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
   body: String @resolveProperty(path: "field_body.0.processed")
-  paragraphs: [PageParagraphs!]! @resolveEntityReferenceRevisions(field: "field_paragraphs")
+  paragraphs: [PageParagraphs]! @resolveEntityReferenceRevisions(field: "field_paragraphs")
 }
 
 union PageParagraphs = ParagraphText | ParagraphReferences
@@ -264,7 +269,7 @@ type ParagraphReferences {
 type GutenbergPage @entity(type: "node", bundle: "gutenberg_page") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
-  body: [RootBlock!]! @resolveEditorBlocks(path: "body.value", ignored: ["custom\/root", "core\/columns"])
+  body: [RootBlock]! @resolveEditorBlocks(path: "body.value", ignored: ["custom\/root", "core\/columns"])
 }
 
 type Webform @entity(type: "webform", access: false) {
@@ -287,11 +292,11 @@ union RootBlock @resolveEditorBlockType = BlockTwoColumns | BlockHtmlList | Bloc
 union ContentBlock @resolveEditorBlockType = BlockHtmlList | BlockHtmlParagraph | BlockHtmlQuote | BlockImage | BlockTeaser
 
 type BlockTwoColumns @type(id: "custom\/two-columns") {
-  children: [BlockColumn!]! @resolveEditorBlockChildren
+  children: [BlockColumn]! @resolveEditorBlockChildren
 }
 
 type BlockColumn @type(id: "core\/column") {
-  children: [ContentBlock!]! @resolveEditorBlockChildren
+  children: [ContentBlock]! @resolveEditorBlockChildren
 }
 
 type BlockHtmlParagraph @type(id: "core\/paragraph") {
@@ -326,23 +331,23 @@ type MenuItem {
 }
 
 type MainMenu @menu(menu_id: "main") {
-  items: [MenuItem!]! @lang @resolveMenuItems
+  items: [MenuItem]! @lang @resolveMenuItems
 }
 
 type FirstLevelMainMenu @menu(menu_id: "main", max_level: 1) {
-  items: [MenuItem!]! @lang @resolveMenuItems(max_level: 1)
+  items: [MenuItem]! @lang @resolveMenuItems(max_level: 1)
 }
 
 type GatsbyStringTranslation @stringTranslation(contextPrefix: "gatsby")
 
 type Feed {
-  typeName: String! @prop(key: "typeName")
-  translatable: Boolean! @prop(key: "translatable")
-  singleFieldName: String! @prop(key: "singleFieldName")
-  listFieldName: String! @prop(key: "listFieldName")
-  changes(lastBuild: Int, currentBuild: Int): [String!]! @prop(key: "changes")
-  pathFieldName: String @prop(key: "pathFieldName")
-  templateFieldName: String @prop(key: "templateFieldName")
+  typeName: String!
+  translatable: Boolean!
+  singleFieldName: String!
+  listFieldName: String!
+  changes(lastBuild: Int, currentBuild: Int): [String!]!
+  pathFieldName: String
+  templateFieldName: String
 }
 
 directive @isPath on FIELD_DEFINITION

--- a/apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/graphql/silverback_gatsby_test.graphqls
+++ b/apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/graphql/silverback_gatsby_test.graphqls
@@ -22,7 +22,7 @@ type Page @entity(type: "node", bundle: "page") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
   body: String @resolveProperty(path: "field_body.0.processed")
-  paragraphs: [PageParagraphs!]!
+  paragraphs: [PageParagraphs]!
     @resolveEntityReferenceRevisions(field: "field_paragraphs")
 }
 
@@ -42,7 +42,7 @@ type ParagraphReferences {
 type GutenbergPage @entity(type: "node", bundle: "gutenberg_page") {
   path: String! @isPath @resolveEntityPath
   title: String! @resolveProperty(path: "title.value")
-  body: [RootBlock!]!
+  body: [RootBlock]!
     @resolveEditorBlocks(
       path: "body.value"
       ignored: ["custom/root", "core/columns"]
@@ -80,11 +80,11 @@ union ContentBlock @resolveEditorBlockType =
   | BlockTeaser
 
 type BlockTwoColumns @type(id: "custom/two-columns") {
-  children: [BlockColumn!]! @resolveEditorBlockChildren
+  children: [BlockColumn]! @resolveEditorBlockChildren
 }
 
 type BlockColumn @type(id: "core/column") {
-  children: [ContentBlock!]! @resolveEditorBlockChildren
+  children: [ContentBlock]! @resolveEditorBlockChildren
 }
 
 type BlockHtmlParagraph @type(id: "core/paragraph") {
@@ -119,11 +119,11 @@ type MenuItem {
 }
 
 type MainMenu @menu(menu_id: "main") {
-  items: [MenuItem!]! @lang @resolveMenuItems
+  items: [MenuItem]! @lang @resolveMenuItems
 }
 
 type FirstLevelMainMenu @menu(menu_id: "main", max_level: 1) {
-  items: [MenuItem!]! @lang @resolveMenuItems(max_level: 1)
+  items: [MenuItem]! @lang @resolveMenuItems(max_level: 1)
 }
 
 type GatsbyStringTranslation @stringTranslation(contextPrefix: "gatsby")

--- a/apps/silverback-gatsby/generated/schema.graphql
+++ b/apps/silverback-gatsby/generated/schema.graphql
@@ -529,7 +529,7 @@ type DrupalPage implements Node {
   path: String!
   title: String!
   body: String
-  paragraphs: [DrupalPageParagraphs!]!
+  paragraphs: [DrupalPageParagraphs!]
   _original_typename: String!
   drupalId: String!
   defaultTranslation: Boolean!
@@ -597,7 +597,7 @@ type DrupalGutenbergPage implements Node {
   translations: [DrupalGutenbergPage!]!
   path: String!
   title: String!
-  body: [DrupalRootBlock!]!
+  body: [DrupalRootBlock!]
   _original_typename: String!
   drupalId: String!
   defaultTranslation: Boolean!
@@ -612,7 +612,7 @@ type DrupalGutenbergPage implements Node {
 union DrupalRootBlock = DrupalBlockTwoColumns | DrupalBlockHtmlList | DrupalBlockHtmlParagraph | DrupalBlockHtmlQuote | DrupalBlockImage | DrupalBlockTeaser
 
 type DrupalBlockTwoColumns {
-  children: [DrupalBlockColumn!]!
+  children: [DrupalBlockColumn!]
   _original_typename: String!
 }
 
@@ -647,7 +647,7 @@ type DrupalBlockTeaser {
 
 type DrupalBlockColumn {
   remoteTypeName: String!
-  children: [DrupalContentBlock!]!
+  children: [DrupalContentBlock!]
   _original_typename: String!
 }
 
@@ -671,7 +671,7 @@ type DrupalMainMenu implements Node {
   remoteTypeName: String!
   translations: [DrupalMainMenu!]!
   remoteId: String!
-  items: [DrupalMenuItem!]!
+  items: [DrupalMenuItem!]
   _original_typename: String!
   drupalId: String!
   defaultTranslation: Boolean!
@@ -696,7 +696,7 @@ type DrupalFirstLevelMainMenu implements Node {
   remoteTypeName: String!
   translations: [DrupalFirstLevelMainMenu!]!
   remoteId: String!
-  items: [DrupalMenuItem!]!
+  items: [DrupalMenuItem!]
   _original_typename: String!
   drupalId: String!
   defaultTranslation: Boolean!

--- a/apps/silverback-gatsby/src/components/content-blocks/two-columns.tsx
+++ b/apps/silverback-gatsby/src/components/content-blocks/two-columns.tsx
@@ -9,9 +9,9 @@ export const BlockTwoColumns: React.FC<BlockTwoColumnsFragment> = ({
   children,
 }) => (
   <div className="columns flex">
-    {children.map((column, index) => (
+    {children?.map((column, index) => (
       <div className="column w-1/2" key={index}>
-        {column.children.map((block) => {
+        {column.children?.map((block) => {
           switch (block.__typename) {
             case 'DrupalBlockHtmlParagraph':
             case 'DrupalBlockHtmlList':

--- a/apps/silverback-gatsby/src/pages/sitemap.tsx
+++ b/apps/silverback-gatsby/src/pages/sitemap.tsx
@@ -51,7 +51,7 @@ const Sitemap: React.FC<PageProps<SitemapQuery>> = ({ data }) => (
   <div>
     <h1>Sitemap</h1>
     {data.drupalMainMenu && (
-      <RenderTree items={buildTree(data.drupalMainMenu.items)} />
+      <RenderTree items={buildTree(data.drupalMainMenu.items || [])} />
     )}
   </div>
 );

--- a/apps/silverback-gatsby/src/templates/gutenberg-page.tsx
+++ b/apps/silverback-gatsby/src/templates/gutenberg-page.tsx
@@ -87,7 +87,7 @@ const GutenbergPage: React.FC<
         <tr>
           <Row>{page.title}</Row>
           <Row className="gutenberg-body">
-            {page.body.map((block) => {
+            {page.body?.map((block) => {
               switch (block.__typename) {
                 case 'DrupalBlockHtmlParagraph':
                 case 'DrupalBlockHtmlList':

--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -54,6 +54,28 @@ type Query {
 }
 ```
 
+### Default values
+
+The default directive can be used to catch `NULL` values anywhere in the chain.
+If any directive to left emits `NULL`, the result of directives to the right
+will be applied. If there are no directives to the right, it attempts to find an
+appropriate default value like `''`, `0`, `[]`, `false` or `{}`, based on the
+assigned GraphQL type. A `@default` directive on an optional field (no `!` in
+the return type) has no effect.
+
+```graphql
+type Query {
+  # This will emit `''`.
+  string: String! @default
+  # This will emit `0`.
+  int: Int! @default
+  # This will emit `[]`.
+  list: [String!]! @default
+  # This will emit `bar`
+  manual: String! @default @value(json: "\"bar\"")
+}
+```
+
 ### Type resolution
 
 Directives can also be used to resolve the runtime types of unions and

--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -56,23 +56,27 @@ type Query {
 
 ### Default values
 
-The default directive can be used to catch `NULL` values anywhere in the chain.
-If any directive to left emits `NULL`, the result of directives to the right
-will be applied. If there are no directives to the right, it attempts to find an
-appropriate default value like `''`, `0`, `[]`, `false` or `{}`, based on the
-assigned GraphQL type. A `@default` directive on an optional field (no `!` in
-the return type) has no effect.
+Since Drupal's data structures can't guarantee integrity, the graphql schema
+will enforce default values as much as possible. Whenever a type is annotated as
+non-nullable, it attempts to apply a default value if the value is `null`. The
+default value is determined by the type, e.g. `0` for `Int`, `false` for
+`Boolean`, `""` for `String` and `[]` for list types like `[String!]!`.
+
+For custom types, interface, unions or scalars, the `@default` directive can be
+used to start a directive chain that defines a default value.
 
 ```graphql
+scalar MyScalar @default @value(json: "\"bar\"")
+
 type Query {
   # This will emit `''`.
-  string: String! @default
+  string: String! @value(json: "null")
   # This will emit `0`.
-  int: Int! @default
+  int: Int! @value(json: "null")
   # This will emit `[]`.
-  list: [String!]! @default
+  list: [String!]! @value(json: "null")
   # This will emit `bar`
-  manual: String! @default @value(json: "\"bar\"")
+  manual: MyScalar! @value(json: "null")
 }
 ```
 

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectiveInterpreter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectiveInterpreter.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace Drupal\graphql_directives;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use GraphQL\Language\AST\ArgumentNode;
+use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
+use GraphQL\Language\AST\ListTypeNode;
+use GraphQL\Language\AST\ListValueNode;
+use GraphQL\Language\AST\NamedTypeNode;
+use GraphQL\Language\AST\NameNode;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\NonNullTypeNode;
+use GraphQL\Language\AST\NullValueNode;
+use GraphQL\Language\AST\ObjectFieldNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Language\AST\ObjectValueNode;
+use GraphQL\Language\AST\ScalarTypeDefinitionNode;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Language\AST\TypeDefinitionNode;
+use GraphQL\Language\AST\TypeNode;
+use GraphQL\Language\AST\UnionTypeDefinitionNode;
+use GraphQL\Language\AST\ValueNode;
+
+class DirectiveInterpreter {
+
+  /**
+   * @var \Drupal\graphql\GraphQL\Resolver\ResolverInterface[] $defaultValueMap
+   */
+  protected array $defaultValueMap;
+
+  /**
+   * @var \Drupal\graphql\GraphQL\Resolver\ResolverInterface[][] $fieldResolvers
+   */
+  protected array $fieldResolvers = [];
+
+  /**
+   * @var \Drupal\graphql\GraphQL\Resolver\ResolverInterface[] $typeResolvers
+   */
+  protected array $typeResolvers = [];
+
+  /**
+   * @return \Drupal\graphql\GraphQL\Resolver\ResolverInterface[][]
+   */
+  public function getFieldResolvers(): array {
+    return $this->fieldResolvers;
+  }
+
+  /**
+   * @return \Drupal\graphql\GraphQL\Resolver\ResolverInterface[]
+   */
+  public function getTypeResolvers(): array {
+    return $this->typeResolvers;
+  }
+
+  public function __construct(
+    protected DocumentNode           $document,
+    protected ResolverBuilder        $builder,
+    protected PluginManagerInterface $directiveManager
+  ) {
+    $this->defaultValueMap = [
+      'ID' => $builder->fromValue('#'),
+      'String' => $builder->fromValue(''),
+      'Int' => $builder->fromValue(0),
+      'Float' => $builder->fromValue(0.0),
+      'Boolean' => $builder->fromValue(FALSE),
+    ];
+  }
+
+  protected function addFieldResolver(string $type, string $field, ResolverInterface $resolver) {
+    $this->fieldResolvers[$type][$field] = $resolver;
+  }
+
+  protected function addTypeResolver(string $type, ResolverInterface $resolver) {
+    $this->typeResolvers[$type] = $resolver;
+  }
+
+  public function interpret() {
+    // First pass, collect all type and default resolvers.
+    foreach ($this->document->definitions as $definition) {
+      if ($definition instanceof ObjectTypeDefinitionNode) {
+        if ($resolver = $this->buildDefaultResolver($definition->directives)) {
+          $this->defaultValueMap[$definition->name->value] = $resolver;
+        }
+      }
+      if ($definition instanceof InterfaceTypeDefinitionNode || $definition instanceof UnionTypeDefinitionNode) {
+        $this->defaultValueMap[$definition->name->value] = $this->buildDefaultResolver($definition->directives);
+        if ($resolver = $this->buildTypeResolver($definition->directives)) {
+          $this->addTypeResolver($definition->name->value, $resolver);
+        }
+      }
+      if ($definition instanceof ScalarTypeDefinitionNode) {
+        $this->defaultValueMap[$definition->name->value] = $this->buildDefaultResolver($definition->directives);
+      }
+    }
+
+    // Then, create directive-based resolvers for all annotated fields.
+    foreach ($this->document->definitions as $definition) {
+      if ($definition instanceof ObjectTypeDefinitionNode) {
+        foreach ($definition->fields as $field) {
+          if ($field instanceof FieldDefinitionNode) {
+            if ($resolver = $this->buildFieldResolver($definition, $field)) {
+              $this->addFieldResolver($definition->name->value, $field->name->value, $resolver);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  protected function buildDefaultResolver(NodeList $annotations) {
+    $directives = [];
+    $default = FALSE;
+    foreach ($annotations as $annotation) {
+      if ($annotation instanceof DirectiveNode) {
+        if ($annotation->name->value === 'default') {
+          $default = TRUE;
+        }
+        if ($default && $this->directiveManager->hasDefinition($annotation->name->value)) {
+          $directives[] = $annotation;
+        }
+      }
+    }
+
+    if (count($directives) === 0) {
+      return NULL;
+    }
+
+    return (count($directives) === 1 && $directive = reset($directives))
+      ? $this->buildDirectiveResolver($directive)
+      : $this->builder->compose(...array_map([
+        $this,
+        'buildDirectiveResolver',
+      ], $directives));
+  }
+
+  protected function buildTypeResolver(NodeList $annotations) {
+    $directives = [];
+    foreach ($annotations as $annotation) {
+      if ($annotation instanceof DirectiveNode) {
+        if ($annotation->name->value === 'default') {
+          break;
+        }
+        if ($this->directiveManager->hasDefinition($annotation->name->value)) {
+          $directives[] = $annotation;
+        }
+      }
+    }
+
+    if (count($directives) === 0) {
+      return NULL;
+    }
+
+    return (count($directives) === 1 && $directive = reset($directives))
+      ? $this->buildDirectiveResolver($directive)
+      : $this->builder->compose(...array_map([
+        $this,
+        'buildDirectiveResolver',
+      ], $directives));
+  }
+
+  protected function buildFieldResolver(TypeDefinitionNode $objectType, FieldDefinitionNode $field) {
+    /** @var \GraphQL\Language\AST\DirectiveNode[] $directives */
+    $directives = array_values(array_filter(iterator_to_array($field->directives->getIterator()), function ($directive) {
+      return
+        $directive instanceof DirectiveNode &&
+        ($directive->name->value === 'map' ||
+        $this->directiveManager->hasDefinition($directive->name->value));
+    }));
+
+    /** @var array{\GraphQL\Language\AST\DirectiveNode[], \GraphQL\Language\AST\TypeNode, bool}[] $frames */
+    $frames = [];
+    /** @var array{\GraphQL\Language\AST\DirectiveNode[], \GraphQL\Language\AST\TypeNode, bool}  $currentFrame */
+    $currentFrame = [[], $field->type, FALSE];
+
+    $split = [[]];
+    for($i = 0; $i < count($directives); $i++) {
+      $directive = $directives[$i];
+      if ($directive->name->value === 'map') {
+        $split[] = [];
+      }
+      else {
+        $split[count($split) - 1][] = $directive;
+      }
+    }
+
+    while(!($currentFrame[1] instanceof NamedTypeNode)) {
+      if ($currentFrame[1] instanceof NonNullTypeNode) {
+        $currentFrame[2] = TRUE;
+        $currentFrame[1] = $currentFrame[1]->type;
+      }
+      if ($currentFrame[1] instanceof ListTypeNode) {
+        $currentFrame[0] = array_shift($split) ?? [];
+        $frames[] = $currentFrame;
+        $currentFrame = [[], $currentFrame[1]->type, FALSE];
+      }
+    }
+
+    if (count($split) > 1) {
+      throw new MapNestingException($objectType->name->value, $field->name->value);
+    }
+
+    $frames[] = [array_shift($split) ?? [], $currentFrame[1], $currentFrame[2]];
+    // If the first frame has no directive, we inject a magic @prop directive.
+    if (count($frames[0][0]) === 0) {
+      $frames[0][0] = [
+        new DirectiveNode([
+          'name' => new NameNode(['value' => 'prop']),
+          'arguments' => new NodeList(
+            [
+              new ArgumentNode([
+                'name' => new NameNode(['value' => 'key']),
+                'value' => new StringValueNode(['value' => $field->name->value]),
+              ]),
+            ]
+          ),
+        ]),
+      ];
+    }
+
+    return count($frames) === 1
+      ? $this->buildFrameResolver($frames[0][0], $frames[0][1], $frames[0][2])
+      : $this->builder->compose(...array_map(function ($frame, $index) {
+        return $index === 0
+          ? $this->buildFrameResolver($frame[0], $frame[1], $frame[2])
+          : $this->builder->map($this->buildFrameResolver($frame[0], $frame[1], $frame[2]));
+      }, $frames, array_keys($frames)));
+
+  }
+
+  /**
+   * @param \GraphQL\Language\AST\DirectiveNode[] $directives
+   * @param \GraphQL\Language\AST\TypeNode $type
+   * @param bool $nonNullable
+   *
+   * @return \Drupal\graphql\GraphQL\Resolver\ResolverInterface|null
+   * @throws \Drupal\graphql_directives\MissingDefaultException
+   */
+  protected function buildFrameResolver(array $directives, TypeNode $type, bool $nonNullable): ?ResolverInterface {
+    if (count($directives) === 0) {
+      $resolver = $this->builder->fromParent();
+    }
+    else {
+      $resolver = (count($directives) === 1 && $directive = reset($directives))
+        ? $this->buildDirectiveResolver($directive)
+        : $this->builder->compose(...array_map([
+          $this,
+          'buildDirectiveResolver',
+        ], $directives));
+    }
+
+    return $nonNullable
+      ? $this->builder->defaultValue($resolver, $this->buildDefaultValue($type))
+      : $resolver;
+  }
+
+  protected function buildDefaultValue(TypeNode $type): ResolverInterface {
+    if ($type instanceof NonNullTypeNode) {
+      return $this->buildDefaultValue($type->type);
+    }
+    if ($type instanceof ListTypeNode) {
+      return $this->builder->fromValue([]);
+    }
+    /** @var \GraphQL\Language\AST\NamedTypeNode $type */
+    if (!isset($this->defaultValueMap[$type->name->value])) {
+      throw new MissingDefaultException($type->name->value);
+    }
+    return $this->defaultValueMap[$type->name->value];
+  }
+
+  protected function buildDirectiveResolver(DirectiveNode $directive): ResolverInterface {
+    $plugin = $this->directiveManager->createInstance($directive->name->value);
+    return $plugin->buildResolver($this->builder, $this->buildParameters($directive));
+  }
+
+  protected function buildParameters(DirectiveNode $directive): array {
+    $config = [];
+    if ($directive->arguments) {
+      foreach ($directive->arguments as $argument) {
+        $config[$argument->name->value] = $this->extractArgument($argument->value);
+      }
+    }
+    return $config;
+  }
+
+  protected function extractArgument(ValueNode $value): mixed {
+    if ($value instanceof NullValueNode) {
+      return NULL;
+    }
+    else {
+      if ($value instanceof ListValueNode) {
+        return array_map([
+          $this,
+          'extractArgument',
+        ], iterator_to_array($value->values->getIterator()));
+      }
+      else {
+        if ($value instanceof ObjectValueNode) {
+          return array_reduce(array_map(function (ObjectFieldNode $field) {
+            return [$field->name->value => $this->extractArgument($field->value)];
+          }, iterator_to_array($value->fields->getIterator())), 'array_merge', []);
+        }
+        else {
+          return $value->value;
+        }
+      }
+    }
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
@@ -23,6 +23,20 @@ class DirectivePrinter {
   public function printDirectives() {
     $definitions = $this->directiveManager->getDefinitions();
 
+    $default = new DirectiveDefinitionNode([
+      'name' => new NameNode(['value' => 'default']),
+      'repeatable' => TRUE,
+      'description' => new StringValueNode(['value' => implode("\n", [
+        'Provide an automatic or manual default value.'
+      ]), 'block' => TRUE]),
+      'arguments' => new NodeList([]),
+      'locations' => new NodeList([
+        new NameNode(['value' => DirectiveLocation::FIELD_DEFINITION]),
+        new NameNode(['value' => DirectiveLocation::UNION]),
+        new NameNode(['value' => DirectiveLocation::IFACE]),
+      ]),
+    ]);
+
     $map = new DirectiveDefinitionNode([
       'name' => new NameNode(['value' => 'map']),
       'repeatable' => TRUE,
@@ -54,6 +68,7 @@ class DirectivePrinter {
     ]);
 
     $directives = [
+      Printer::doPrint($default),
       Printer::doPrint($map),
       Printer::doPrint($type),
     ];

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
@@ -27,12 +27,13 @@ class DirectivePrinter {
       'name' => new NameNode(['value' => 'default']),
       'repeatable' => TRUE,
       'description' => new StringValueNode(['value' => implode("\n", [
-        'Provide an automatic or manual default value.'
+        'Provide a default value for a given type.'
       ]), 'block' => TRUE]),
       'arguments' => new NodeList([]),
       'locations' => new NodeList([
-        new NameNode(['value' => DirectiveLocation::FIELD_DEFINITION]),
         new NameNode(['value' => DirectiveLocation::UNION]),
+        new NameNode(['value' => DirectiveLocation::SCALAR]),
+        new NameNode(['value' => DirectiveLocation::OBJECT]),
         new NameNode(['value' => DirectiveLocation::IFACE]),
       ]),
     ]);
@@ -109,8 +110,10 @@ class DirectivePrinter {
         'arguments' => new NodeList($arguments),
         'locations' => new NodeList([
           new NameNode(['value' => DirectiveLocation::FIELD_DEFINITION]),
+          new NameNode(['value' => DirectiveLocation::SCALAR]),
           new NameNode(['value' => DirectiveLocation::UNION]),
           new NameNode(['value' => DirectiveLocation::IFACE]),
+          new NameNode(['value' => DirectiveLocation::OBJECT]),
         ]),
       ]);
       $directives[] = Printer::doPrint($dir);

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
@@ -25,6 +25,7 @@ class DirectivePrinter {
 
     $map = new DirectiveDefinitionNode([
       'name' => new NameNode(['value' => 'map']),
+      'repeatable' => TRUE,
       'description' => new StringValueNode(['value' => implode("\n", [
           'Apply all directives on the right to output on the left.'
         ]), 'block' => TRUE]),
@@ -36,6 +37,7 @@ class DirectivePrinter {
 
     $type = new DirectiveDefinitionNode([
       'name' => new NameNode(['value' => 'type']),
+      'repeatable' => TRUE,
       'description' => new StringValueNode(['value' => implode("\n", [
         'Mark a type as member of a generic.',
         'The id argument contains a string that has to match the generics resolution.'
@@ -85,6 +87,7 @@ class DirectivePrinter {
 
       $dir = new DirectiveDefinitionNode([
         'name' => new NameNode(['value' => $definition['id']]),
+        'repeatable' => TRUE,
         'description' => count($description)
           ? new StringValueNode(['value' => implode("\n", $description), 'block' => TRUE])
           : NULL,

--- a/packages/composer/amazeelabs/graphql_directives/src/MapNestingException.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/MapNestingException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\graphql_directives;
+
+class MapNestingException extends \Exception {
+  protected string $type;
+
+  public function __construct(string $type, string $field) {
+    $this->type = $type;
+    parent::__construct("Invalid nesting of @map directives in $type::$field. Maybe the return type has too many levels of []?");
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/MissingDefaultException.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/MissingDefaultException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\graphql_directives;
+
+class MissingDefaultException extends \Exception {
+  protected string $type;
+
+  public function __construct(string $type) {
+    $this->type = $type;
+    parent::__construct("Missing @default directive for type $type. Either add a @default directive to $type or turn all occasions of '$type!' into '$type'.");
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
@@ -7,24 +7,14 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\graphql\GraphQL\Execution\FieldContext;
-use Drupal\graphql\GraphQL\Resolver\Composite;
-use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
 use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistry;
 use Drupal\graphql\Plugin\GraphQL\Schema\ComposableSchema;
 use Drupal\graphql\Plugin\SchemaExtensionPluginManager;
 use Drupal\graphql_directives\DirectableSchemaExtensionPluginBase;
+use Drupal\graphql_directives\DirectiveInterpreter;
 use Drupal\graphql_directives\DirectivePrinter;
-use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
-use GraphQL\Language\AST\ListValueNode;
-use GraphQL\Language\AST\NamedTypeNode;
-use GraphQL\Language\AST\ListTypeNode;
-use GraphQL\Language\AST\NodeList;
-use GraphQL\Language\AST\NonNullTypeNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
-use GraphQL\Language\AST\ObjectValueNode;
-use GraphQL\Language\AST\ScalarTypeDefinitionNode;
-use GraphQL\Language\AST\UnionTypeDefinitionNode;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -105,115 +95,11 @@ class DirectableSchema extends ComposableSchema {
     ]);
   }
 
-  /**
-   * @param ?\GraphQL\Language\AST\NodeList $arguments
-   *
-   * @return array
-   */
-  protected function argumentsToParameters(?NodeList $arguments): array {
-    $config = [];
-    if ($arguments) {
-      foreach ($arguments as $argument) {
-        if ($argument->value instanceof ListValueNode) {
-          $config[$argument->name->value] = array_filter(array_map(
-            fn ($node) => !(
-              $node->value instanceof ObjectValueNode ||
-              $node->value instanceof ListValueNode
-            ) ? $node->value : null,
-            iterator_to_array($argument->value->values->getIterator())
-          ));
-        }
-        else if (!$argument->value instanceof ObjectValueNode) {
-          $config[$argument->name->value] = $argument->value->value;
-        }
-      }
-    }
-    return $config;
-  }
-
-  protected function buildResolverFromDirectives(
-    NodeList $directives,
-    ResolverBuilder $builder,
-    $automaticDefaultValue
-  ): ResolverInterface {
-    /**
-     * @var array{
-     *   type: string,
-     *   length: int,
-     *   composite: \Drupal\graphql\GraphQL\Resolver\Composite
-     * }[] $composites
-     */
-    $composites = [];
-    $composite = new Composite([]);
-    $count = 0;
-
-    // Stack composites of directives on top of each other.
-    foreach ($directives as $directive) {
-
-      // If the directive is "map" or "default" start a new stack entry.
-      if (in_array($directive->name->value, ['map', 'default'])) {
-        $composites[] = [
-          'type' => $directive->name->value,
-          'length' => $count,
-          'composite' => $composite,
-        ];
-        $count = 0;
-        $composite = new Composite([]);
-        continue;
-      }
-
-      // If the directive is implemented, add it to the current composite.
-      if ($this->directiveManager->hasDefinition($directive->name->value)) {
-        $plugin = $this->directiveManager
-          ->createInstance($directive->name->value);
-        $parameters = $this->argumentsToParameters($directive->arguments);
-        $composite->add($plugin->buildResolver(
-          $builder,
-          $parameters
-        ));
-        $count++;
-      }
-    }
-
-    // Fold the stack of composites, but adding each composite as a mapped
-    // resolver to its parent in the stack. Keep default value chain segments
-    // separated and chain them the other way around afterwards.
-    $defaultChain = [];
-    while($parent = array_pop($composites)) {
-      if($parent['type'] === 'map') {
-        $parent['composite']->add($builder->map($composite));
-      }
-      if ($parent['type'] === 'default') {
-        if ($count === 0) {
-          $defaultChain[] = $builder->fromValue($automaticDefaultValue);
-        }
-        else {
-          $defaultChain[] = $composite;
-        }
-      }
-      $count = $parent['length'];
-      $composite = $parent['composite'];
-    }
-
-    while($default = array_shift($defaultChain)) {
-      $composite = $builder->defaultValue($composite, $default);
-    }
-
-    return $composite;
-  }
-
   public function getResolverRegistry() {
     $registry = new ResolverRegistry();
     $extensions = $this->getExtensions();
     $builder = new ResolverBuilder();
     $document = $this->getSchemaDocument($extensions);
-
-    $scalars = ['String', 'Float', 'Int', 'Boolean'];
-    foreach ($document->definitions as $definition) {
-      if ($definition instanceof ScalarTypeDefinitionNode) {
-        $scalars[] = $definition->name->value;
-      }
-    }
 
     foreach ($document->definitions as $definition) {
       if ($definition instanceof ObjectTypeDefinitionNode) {
@@ -226,64 +112,24 @@ class DirectableSchema extends ComposableSchema {
             }
           }
         }
-        foreach($definition->fields as $field) {
-          if ($field->directives) {
-            $defaultValue = NULL;
-            if ($field->type instanceof NonNullTypeNode) {
-              $type = $field->type->type;
-              if ($type instanceof ListTypeNode) {
-                $defaultValue = [];
-              }
-              if ($type instanceof NamedTypeNode) {
-                if (!in_array($type->name->value, $scalars)) {
-                  $defaultValue = [];
-                }
-                else {
-                  if ($type->name->value === 'Int') {
-                    $defaultValue = 0;
-                  }
-                  else if ($type->name->value === 'Float') {
-                    $defaultValue = 0.0;
-                  }
-                  else if ($type->name->value === 'Boolean') {
-                    $defaultValue = 0.0;
-                  }
-                  else {
-                    $defaultValue = '';
-                  }
-                }
-              }
-            }
-            $registry->addFieldResolver(
-              $definition->name->value,
-              $field->name->value,
-              $this->buildResolverFromDirectives(
-                $field->directives,
-                $builder,
-                $defaultValue
-              )
-            );
-          }
-        }
       }
+    }
 
-      if (
-        $definition instanceof InterfaceTypeDefinitionNode
-        ||
-        $definition instanceof UnionTypeDefinitionNode
-      ) {
-        if ($definition->directives) {
-          $this->typeResolvers[$definition->name->value] = $this->buildResolverFromDirectives($definition->directives, $builder, NULL);
-          $registry->addTypeResolver(
-            $definition->name->value,
-            function ($value, $context, $info) use ($definition, $builder) {
-              $id = $this->typeResolvers[$definition->name->value]
-                ->resolve($value, [], $context, $info, new FieldContext($context, $info));
-              return $this->typeMap[$id];
-            }
-          );
-        }
+    $interpreter = new DirectiveInterpreter($document, $builder, $this->directiveManager);
+    $interpreter->interpret();
+    foreach($interpreter->getFieldResolvers() as $type => $fields) {
+      foreach($fields as $field => $resolver) {
+        $registry->addFieldResolver($type, $field, $resolver);
       }
+    }
+
+    foreach($interpreter->getTypeResolvers() as $type => $resolver) {
+      $registry->addTypeResolver(
+        $type,
+        function ($value, $context, $info) use ($resolver) {
+          $id = $resolver->resolve($value, [], $context, $info, new FieldContext($context, $info));
+          return $this->typeMap[$id];
+        });
     }
     return $registry;
   }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/default/.graphqlconfig
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/default/.graphqlconfig
@@ -1,0 +1,5 @@
+{
+  "name": "Directives Test - Default",
+  "schemaPath": "./schema.graphqls",
+  "includes": ["./directives.graphqls"]
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/default/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/default/schema.graphqls
@@ -1,22 +1,21 @@
+scalar Manual @default @value(json: "\"foo\"")
+
 type Query {
-  optional: String @default
-  string: String! @default
-  int: Int! @default
-  float: Float! @default
-  boolean: Boolean! @default
-  list: [String]! @default
-  object: Object! @default
-  manual: String! @default @value(json: "\"foo\"")
+  optional: String
+  string: String!
+  int: Int!
+  float: Float!
+  boolean: Boolean!
+  list: [String]!
+  listItem: [String!]! @value(json: "[null]")
+  manual: Manual!
+  object: Object!
 }
 
-type Object {
-  chain: String!
-    @value(json: "null")
-    @default
-    @prop(key: "foo")
-    @default
-    @value(json: "\"bar\"")
-  prop: String! @prop(key: "foo") @default
-  optional: String @prop(key: "optional") @default
-  mandatory: String! @prop(key: "mandatory") @default
+
+type Object @default @value(json: "{\"magic\": \"its magic\"}") {
+  magic: String!
+  prop: String! @prop(key: "magic")
+  optional: String
+  mandatory: String!
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/default/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/default/schema.graphqls
@@ -10,8 +10,13 @@ type Query {
 }
 
 type Object {
-  chain: String! @default @prop(key: "foo") @default @value(json: "\"bar\"")
+  chain: String!
+    @value(json: "null")
+    @default
+    @prop(key: "foo")
+    @default
+    @value(json: "\"bar\"")
   prop: String! @prop(key: "foo") @default
-  optional: String @default
-  mandatory: String! @default
+  optional: String @prop(key: "optional") @default
+  mandatory: String! @prop(key: "mandatory") @default
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/default/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/default/schema.graphqls
@@ -1,0 +1,17 @@
+type Query {
+  optional: String @default
+  string: String! @default
+  int: Int! @default
+  float: Float! @default
+  boolean: Boolean! @default
+  list: [String]! @default
+  object: Object! @default
+  manual: String! @default @value(json: "\"foo\"")
+}
+
+type Object {
+  chain: String! @default @prop(key: "foo") @default @value(json: "\"bar\"")
+  prop: String! @prop(key: "foo") @default
+  optional: String @default
+  mandatory: String! @default
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/entities/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/entities/schema.graphqls
@@ -16,5 +16,5 @@ type Post {
   language: ID! @resolveEntityLanguage
   body: String! @resolveProperty(path: "body.value")
   translation: Post @resolveEntityTranslation(lang: "fr")
-  translations: [Post!]! @resolveEntityTranslations
+  translations: [Post]! @resolveEntityTranslations
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/menu_links/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/menu_links/schema.graphqls
@@ -1,21 +1,21 @@
 type Query {
-  menu: Menu! @loadEntity(type: "menu", id: "main", operation: "view label")
-  limited: Limited!
+  menu: Menu @loadEntity(type: "menu", id: "main", operation: "view label")
+  limited: Limited
     @loadEntity(type: "menu", id: "main", operation: "view label")
-  de: Menu!
+  de: Menu
     @loadEntity(type: "menu", id: "main", operation: "view label")
     @lang(code: "de")
-  fr: Menu!
+  fr: Menu
     @loadEntity(type: "menu", id: "main", operation: "view label")
     @lang(code: "fr")
 }
 
 type Menu {
-  items: [MenuItem!]! @resolveMenuItems
+  items: [MenuItem]! @resolveMenuItems
 }
 
 type Limited {
-  items: [MenuItem!]! @resolveMenuItems(max_level: 2)
+  items: [MenuItem]! @resolveMenuItems(max_level: 2)
 }
 
 type MenuItem {

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/references/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/references/schema.graphqls
@@ -6,6 +6,6 @@ type Query {
 
 type Article {
   title: String! @resolveEntityLabel
-  references: [Article!]! @resolveEntityReference(field: "references")
-  revisions: [Article!]! @resolveEntityReferenceRevisions(field: "revisions")
+  references: [Article]! @resolveEntityReference(field: "references")
+  revisions: [Article]! @resolveEntityReferenceRevisions(field: "revisions")
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/utilities/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/utilities/schema.graphqls
@@ -9,9 +9,9 @@ type Query {
     @value(json: "[{\"x\": \"a\"},{\"x\": \"b\"}]")
     @map
     @prop(key: "x")
-  union: [TestUnion!]!
+  union: [TestUnion]!
     @value(json: "[{\"type\": \"a\", \"y\":\"A\"},{\"type\": \"b\", \"z\":\"B\"}]")
-  interface: [TestInterface!]!
+  interface: [TestInterface]!
     @value(json: "[{\"type\": \"a\", \"y\":\"A\"},{\"type\": \"b\", \"z\":\"B\"}]")
 }
 

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/DefaultValueTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/DefaultValueTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\Tests\graphql_directives\Kernel;
+
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql_directives\Traits\GraphQLDirectivesTestTrait;
+
+class DefaultValueTest extends GraphQLTestBase {
+  use GraphQLDirectivesTestTrait;
+
+  public static $modules = [
+    'graphql_directives',
+  ];
+
+  protected function setUp() : void {
+    parent::setUp();
+    $this->setupDirectableSchema(__DIR__ . '/../../assets/default');
+  }
+
+  public function testOptionalValue() {
+    $this->assertResults('{ optional }', [], ['optional' => NULL]);
+  }
+
+  public function testDefaultString() {
+    $this->assertResults('{ string }', [], ['string' => '']);
+  }
+
+  public function testDefaultInt() {
+    $this->assertResults('{ int }', [], ['int' => 0]);
+  }
+
+  public function testDefaultFloat() {
+    $this->assertResults('{ float }', [], ['float' => 0.0]);
+  }
+
+  public function testDefaultBoolean() {
+    $this->assertResults('{ boolean }', [], ['boolean' => FALSE]);
+  }
+
+  public function testDefaultList() {
+    $this->assertResults('{ list }', [], ['list' => []]);
+  }
+
+  public function testDefaultObject() {
+    $this->assertResults('{ object { prop, optional, mandatory }', [], ['object' => [
+      'prop' => '',
+      'optional' => NULL,
+      'mandatory' => '',
+    ]]);
+  }
+
+  public function testManualDefault() {
+    $this->assertResults('{ manual }', [], ['manual' => 'foo']);
+  }
+
+  public function testChainedDefaults() {
+    $this->assertResults('{ object { chained } }', [], [
+      'object' => [
+        'chain' => 'bar'
+      ]
+    ]);
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/DefaultValueTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/DefaultValueTest.php
@@ -42,7 +42,7 @@ class DefaultValueTest extends GraphQLTestBase {
   }
 
   public function testDefaultObject() {
-    $this->assertResults('{ object { prop, optional, mandatory }', [], ['object' => [
+    $this->assertResults('{ object { prop, optional, mandatory } }', [], ['object' => [
       'prop' => '',
       'optional' => NULL,
       'mandatory' => '',
@@ -54,7 +54,7 @@ class DefaultValueTest extends GraphQLTestBase {
   }
 
   public function testChainedDefaults() {
-    $this->assertResults('{ object { chained } }', [], [
+    $this->assertResults('{ object { chain } }', [], [
       'object' => [
         'chain' => 'bar'
       ]

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/DefaultValueTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/DefaultValueTest.php
@@ -41,9 +41,13 @@ class DefaultValueTest extends GraphQLTestBase {
     $this->assertResults('{ list }', [], ['list' => []]);
   }
 
+  public function testDefaultListItem() {
+    $this->assertResults('{ listItem }', [], ['listItem' => ['']]);
+  }
+
   public function testDefaultObject() {
     $this->assertResults('{ object { prop, optional, mandatory } }', [], ['object' => [
-      'prop' => '',
+      'prop' => 'its magic',
       'optional' => NULL,
       'mandatory' => '',
     ]]);
@@ -53,10 +57,10 @@ class DefaultValueTest extends GraphQLTestBase {
     $this->assertResults('{ manual }', [], ['manual' => 'foo']);
   }
 
-  public function testChainedDefaults() {
-    $this->assertResults('{ object { chain } }', [], [
+  public function testMagicProp() {
+    $this->assertResults('{ object { magic } }', [], [
       'object' => [
-        'chain' => 'bar'
+        'magic' => 'its magic'
       ]
     ]);
   }

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectiveInterpreterTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectiveInterpreterTest.php
@@ -1,0 +1,501 @@
+<?php
+
+namespace Drupal\Tests\graphql_directives\Unit;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+use Drupal\graphql_directives\DirectiveInterpreter;
+use Drupal\graphql_directives\MapNestingException;
+use Drupal\graphql_directives\MissingDefaultException;
+use Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop;
+use Drupal\Tests\UnitTestCase;
+use GraphQL\Language\Parser;
+
+class TestResolver implements ResolverInterface {
+
+  public function __construct(public $value, public $args = []) {
+  }
+
+  public function resolve($value, $args, $context, $info, $field) {
+  }
+
+  public function map($key, ResolverInterface $value) {
+    $this->args[$key] = $value;
+    return $this;
+  }
+
+}
+
+class TestDirective implements DirectiveInterface {
+
+  public function __construct(public $id) {
+  }
+
+  public function buildResolver(ResolverBuilder $builder, array $arguments): ResolverInterface {
+    $resolver = new TestResolver(['produce', $this->id]);
+    foreach ($arguments as $key => $value) {
+      $resolver->map($key, $builder->fromValue($value));
+    }
+    return $resolver;
+  }
+
+}
+
+class DirectiveInterpreterTest extends UnitTestCase {
+
+  protected ResolverBuilder $builder;
+
+  protected PluginManagerInterface $directiveManager;
+
+  protected function setUp() {
+    parent::setUp();
+    $this->directiveManager = $this->createMock(PluginManagerInterface::class);
+
+    // The directive manager only knows about fictional directives from @a to @z.
+    $this->directiveManager->method('hasDefinition')
+      ->willReturnCallback(fn($id) => $id === 'prop' || preg_match('/^[a-z]$/', $id));
+    // And returns a TestResolver with that requested id as value.
+    $this->directiveManager->method('createInstance')
+      ->willReturnCallback(fn($id) => $id === 'prop' ? new Prop([], 'prop', []) : new TestDirective($id));
+
+    $this->builder = $this->createMock(ResolverBuilder::class);
+    $this->builder->method('produce')
+      ->willReturnCallback(fn($id) => new TestResolver(['produce', $id]));
+    $this->builder->method('fromValue')
+      ->willReturnCallback(fn($value) => new TestResolver(['value', $value]));
+    $this->builder->method('fromParent')
+      ->willReturnCallback(fn() => new TestResolver(['parent']));
+    $this->builder->method('fromContext')
+      ->willReturnCallback(fn($name) => new TestResolver(['context', $name]));
+    $this->builder->method('fromArgument')
+      ->willReturnCallback(fn($name) => new TestResolver(['argument', $name]));
+    $this->builder->method('compose')
+      ->willReturnCallback(fn(...$resolvers) => new TestResolver([
+        'compose',
+        ...$resolvers,
+      ]));
+    $this->builder->method('defaultValue')
+      ->willReturnCallback(fn(...$resolvers) => new TestResolver([
+        'default',
+        ...$resolvers,
+      ]));
+
+    $this->builder->method('map')
+      ->willReturnCallback(fn(...$resolvers) => new TestResolver([
+        'map',
+        ...$resolvers,
+      ]));
+  }
+
+  protected function assertResolvers(string $schema, array $expected) {
+    $parsed = Parser::parse($schema);
+    $interpreter = new DirectiveInterpreter($parsed, $this->builder, $this->directiveManager);
+    $interpreter->interpret();
+    $this->assertEquals($expected, array_merge(
+      $interpreter->getTypeResolvers(),
+      $interpreter->getFieldResolvers(),
+    ));
+  }
+
+  public function testNoDirectives() {
+    $this->assertResolvers('type Query { a: String }', [
+      'Query' => [
+        'a' => $this->builder->produce('prop')
+          ->map('input', $this->builder->fromParent())
+          ->map('property', $this->builder->fromValue('a')),
+      ],
+    ]);
+  }
+
+  public function testNoKnownDirectives() {
+    $this->assertResolvers('type Query { a: String @unknown }', [
+      'Query' => [
+        'a' => $this->builder->produce('prop')
+          ->map('input', $this->builder->fromParent())
+          ->map('property', $this->builder->fromValue('a')),
+      ],
+    ]);
+  }
+
+  public function testSingleDirective() {
+    $this->assertResolvers('type Query { a: String @a }', [
+      'Query' => [
+        'a' => $this->builder->produce('a'),
+      ],
+    ]);
+  }
+
+  public function testChainedDirectives() {
+    $this->assertResolvers('type Query { a: String @a @b }', [
+      'Query' => [
+        'a' => $this->builder->compose(
+          $this->builder->produce('a'),
+          $this->builder->produce('b'),
+        ),
+      ],
+    ]);
+  }
+
+
+  public function testNullArgument() {
+    $this->assertResolvers('type Query { a: String @a(b: null) }', [
+      'Query' => [
+        'a' => $this->builder->produce('a')
+          ->map('b', $this->builder->fromValue(NULL)),
+      ],
+    ]);
+  }
+
+  public function testIntArgument() {
+    $this->assertResolvers('type Query { a: String @a(b: 0, c: -1) }', [
+      'Query' => [
+        'a' => $this->builder->produce('a')
+          ->map('b', $this->builder->fromValue(0))
+          ->map('c', $this->builder->fromValue(-1)),
+      ],
+    ]);
+  }
+
+  public function testFloatArgument() {
+    $this->assertResolvers('type Query { a: String @a(b: 1.34) }', [
+      'Query' => [
+        'a' => $this->builder->produce('a')
+          ->map('b', $this->builder->fromValue(1.34)),
+      ],
+    ]);
+  }
+
+  public function testStringArgument() {
+    $this->assertResolvers('type Query { a: String @a(b: "c") }', [
+      'Query' => [
+        'a' => $this->builder->produce('a')
+          ->map('b', $this->builder->fromValue('c')),
+      ],
+    ]);
+  }
+
+  public function testEnumArgument() {
+    $this->assertResolvers('type Query { a: String @a(b: C) }', [
+      'Query' => [
+        'a' => $this->builder->produce('a')
+          ->map('b', $this->builder->fromValue('C')),
+      ],
+    ]);
+  }
+
+  public function testObjectArgument() {
+    $this->assertResolvers('type Query { a: String @a(b: {c: "d"}) }', [
+      'Query' => [
+        'a' => $this->builder->produce('a')
+          ->map('b', $this->builder->fromValue(['c' => 'd'])),
+      ],
+    ]);
+  }
+
+  public function testListArgument() {
+    $this->assertResolvers('type Query { a: String @a(b: ["c", "d"]) }', [
+      'Query' => [
+        'a' => $this->builder->produce('a')
+          ->map('b', $this->builder->fromValue(['c', 'd'])),
+      ],
+    ]);
+  }
+
+  public function testNestedListArgument() {
+    $this->assertResolvers('type Query { a: String @a(b: ["c", ["d"]]) }', [
+      'Query' => [
+        'a' => $this->builder->produce('a')
+          ->map('b', $this->builder->fromValue(['c', ['d']])),
+      ],
+    ]);
+  }
+
+  public function testComplexArgument() {
+    $this->assertResolvers('type Query { a: String @a(b: {c: ["d", "e"]}) }', [
+      'Query' => [
+        'a' => $this->builder->produce('a')
+          ->map('b', $this->builder->fromValue(['c' => ['d', 'e']])),
+      ],
+    ]);
+  }
+
+  public function testOptional() {
+    $this->assertResolvers('type Query { a: String @a }', [
+      'Query' => [
+        'a' => $this->builder->produce('a'),
+      ],
+    ]);
+  }
+
+  public function testDefaultBoolean() {
+    $this->assertResolvers('type Query { a: Boolean! @a }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('a'),
+          $this->builder->fromValue(FALSE),
+        ),
+      ],
+    ]);
+  }
+
+  public function testDefaultID() {
+    $this->assertResolvers('type Query { a: ID! @a }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('a'),
+          $this->builder->fromValue('#'),
+        ),
+      ],
+    ]);
+  }
+
+  public function testDefaultString() {
+    $this->assertResolvers('type Query { a: String! @a }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('a'),
+          $this->builder->fromValue(''),
+        ),
+      ],
+    ]);
+  }
+
+  public function testDefaultInt() {
+    $this->assertResolvers('type Query { a: Int! @a }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('a'),
+          $this->builder->fromValue(0),
+        ),
+      ],
+    ]);
+  }
+
+  public function testDefaultFloat() {
+    $this->assertResolvers('type Query { a: Float! @a }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('a'),
+          $this->builder->fromValue(0.0),
+        ),
+      ],
+    ]);
+  }
+
+  public function testDefaultList() {
+    $this->assertResolvers('type Query { a: [Int]! @a }', [
+      'Query' => [
+        'a' => $this->builder->compose(
+          $this->builder->defaultValue(
+          $this->builder->produce('a'),
+          $this->builder->fromValue([]),
+          ),
+          $this->builder->map($this->builder->fromParent()),
+        ),
+      ],
+    ]);
+  }
+
+  public function testMultiDefault() {
+    $this->assertResolvers('type Query { a: String! @a @b }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->compose(
+            $this->builder->produce('a'),
+            $this->builder->produce('b'),
+          ),
+          $this->builder->fromValue(''),
+        ),
+      ],
+    ]);
+  }
+
+  public function testUnknownType() {
+    $this->expectException(MissingDefaultException::class);
+    $this->assertResolvers('type Query { a: Unknown! @a }', []);
+  }
+
+  public function testDefaultScalarType() {
+    $this->assertResolvers('scalar Email @default @c type Query { a: Email! @b }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('b'),
+          $this->builder->produce('c'),
+        ),
+      ],
+    ]);
+  }
+
+  public function testDefaultObjectType() {
+    $this->assertResolvers('type Object @default @c { a: String @a } type Query { a: Object! @b }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('b'),
+          $this->builder->produce('c'),
+        ),
+      ],
+      'Object' => [
+        'a' => $this->builder->produce('a'),
+      ],
+    ]);
+  }
+
+  public function testDefaultInterfaceType() {
+    $this->assertResolvers('interface Animal @b @default @c { a: String! @a } type Query { a: Animal! @b }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('b'),
+          $this->builder->produce('c'),
+        ),
+      ],
+      'Animal' => $this->builder->produce('b'),
+    ]);
+  }
+
+  public function testDefaultUnionType() {
+    $this->assertResolvers('union Animal @b @default @c = Cat | Dog type Query { a: Animal! @b }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('b'),
+          $this->builder->produce('c'),
+        ),
+      ],
+      'Animal' => $this->builder->produce('b'),
+    ]);
+  }
+
+
+  public function testOptionalMap() {
+    $this->assertResolvers('type Query { a: [String] @a @map @b }', [
+      'Query' => [
+        'a' => $this->builder->compose(
+          $this->builder->produce('a'),
+          $this->builder->map(
+            $this->builder->produce('b'),
+          )
+        ),
+      ],
+    ]);
+  }
+
+  public function testMandatoryMap() {
+    $this->assertResolvers('type Query { a: [String!]! @a @map @b }', [
+      'Query' => [
+        'a' => $this->builder->compose(
+          $this->builder->defaultValue(
+            $this->builder->produce('a'),
+            $this->builder->fromValue([]),
+          ),
+          $this->builder->map(
+            $this->builder->defaultValue(
+              $this->builder->produce('b'),
+              $this->builder->fromValue(''),
+            ),
+          )
+        ),
+      ],
+    ]);
+  }
+
+  public function testInvalidMapNesting() {
+    $this->expectException(MapNestingException::class);
+    $this->assertResolvers('type Query { a: [String!]! @a @map @b @map @a @b }', []);
+  }
+
+  public function testNestedMapDirectives() {
+    $this->assertResolvers('type Query { a: [[String!]]! @a @map @map @a @b }', [
+      'Query' => [
+        'a' => $this->builder->compose(
+          $this->builder->defaultValue(
+            $this->builder->produce('a'),
+            $this->builder->fromValue([]),
+          ),
+          $this->builder->map(
+            $this->builder->fromParent(),
+          ),
+          $this->builder->map(
+            $this->builder->defaultValue(
+              $this->builder->compose(
+                $this->builder->produce('a'),
+                $this->builder->produce('b'),
+              ),
+              $this->builder->fromValue(''),
+            )
+          )
+        ),
+      ],
+    ]);
+  }
+
+  public function testMagicProp() {
+    $this->assertResolvers('type Query { a: String }', [
+      'Query' => [
+        'a' => $this->builder->produce('prop')
+          ->map('input', $this->builder->fromParent())
+          ->map('property', $this->builder->fromValue('a')),
+      ],
+    ]);
+  }
+
+  public function testNonNullableMagicProp() {
+    $this->assertResolvers('type Query { a: String! }', [
+      'Query' => [
+        'a' => $this->builder->defaultValue(
+          $this->builder->produce('prop')
+            ->map('input', $this->builder->fromParent())
+            ->map('property', $this->builder->fromValue('a')),
+          $this->builder->fromValue(''),
+        ),
+      ],
+    ]);
+  }
+
+  public function testMapMagicProp() {
+    $this->assertResolvers('type Query { a: [[String]!]! }', [
+      'Query' => [
+        'a' =>
+        $this->builder->compose(
+          $this->builder->defaultValue(
+            $this->builder->produce('prop')
+              ->map('input', $this->builder->fromParent())
+              ->map('property', $this->builder->fromValue('a')),
+            $this->builder->fromValue([]),
+          ),
+          $this->builder->map(
+            $this->builder->defaultValue(
+              $this->builder->fromParent(),
+              $this->builder->fromValue([]),
+            ),
+          ),
+          $this->builder->map($this->builder->fromParent()),
+        ),
+      ],
+    ]);
+  }
+
+  public function testMagicPropToMap() {
+    $this->assertResolvers('type Query { a: [[String]!]! @map @b }', [
+      'Query' => [
+        'a' =>
+          $this->builder->compose(
+            $this->builder->defaultValue(
+              $this->builder->produce('prop')
+                ->map('input', $this->builder->fromParent())
+                ->map('property', $this->builder->fromValue('a')),
+              $this->builder->fromValue([]),
+            ),
+            $this->builder->map(
+              $this->builder->defaultValue(
+                $this->builder->produce('b'),
+                $this->builder->fromValue([]),
+              ),
+            ),
+            $this->builder->map($this->builder->fromParent()),
+          ),
+      ],
+    ]);
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectivePrinterTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectivePrinterTest.php
@@ -26,6 +26,12 @@ class DirectivePrinterTest extends UnitTestCase {
         '"""',
         'directive @type(id: String!) repeatable on OBJECT'
       ]),
+      implode("\n", [
+        '"""',
+        'Provide an automatic or manual default value.',
+        '"""',
+        'directive @default repeatable on FIELD_DEFINITION | UNION | INTERFACE'
+      ]),
     ];
     $builtin[] = implode("\n", $lines);
     asort($builtin);

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectivePrinterTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectivePrinterTest.php
@@ -16,7 +16,7 @@ class DirectivePrinterTest extends UnitTestCase {
         '"""',
         'Apply all directives on the right to output on the left.',
         '"""',
-        'directive @map on FIELD_DEFINITION'
+        'directive @map repeatable on FIELD_DEFINITION'
       ]),
 
       implode("\n", [
@@ -24,7 +24,7 @@ class DirectivePrinterTest extends UnitTestCase {
         'Mark a type as member of a generic.',
         'The id argument contains a string that has to match the generics resolution.',
         '"""',
-        'directive @type(id: String!) on OBJECT'
+        'directive @type(id: String!) repeatable on OBJECT'
       ]),
     ];
     $builtin[] = implode("\n", $lines);
@@ -41,7 +41,7 @@ class DirectivePrinterTest extends UnitTestCase {
         'id' => 'todo',
       ],
     ], [
-      'directive @todo on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @todo repeatable on FIELD_DEFINITION | UNION | INTERFACE',
     ]);
   }
 
@@ -55,7 +55,7 @@ class DirectivePrinterTest extends UnitTestCase {
       '"""',
       'Mark a field as not implemented.',
       '"""',
-      'directive @todo on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @todo repeatable on FIELD_DEFINITION | UNION | INTERFACE',
     ]);
   }
 
@@ -70,7 +70,7 @@ class DirectivePrinterTest extends UnitTestCase {
         ],
       ],
     ], [
-      'directive @value(json: String!, function: String) on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | UNION | INTERFACE',
     ]);
   }
 
@@ -87,8 +87,8 @@ class DirectivePrinterTest extends UnitTestCase {
         'id' => 'todo',
       ],
     ], [
-      'directive @todo on FIELD_DEFINITION | UNION | INTERFACE',
-      'directive @value(json: String!, function: String) on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @todo repeatable on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | UNION | INTERFACE',
     ]);
   }
 
@@ -111,7 +111,7 @@ class DirectivePrinterTest extends UnitTestCase {
       'Provided by the "graphql_directives" module.',
       'Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".',
       '"""',
-      'directive @value(json: String!, function: String) on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | UNION | INTERFACE',
     ]);
   }
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectivePrinterTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectivePrinterTest.php
@@ -28,9 +28,9 @@ class DirectivePrinterTest extends UnitTestCase {
       ]),
       implode("\n", [
         '"""',
-        'Provide an automatic or manual default value.',
+        'Provide a default value for a given type.',
         '"""',
-        'directive @default repeatable on FIELD_DEFINITION | UNION | INTERFACE'
+        'directive @default repeatable on UNION | SCALAR | OBJECT | INTERFACE'
       ]),
     ];
     $builtin[] = implode("\n", $lines);
@@ -47,7 +47,7 @@ class DirectivePrinterTest extends UnitTestCase {
         'id' => 'todo',
       ],
     ], [
-      'directive @todo repeatable on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @todo repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
     ]);
   }
 
@@ -61,7 +61,7 @@ class DirectivePrinterTest extends UnitTestCase {
       '"""',
       'Mark a field as not implemented.',
       '"""',
-      'directive @todo repeatable on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @todo repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
     ]);
   }
 
@@ -76,7 +76,7 @@ class DirectivePrinterTest extends UnitTestCase {
         ],
       ],
     ], [
-      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
     ]);
   }
 
@@ -93,8 +93,8 @@ class DirectivePrinterTest extends UnitTestCase {
         'id' => 'todo',
       ],
     ], [
-      'directive @todo repeatable on FIELD_DEFINITION | UNION | INTERFACE',
-      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @todo repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
+      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
     ]);
   }
 
@@ -117,7 +117,7 @@ class DirectivePrinterTest extends UnitTestCase {
       'Provided by the "graphql_directives" module.',
       'Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".',
       '"""',
-      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | UNION | INTERFACE',
+      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
     ]);
   }
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/graphql/silverback_gatsby.base.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/graphql/silverback_gatsby.base.graphqls
@@ -1,11 +1,11 @@
 type Feed {
-  typeName: String! @prop(key: "typeName")
-  translatable: Boolean! @prop(key: "translatable")
-  singleFieldName: String! @prop(key: "singleFieldName")
-  listFieldName: String! @prop(key: "listFieldName")
-  changes(lastBuild: Int, currentBuild: Int): [String!]! @prop(key: "changes")
-  pathFieldName: String @prop(key: "pathFieldName")
-  templateFieldName: String @prop(key: "templateFieldName")
+  typeName: String!
+  translatable: Boolean!
+  singleFieldName: String!
+  listFieldName: String!
+  changes(lastBuild: Int, currentBuild: Int): [String!]!
+  pathFieldName: String
+  templateFieldName: String
 }
 
 ################################################################################

--- a/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/graphql/silverback_gatsby_example.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/modules/silverback_gatsby_example/graphql/silverback_gatsby_example.graphqls
@@ -28,12 +28,12 @@ type MenuItem {
 All menu items, for the sitemap or being post-loaded.
 """
 type MainMenu @menu(menu_ids: ["access_denied", "main"]) {
-  items: [MenuItem!]! @resolveMenuItems
+  items: [MenuItem]! @resolveMenuItems
 }
 
 """
 Menu items up to level 2, to be rendered directly into the page layout.
 """
 type VisibleMainMenu @menu(menu_ids: ["access_denied", "main"], max_level: 2) {
-  items: [MenuItem!]! @resolveMenuItems
+  items: [MenuItem]! @resolveMenuItems
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/graphql/schema.graphqls
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/graphql/schema.graphqls
@@ -1,11 +1,11 @@
 type Query {
-  en: Page! @loadEntity(type: "node", id: "1")
-  de: Page! @loadEntity(type: "node", id: "1") @resolveEntityTranslation(lang: "de")
+  en: Page @loadEntity(type: "node", id: "1")
+  de: Page @loadEntity(type: "node", id: "1") @resolveEntityTranslation(lang: "de")
 }
 
 type Page {
   title: String! @resolveProperty(path: "title.value")
-  content: [Blocks!]! @resolveEditorBlocks(path: "body.value", aggregated: ["core/paragraph", "core/list"])
+  content: [Blocks]! @resolveEditorBlocks(path: "body.value", aggregated: ["core/paragraph", "core/list"])
 }
 
 union Blocks @resolveEditorBlockType =
@@ -31,5 +31,5 @@ type Image {
 }
 
 type Columns @type(id: "custom/columns") {
-  columns: [ColumnBlocks!]! @resolveEditorBlockChildren
+  columns: [ColumnBlocks]! @resolveEditorBlockChildren
 }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql_directives`

## Description of changes

Add a `@default` directive that allows to inject manual or automatic
default values.

## Motivation and context

Provide a simple way to react to null values in graphql schemas.

## Related Issue(s)

#1169

## How has this been tested?

- [x] Kernel tests
