### PR TITLE
feat: gutenberg validation

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/README.md
+++ b/packages/composer/amazeelabs/silverback_gutenberg/README.md
@@ -115,3 +115,53 @@ Next, GraphQL resolvers which parse Gutenberg code should call
 `LinkProcessor::processLinks` before parsing the blocks. See
 [`DataProducer/Gutenberg.php`](../../../../apps/silverback-drupal/web/modules/custom/silverback_gatsby_test/src/Plugin/GraphQL/DataProducer/Gutenberg.php)
 for an example.
+
+## Validation
+
+Custom validator plugins can be created in
+`src/Plugin/Validation/GutenbergValidator`
+
+Example, to validate that a title is required, given that
+
+- the block name is `custom/title`
+- the field attribute is `text`
+
+```php
+<?php
+
+namespace Drupal\custom_gutenberg\Plugin\Validation\GutenbergValidator;
+
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * @GutenbergValidator(
+ *   id="title_validator",
+ *   label = @Translation("Title validator")
+ * )
+ */
+class TitleValidator extends GutenbergValidatorBase {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function applies(array $block) {
+    return $block['blockName'] === 'custom/title';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validatedFields($block = []) {
+    return [
+      'text' => [
+        'field_label' => $this->t('Title'),
+        'rules' => ['required']
+      ],
+    ];
+  }
+
+}
+```

--- a/packages/composer/amazeelabs/silverback_gutenberg/README.md
+++ b/packages/composer/amazeelabs/silverback_gutenberg/README.md
@@ -121,10 +121,10 @@ for an example.
 Custom validator plugins can be created in
 `src/Plugin/Validation/GutenbergValidator`
 
-Example, to validate that a title is required, given that
+Example, to validate an email field that is also required.
 
