### PR TITLE
fix(drupal): no ignored blocks in EditorBlocksProcessor

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/src/EditorBlocksProcessor.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/EditorBlocksProcessor.php
@@ -34,6 +34,9 @@ class EditorBlocksProcessor {
   }
 
   static function processsIgnoredBlocks(array $blocks, ?array $ignored) {
+    if (empty($ignored)) {
+      return $blocks;
+    }
     $processed = [];
     foreach (array_filter($blocks, fn ($block) => !!$block['blockName']) as $block) {
       if (in_array($block['blockName'], $ignored)) {

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Unit/EditorBlocksProcessorTest.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Unit/EditorBlocksProcessorTest.php
@@ -14,6 +14,29 @@ class EditorBlocksProcessorTest extends UnitTestCase {
     );
   }
 
+  public function testNoIgnoredBlocks() {
+    $input = [
+      [
+        'blockName' => 'custom/a',
+      ],
+      [
+        'blockName' => 'custom/b',
+      ],
+    ];
+    $expected = [
+      [
+        'blockName' => 'custom/a',
+      ],
+      [
+        'blockName' => 'custom/b',
+      ],
+    ];
+    $this->assertEquals(
+      $expected,
+      EditorBlocksProcessor::processsIgnoredBlocks($input, NULL),
+    );
+  }
+
   public function testNoTransientBlocks() {
     $input = [
       [


### PR DESCRIPTION
## Package(s) involved

`silverback_gutenberg`

## Description of changes

Return early when there is no ignored block to process.
`in_array($block['blockName'], $ignored)` can throw if the value is null.

## Motivation and context

`null` was passed as the ignored parameter when writing custom resolvers with nested blocks.

## How has this been tested?

PHPUnit.