### PR TITLE
silverback-cli: Drupal 10 compatibility

### DIFF
--- a/apps/silverback-drupal/composer.lock
+++ b/apps/silverback-drupal/composer.lock
@@ -195,13 +195,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback-cli",
-                "reference": "fe352d2b9fa52af374591c1642c2ea190373d9ad"
+                "reference": "4ef728fe4122c119375bae71d0bb41c0b3680790"
             },
             "require": {
-                "alchemy/zippy": "^1.0.0",
                 "drush/drush": ">=10.6.2",
                 "ext-json": "*",
-                "ext-zip": "*",
+                "nelexa/zip": "^4.0.0",
                 "vlucas/phpdotenv": "^5.5.0"
             },
             "bin": [
@@ -340,11 +339,11 @@
         },
         {
             "name": "amazeelabs/silverback_iframe",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_iframe",
-                "reference": "94de4ca9c1deb3310ff77f870352060f7ababcce"
+                "reference": "60fc3ddc9d35a4c5a9547c48bce101a0d2917672"
             },
             "type": "drupal-module",
             "license": [
@@ -358,11 +357,11 @@
         },
         {
             "name": "amazeelabs/silverback_iframe_theme",
-            "version": "1.1.3",
+            "version": "1.2.0",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_iframe_theme",
-                "reference": "375ae9a481b523d6a05cf638e7f89ffbf65c2d82"
+                "reference": "619255e54c4c7802d6e616fc2383c5e7e68a9c45"
             },
             "type": "drupal-theme",
             "license": [
@@ -5416,6 +5415,79 @@
                 }
             ],
             "time": "2022-03-03T13:19:32+00:00"
+        },
+        {
+            "name": "nelexa/zip",
+            "version": "4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ne-Lexa/php-zip.git",
+                "reference": "88a1b6549be813278ff2dd3b6b2ac188827634a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ne-Lexa/php-zip/zipball/88a1b6549be813278ff2dd3b6b2ac188827634a7",
+                "reference": "88a1b6549be813278ff2dd3b6b2ac188827634a7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zlib": "*",
+                "php": "^7.4 || ^8.0",
+                "psr/http-message": "*",
+                "symfony/finder": "*"
+            },
+            "require-dev": {
+                "ext-bz2": "*",
+                "ext-dom": "*",
+                "ext-fileinfo": "*",
+                "ext-iconv": "*",
+                "ext-openssl": "*",
+                "ext-xml": "*",
+                "friendsofphp/php-cs-fixer": "^3.4.0",
+                "guzzlehttp/psr7": "^1.6",
+                "phpunit/phpunit": "^9",
+                "symfony/http-foundation": "*",
+                "symfony/var-dumper": "*",
+                "vimeo/psalm": "^4.6"
+            },
+            "suggest": {
+                "ext-bz2": "Needed to support BZIP2 compression",
+                "ext-fileinfo": "Needed to get mime-type file",
+                "ext-iconv": "Needed to support convert zip entry name to requested character encoding",
+                "ext-openssl": "Needed to support encrypt zip entries or use ext-mcrypt"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpZip\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ne-Lexa",
+                    "email": "alexey@nelexa.ru",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PhpZip is a php-library for extended work with ZIP-archives. Open, create, update, delete, extract and get info tool. Supports appending to existing ZIP files, WinZip AES encryption, Traditional PKWARE Encryption, BZIP2 compression, external file attributes and ZIP64 extensions. Alternative ZipArchive. It does not require php-zip extension.",
+            "homepage": "https://github.com/Ne-Lexa/php-zip",
+            "keywords": [
+                "archive",
+                "extract",
+                "unzip",
+                "winzip",
+                "zip",
+                "ziparchive"
+            ],
+            "support": {
+                "issues": "https://github.com/Ne-Lexa/php-zip/issues",
+                "source": "https://github.com/Ne-Lexa/php-zip/tree/4.0.2"
+            },
+            "time": "2022-06-17T11:17:46+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/packages/composer/amazeelabs/silverback-cli/composer.json
+++ b/packages/composer/amazeelabs/silverback-cli/composer.json
@@ -5,8 +5,7 @@
   "license": "GPL-2.0-or-later",
   "version": "2.8.2",
   "require": {
-    "ext-zip": "*",
-    "alchemy/zippy": "^1.0.0",
+    "nelexa/zip": "^4.0.0",
     "drush/drush": ">=10.6.2",
     "vlucas/phpdotenv": "^5.5.0",
     "ext-json": "*"

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Setup.php
@@ -2,7 +2,6 @@
 
 namespace AmazeeLabs\Silverback\Commands;
 
-use Alchemy\Zippy\Zippy;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -41,7 +40,6 @@ EOD
     $private = 'web/sites/default/files/private';
     $zipCache = self::zipCache();
     $drush = './vendor/bin/drush';
-    $zippy = Zippy::load();
 
     $this->cleanDir($public);
 
@@ -57,8 +55,9 @@ EOD
 
     if ($installFromCache) {
       $output->writeln("<info>Restoring from $zipCache...</>");
-      $cache = $zippy->open($zipCache);
-      $cache->extract('web/sites/default');
+      $zipFile = new \PhpZip\ZipFile();
+      $zipFile->openFile($zipCache)
+        ->extractTo('web/sites/default');
     }
     else {
       $output->writeln('<info>Installing from scratch' . ($configExists ? ' using existing config' : '') . '.</>');
@@ -97,10 +96,13 @@ EOD
       else {
         $output->writeln("<info>Creating $zipCache...</>");
       }
-      $zippy->create($zipCache, ['files' => $public], TRUE);
+      $zipFile = new \PhpZip\ZipFile();
+      $zipFile->addDirRecursive($public, 'files')
+        ->saveAsFile($zipCache);
     }
 
     $output->writeln("<info>Setup complete.</>");
+
     return 0;
   }
 

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SilverbackCommand.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SilverbackCommand.php
@@ -65,6 +65,8 @@ class SilverbackCommand extends Command {
     }
     // TODO: scan upwards and detect root directory?
     $this->rootDirectory = getcwd();
+
+    return 0;
   }
 
   protected function copyDir($source, $destination) {

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotCreate.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotCreate.php
@@ -34,6 +34,8 @@ class SnapshotCreate extends SnapshotBase {
 
     $this->copyDir('web/sites/default/files', $path);
     $output->writeln("</info>The snapshot has been saved to $path.</>");
+
+    return 0;
   }
 
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotRestore.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/SnapshotRestore.php
@@ -34,6 +34,8 @@ class SnapshotRestore extends SnapshotBase {
     $this->fileSystem->remove('web/sites/default/files');
     $this->copyDir($snapshotDirectory, 'web/sites/default/files');
     $output->writeln("<info>The snapshot has been restored from $snapshotDirectory.</>");
+
+    return 0;
   }
 
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Teardown.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/Teardown.php
@@ -19,6 +19,8 @@ class Teardown extends SilverbackCommand {
       $this->cleanDir('web/sites/default/files');
     }
     $output->writeln("<info>Deleted the current site.</>");
+
+    return 0;
   }
 
 }

