### PR TITLE
Update preview links

### DIFF
--- a/packages/composer/amazeelabs/silverback_external_preview/README.md
+++ b/packages/composer/amazeelabs/silverback_external_preview/README.md
@@ -1,10 +1,13 @@
 # Silverback external preview
-Provides a UI to preview pages (published and draft) on an external website - usually a Gatsby or NextJS frontend.
 
-## Environment variables
+Provides a UI to preview pages (published and draft) on an external website -
+usually a Gatsby or NextJS frontend.
 
-```EXTERNAL_PREVIEW_BASE_URL```
-The preview base URL of the website e.g. https://localhost:8000
+## Drupal config
 
-```EXTERNAL_PREVIEW_LIVE_BASE_URL```
-The live base URL of the website e.g. https://localhost:9000
+- Enable the module
+- Set the settings, for example:
+  ```
+  drush cset silverback_external_preview.settings preview_host http://localhost:8000
+  drush cset silverback_external_preview.settings live_host http://localhost:9000
+  ```

--- a/packages/composer/amazeelabs/silverback_external_preview/config/install/silverback_external_preview.settings.yml
+++ b/packages/composer/amazeelabs/silverback_external_preview/config/install/silverback_external_preview.settings.yml
@@ -1,0 +1,2 @@
+preview_host: ''
+live_host: ''

--- a/packages/composer/amazeelabs/silverback_external_preview/config/schema/silverback_external_preview.schema.yml
+++ b/packages/composer/amazeelabs/silverback_external_preview/config/schema/silverback_external_preview.schema.yml
@@ -1,0 +1,10 @@
+silverback_external_preview.settings:
+  type: config_object
+  label: 'External preview settings'
+  mapping:
+    preview_host:
+      type: string
+      label: 'Base URL of the preview frontend. Must have no trailing slash.'
+    live_host:
+      type: string
+      label: 'Base URL of the live frontend. Must have no trailing slash.'

--- a/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.services.yml
+++ b/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.services.yml
@@ -1,4 +1,4 @@
 services:
   silverback_external_preview.external_preview_link:
     class: \Drupal\silverback_external_preview\ExternalPreviewLink
-    arguments: ['@path_alias.manager', '@entity_type.manager', '@tempstore.private','@module_handler', '@language_manager']
+    arguments: ['@path_alias.manager', '@entity_type.manager', '@tempstore.private','@module_handler', '@language_manager', '@config.factory']


### PR DESCRIPTION
update preview links to use new __preview path on the frontend

BREAKING CHANGE: preview and live hosts are Drupal config settings, rather than ENV vars.