### PR TITLE
feat: allow forcing POST requests

### DIFF
--- a/packages/npm/@amazeelabs/silverback-graphql-persisted/src/index.ts
+++ b/packages/npm/@amazeelabs/silverback-graphql-persisted/src/index.ts
@@ -57,12 +57,13 @@ export function persistedFetcher<TData, TVariables>(
   queryMap: QueryMap,
   query: string,
   variables?: TVariables,
+  forcePostRequest?: boolean,
 ) {
   const { queryType, queryId } = getQueryData(query, queryMap);
   return async (): Promise<TData> => {
     const params = { id: queryId, variables };
     let res;
-    if (queryType === 'mutation') {
+    if (queryType === 'mutation' || forcePostRequest) {
       res = await fetch(endpoint, {
         method: 'POST',
         ...{ credentials: 'include' },


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/silverback-graphql-persisted`

## Motivation and context

Netlify may cache responses so hard that it is just not possible to uncache them back 😅


## How has this been tested?

Will be tested manually on a project.