--- a/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/WriteCache.php
+++ b/packages/composer/amazeelabs/silverback-cli/src/AmazeeLabs/Silverback/Commands/WriteCache.php
@@ -2,7 +2,6 @@
 
 namespace AmazeeLabs\Silverback\Commands;
 
-use Alchemy\Zippy\Zippy;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -18,7 +17,6 @@ class WriteCache extends SilverbackCommand {
     parent::execute($input, $output);
     $public = 'web/sites/default/files';
     $zipCache = Setup::zipCache();
-    $zippy = Zippy::load();
     $zipCacheExists = $this->fileSystem->exists($zipCache);
     if ($zipCacheExists) {
       $output->writeln("<info>Updating $zipCache...</>");
@@ -27,8 +25,11 @@ class WriteCache extends SilverbackCommand {
     else {
       $output->writeln("<info>Creating $zipCache...</>");
     }
-    $zippy->create($zipCache, ['files' => $public], TRUE);
+    $zipFile = new \PhpZip\ZipFile();
+    $zipFile->addDirRecursive($public, 'files')
+      ->saveAsFile($zipCache);
     $output->writeln("<info>Cache has been written.</>");
+
     return 0;
   }
 

--- a/packages/composer/amazeelabs/silverback-cli/test
+++ b/packages/composer/amazeelabs/silverback-cli/test
@@ -59,8 +59,7 @@ function install_silverback_and_test {
     cp -n "$1/web/sites/default/default.settings.php" "$1/web/sites/default/settings.php" || true
   fi
 
-  # alchemy/zippy is added here to avoid issues with minimum-stability.
-  composer require amazeelabs/silverback-cli:@dev alchemy/zippy:@dev
+  composer require amazeelabs/silverback-cli:@dev
 
   source .envrc
   if ./vendor/bin/silverback setup; then


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback-cli`

## Description of changes

- Switched to `nelexa/zip` because `alchemy/zippy` seems to be abandoned, and it does not support Symfony 6 which is shipped with Drupal 10.
- Minor PHP code updates for Symfony 6 compatibility.

## Motivation and context

Drupal 10 is out.

## How has this been tested?

Existing integration tests.