-- the block name is `custom/title`
-- the field attribute is `text`
+- the block name is `custom/my-block`
+- the field attribute is `email` and the label `Email`
 
 ```php
 <?php
@@ -136,11 +136,11 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * @GutenbergValidator(
- *   id="title_validator",
- *   label = @Translation("Title validator")
+ *   id="my_block_validator",
+ *   label = @Translation("My block validator")
  * )
  */
-class TitleValidator extends GutenbergValidatorBase {
+class MyBlockValidator extends GutenbergValidatorBase {
 
   use StringTranslationTrait;
 
@@ -148,7 +148,7 @@ class TitleValidator extends GutenbergValidatorBase {
    * {@inheritDoc}
    */
   public function applies(array $block) {
-    return $block['blockName'] === 'custom/title';
+    return $block['blockName'] === 'custom/my-block';
   }
 
   /**
@@ -156,9 +156,9 @@ class TitleValidator extends GutenbergValidatorBase {
    */
   public function validatedFields($block = []) {
     return [
-      'text' => [
-        'field_label' => $this->t('Title'),
-        'rules' => ['required']
+      'email' => [
+        'field_label' => $this->t('Email'),
+        'rules' => ['required', 'email'],
       ],
     ];
   }

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\Core\Asset\AttachedAssetsInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 use Drupal\silverback_gutenberg\Utils;
@@ -79,5 +80,18 @@ function silverback_gutenberg_node_presave(NodeInterface $node) {
 function silverback_gutenberg_silverback_gutenberg_link_processor_block_attrs_alter(array &$attributes, array $context) {
   if ($context['blockName'] === 'drupalmedia/drupal-media-entity' && isset($attributes['caption'])) {
     $attributes['caption'] = $context['processLinksCallback']($attributes['caption']);
+  }
+}
+
+/**
+ * Implements hook_entity_bundle_field_info_alter().
+ */
+function silverback_gutenberg_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle) {
+  // @todo add configurable bundles based on a list that fetches CT
+  //   that have Gutenberg enabled.
+  if ($entity_type->id() === 'node') {
+    if (isset($fields['body'])) {
+      $fields['body']->addConstraint('Gutenberg', []);
+    }
   }
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
@@ -87,10 +87,10 @@ function silverback_gutenberg_silverback_gutenberg_link_processor_block_attrs_al
  * Implements hook_entity_bundle_field_info_alter().
  */
 function silverback_gutenberg_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle) {
-  // @todo add configurable bundles based on a list that fetches CT
-  //   that have Gutenberg enabled.
   if ($entity_type->id() === 'node') {
-    if (isset($fields['body'])) {
+    $gutenberg_config = \Drupal::service('config.factory')->getEditable('gutenberg.settings');
+    $is_gutenberg_enabled = $gutenberg_config->get($bundle . '_enable_full');
+    if (isset($fields['body']) && $is_gutenberg_enabled) {
       $fields['body']->addConstraint('Gutenberg', []);
     }
   }

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.module
@@ -88,7 +88,7 @@ function silverback_gutenberg_silverback_gutenberg_link_processor_block_attrs_al
  */
 function silverback_gutenberg_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle) {
   if ($entity_type->id() === 'node') {
-    $gutenberg_config = \Drupal::service('config.factory')->getEditable('gutenberg.settings');
+    $gutenberg_config = \Drupal::config('gutenberg.settings');
     $is_gutenberg_enabled = $gutenberg_config->get($bundle . '_enable_full');
     if (isset($fields['body']) && $is_gutenberg_enabled) {
       $fields['body']->addConstraint('Gutenberg', []);

--- a/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.services.yml
+++ b/packages/composer/amazeelabs/silverback_gutenberg/silverback_gutenberg.services.yml
@@ -2,3 +2,9 @@ services:
   Drupal\silverback_gutenberg\LinkProcessor:
     class: Drupal\silverback_gutenberg\LinkProcessor
     arguments: ['@path_alias.manager', '@config.factory', '@request_stack', '@module_handler', '@entity.repository', '@entity_type.manager']
+  plugin.manager.gutenberg_validator:
+    class: Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorManager
+    parent: default_plugin_manager
+  plugin.manager.gutenberg_validator_rule:
+    class: Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorRuleManager
+    parent: default_plugin_manager

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Annotation/GutenbergValidator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Annotation/GutenbergValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * @Annotation
+ */
+class GutenbergValidator extends Plugin {
+
+  /**
+   * The validator plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The human-readable name of the validator plugin.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $label;
+
+  /**
+   * The description of the validator plugin.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $description;
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Annotation/GutenbergValidatorRule.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Annotation/GutenbergValidatorRule.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * @Annotation
+ */
+class GutenbergValidatorRule extends Plugin {
+
+  /**
+   * The validator plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The human-readable name of the validator plugin.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $label;
+
+  /**
+   * The description of the validator plugin.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $description;
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorBase.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorBase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\GutenbergValidation;
+
+/**
+ * Base class for all the Gutenberg validators.
+ */
+abstract class GutenbergValidatorBase implements GutenbergValidatorInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validateContent($block) {
+    return [];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validatedFields($block = []) {
+    return [];
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorInterface.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\GutenbergValidation;
+
+/**
+ * Gutenberg validator plugins interface
+ */
+interface GutenbergValidatorInterface {
+
+  /**
+   * Checks if the validator should apply on a block.
+   *
+   * @param array $block
+   *  A gutenberg block (generated for example by the Gutenberg BlockParser
+   *  class).
+   *
+   * @return bool
+   */
+  public function applies(array $block);
+
+  /**
+   * Returns an array with the validation rules for each field that should be
+   * performed on the Gutenberg block. The keys of the array represent the block
+   * properties (field names) and the values are arrays with validation rule
+   * plugins that should be applied for that field, as well as, optionally, the
+   * human-readable label of the field.
+   *
+   * Example:
+   * @code
+   * array(
+   *   'title' => array(
+   *     'field_label' => t('Title'),
+   *     'rules' => array('gutenberg_rule_required'),
+   *    ),
+   *   'caption' => array(
+   *     'field_label' => t('Caption'),
+   *     'rules' => array('gutenberg_rule_required_caption', 'some_other_rule_plugin'),
+   *   ),
+   * );
+   * @endcode
+   *
+   * @return array
+   */
+  public function validatedFields(array $block = []);
+
+  /**
+   * Validates the content of a block. Useful in case the validator should
+   * perform a more complex validation logic, on the entire block, which cannot
+   * be covered by the existing validation rules.
+   *
+   * Use isValid and message keys in the array to display a message
+   *
+   * Example:
+   * @code
+   * array(
+   *   'is_valid' => TRUE,
+   *   'message' => 'Field name is not valid'
+   * );
+   * @endcode
+   *
+   * @return array
+   */
+  public function validateContent($block);
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorManager.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorManager.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\GutenbergValidation;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Provides a Gutenberg Validator plugin manager.
+ */
+class GutenbergValidatorManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a GutenbergValidatorManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct(
+      'Plugin/Validation/GutenbergValidator',
+      $namespaces,
+      $module_handler,
+      'Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorInterface',
+      'Drupal\silverback_gutenberg\Annotation\GutenbergValidator'
+    );
+    $this->alterInfo('gutenberg_validator_info');
+    $this->setCacheBackend($cache_backend, 'gutenberg_validator_info_plugins');
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorRuleInterface.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorRuleInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\GutenbergValidation;
+
+/**
+ * Gutenberg validator rule plugins interface.
+ */
+interface GutenbergValidatorRuleInterface {
+
+  /**
+   * Validates a value.
+   *
+   * @param $value
+   * @param $fieldLabel
+   *
+   * @return bool
+   */
+  public function validate($value, $fieldLabel);
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorRuleManager.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorRuleManager.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\GutenbergValidation;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Provides a Gutenberg Validator Rule plugin manager.
+ */
+class GutenbergValidatorRuleManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a GutenbergValidatorRuleManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct(
+      'Plugin/Validation/GutenbergValidatorRule',
+      $namespaces,
+      $module_handler,
+      'Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorRuleInterface',
+      'Drupal\silverback_gutenberg\Annotation\GutenbergValidatorRule'
+    );
+    $this->alterInfo('gutenberg_validator_rule_info');
+    $this->setCacheBackend($cache_backend, 'gutenberg_validator_rule_info_plugins');
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/Gutenberg.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/Gutenberg.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Constraint(
+ *   id = "Gutenberg",
+ *   label = @Translation("Gutenberg", context = "Validation")
+ * )
+ */
+class Gutenberg extends Constraint {
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/GutenbergValidator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/GutenbergValidator.php
@@ -64,6 +64,11 @@ class GutenbergValidator extends ConstraintValidator implements ContainerInjecti
    * {@inheritDoc}
    */
   public function validate($value, Constraint $constraint) {
+    // If the field is empty, we don't need to validate it.
+    // Delegate to Drupal.
+    if (empty($value->getValue())) {
+      return;
+    }
     $content = $value->getValue()[0]['value'];
     $parser = new BlockParser();
     $blocks = $parser->parse($content);

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/GutenbergValidator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/GutenbergValidator.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\Plugin\Validation\Constraint;
+
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorInterface;
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorRuleManager;
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\gutenberg\Parser\BlockParser;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorManager;
+
+/**
+ * Validator class for the Gutenberg required field.
+ */
+class GutenbergValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  protected $violations = [];
+
+  /**
+   * Validator manager service plugin.
+   *
+   * @var \Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorManager
+   */
+  protected $validatorManager;
+
+  /**
+   * Validator rule manager service plugin.
+   *
+   * @var \Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorRuleManager
+   */
+  protected $validatorRuleManager;
+
+  /**
+   * Constructs a GutenbergValidator object
+   * @param \Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorManager $validator_manager
+   */
+  public function __construct(
+    GutenbergValidatorManager $validator_manager,
+    GutenbergValidatorRuleManager $validator_rule_manager
+  ) {
+    $this->validatorManager = $validator_manager;
+    $this->validatorRuleManager = $validator_rule_manager;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.gutenberg_validator'),
+      $container->get('plugin.manager.gutenberg_validator_rule')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validate($value, Constraint $constraint) {
+    $content = $value->getValue()[0]['value'];
+    $parser = new BlockParser();
+    $blocks = $parser->parse($content);
+    $plugins = [];
+    foreach ($this->validatorManager->getDefinitions() as $definition) {
+      try {
+        $plugins[] = $this->validatorManager->createInstance($definition['id'], []);
+      } catch (PluginNotFoundException | PluginException $e) {
+        // Do nothing if the plugin could not be instantiated, although we
+        // should never get here, as before we just had a call to
+        // getDefinitions().
+      }
+    }
+
+    if (!empty($plugins)) {
+      $this->validateBlocks($blocks, $plugins);
+    }
+    // If we have any violations after running the blocks validation, we
+    // aggregate all of them in one message and fire a validation for the
+    // Gutenberg constraint.
+    if (!empty($this->violations)) {
+      $messages = [];
+      foreach ($this->violations as $violation) {
+        if (is_array($violation['message'])) {
+          $messages = array_merge($messages, $violation['message']);
+        } else {
+          $messages[] = $violation['message'];
+        }
+      }
+      $this->context->addViolation($this->t('Invalid content: <ul><li>@violations</li></ul>', ['@violations' => Markup::create(implode('</li><li>', $messages))]));
+    }
+  }
+
+  /**
+   * Validates a set of Gutenberg blocks (and their inner blocks) against a set
+   * of validator plugins.
+   *
+   * @param $block
+   * @param array $plugins
+   */
+  public function validateBlocks(array $blocks, array $plugins) {
+    // @todo: we have here a pretty big nesting level, would be nice to find a
+    //   solution to reduce it.
+    array_walk($blocks, function($block) use ($plugins) {
+      array_walk($plugins, function(GutenbergValidatorInterface $plugin) use ($block, $plugins) {
+        // Check if the block has inner blocks, and validate them as well.
+        if (!empty($block['innerBlocks'])) {
+          $this->validateBlocks($block['innerBlocks'], [$plugin]);
+        }
+        if (!$plugin->applies($block)) {
+          return;
+        }
+        $validatedFields = $plugin->validatedFields($block);
+        if (!empty($validatedFields)) {
+          array_walk($validatedFields, function($validatedField, $attrName) use ($block) {
+            if (empty($validatedField['rules'])) {
+              return;
+            }
+            $attrValue = $block['attrs'][$attrName] ?? NULL;
+            array_walk($validatedField['rules'], function($validationRulePluginId) use ($attrValue, $attrName, $block, $validatedField) {
+              try {
+                $rulePlugin = $this->validatorRuleManager->createInstance($validationRulePluginId);
+              } catch (PluginNotFoundException | PluginException $e) {
+                return;
+              }
+              $validationMessage = $rulePlugin->validate($attrValue, $validatedField['field_label'] ?? $attrName);
+              // If the returned value is the boolean TRUE, then it means the
+              // field is valid, so we can just return.
+              if ($validationMessage === TRUE) {
+                return;
+              }
+              $this->violations[] = [
+                'attribute' => $attrName,
+                'blockName' => $block['blockName'],
+                'rule' => $validationRulePluginId,
+                'message' => $validationMessage,
+              ];
+            });
+          });
+        }
+        // Last, call the validateContent method, in case there is a custom
+        // validation logic in the validator plugin itself.
+        $validateContent = $plugin->validateContent($block);
+        if (!empty($validateContent) && $validateContent['is_valid'] !== TRUE) {
+          $this->violations[] = [
+            'attribute' => 'block_content',
+            'blockName' => $block['blockName'],
+            'rule' => 'block_content',
+            'message' => $validateContent['message'],
+          ];
+        }
+      });
+    });
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/GutenbergValidatorRule/Email.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/GutenbergValidatorRule/Email.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\Plugin\Validation\GutenbergValidatorRule;
+
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorRuleInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * @GutenbergValidatorRule(
+ *   id="email",
+ *   label = @Translation("Email")
+ * )
+ */
+class Email implements GutenbergValidatorRuleInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validate($value, $fieldLabel) {
+    if (!empty($value) && !\Drupal::service('email.validator')->isValid($value)) {
+      return $this->t('%field is not valid.', ['%field' => $fieldLabel]);
+    }
+    return TRUE;
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/GutenbergValidatorRule/Required.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/GutenbergValidatorRule/Required.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\Plugin\Validation\GutenbergValidatorRule;
+
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorRuleInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * @GutenbergValidatorRule(
+ *   id="required",
+ *   label = @Translation("Required")
+ * )
+ */
+class Required implements GutenbergValidatorRuleInterface {
+
+  use StringTranslationTrait;
+  public $requiredMessage = '%field field is required.';
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validate($value, $fieldLabel) {
+    if (empty($value)) {
+      return $this->t($this->requiredMessage, ['%field' => $fieldLabel]);
+    }
+    return TRUE;
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/GutenbergValidatorRule/Required.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/GutenbergValidatorRule/Required.php
@@ -20,7 +20,7 @@ class Required implements GutenbergValidatorRuleInterface {
    * {@inheritDoc}
    */
   public function validate($value, $fieldLabel) {
-    if (empty($value)) {
+    if (empty($value) || $value === '_none') {
       return $this->t($this->requiredMessage, ['%field' => $fieldLabel]);
     }
     return TRUE;


### PR DESCRIPTION
## Package(s) involved

`silverback_gutenberg`

## Description of changes

Add a validation plugin manager for Gutenberg blocks, with default `Required` and `Email` validator rules.

## How has this been tested?

Manually