### PR TITLE
fix: do not add `target="_blank"` to `javascript:` links

### DIFF
--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/__tests__/utils.test.tsx
@@ -40,6 +40,9 @@ describe('isRelative', () => {
   it('returns false for a mailto: url', () => {
     expect(isRelative('mailto:development@amazeelabs.com')).toBeFalsy();
   });
+  it('returns true for a javascript: url', () => {
+    expect(isRelative('javascript:alert(1)')).toBeTruthy();
+  });
 });
 
 const nav = vi.fn();

--- a/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
+++ b/packages/npm/@amazeelabs/react-framework-bridge/src/utils/index.tsx
@@ -20,6 +20,7 @@ export const isInternalTarget = (target?: string) =>
   typeof target === 'undefined' || target === '' || target === '_self';
 
 export const isRelative = (url?: string) =>
+  url?.startsWith('javascript:') ||
   url?.startsWith('#') ||
   url?.startsWith('?') ||
   Boolean(url?.match(/^\/(?!\/)/));


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/react-framework-bridge`

## Motivation and context

`javascript:` links are opened in a new tab hence do not work.

## How has this been tested?

Added a unit test case.
