### PR TITLE
feat(drupal): prefix Gutenberg blocks validator violation message with breadcrumbs

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/GutenbergValidator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/GutenbergValidator.php
@@ -109,26 +109,27 @@ class GutenbergValidator extends ConstraintValidator implements ContainerInjecti
    * @param $block
    * @param array $plugins
    */
-  public function validateBlocks(array $blocks, array $plugins) {
+  public function validateBlocks(array $blocks, array $plugins, array $breadcrumbs = []) {
     // @todo: we have here a pretty big nesting level, would be nice to find a
     //   solution to reduce it.
-    array_walk($blocks, function($block) use ($plugins) {
-      array_walk($plugins, function(GutenbergValidatorInterface $plugin) use ($block, $plugins) {
+    array_walk($blocks, function($block) use ($plugins, $breadcrumbs) {
+      array_walk($plugins, function(GutenbergValidatorInterface $plugin) use ($block, $plugins, $breadcrumbs) {
         // Check if the block has inner blocks, and validate them as well.
         if (!empty($block['innerBlocks'])) {
-          $this->validateBlocks($block['innerBlocks'], [$plugin]);
+          $breadcrumbs[] = $block['blockName'];
+          $this->validateBlocks($block['innerBlocks'], [$plugin], $breadcrumbs);
         }
         if (!$plugin->applies($block)) {
           return;
         }
         $validatedFields = $plugin->validatedFields($block);
         if (!empty($validatedFields)) {
-          array_walk($validatedFields, function($validatedField, $attrName) use ($block) {
+          array_walk($validatedFields, function($validatedField, $attrName) use ($block, $breadcrumbs) {
             if (empty($validatedField['rules'])) {
               return;
             }
             $attrValue = $block['attrs'][$attrName] ?? NULL;
-            array_walk($validatedField['rules'], function($validationRulePluginId) use ($attrValue, $attrName, $block, $validatedField) {
+            array_walk($validatedField['rules'], function($validationRulePluginId) use ($attrValue, $attrName, $block, $validatedField, $breadcrumbs) {
               try {
                 $rulePlugin = $this->validatorRuleManager->createInstance($validationRulePluginId);
               } catch (PluginNotFoundException | PluginException $e) {
@@ -140,11 +141,17 @@ class GutenbergValidator extends ConstraintValidator implements ContainerInjecti
               if ($validationMessage === TRUE) {
                 return;
               }
+              $breadcrumbs[] = $block['blockName'];
+              $breadcrumbLabels = array_map(function($blockName) {
+                $blockNameParts = explode('/', $blockName);
+                return ucfirst(str_replace('-', ' ', end($blockNameParts)));
+              }, $breadcrumbs);
+              $breadcrumbsLabel = implode(' > ', $breadcrumbLabels);
               $this->violations[] = [
                 'attribute' => $attrName,
                 'blockName' => $block['blockName'],
                 'rule' => $validationRulePluginId,
-                'message' => $validationMessage,
+                'message' => $breadcrumbsLabel . ': ' . $validationMessage,
               ];
             });
           });


### PR DESCRIPTION
## Package(s) involved

`silverback_gutenberg`

## Description of changes

EX - Adds context to the validation violation to identify which block is triggering the error message.

As we have a similar representation of the DOM with the blocks structure, we could extend this in a follow-up to highlight the block that is triggering the error and scroll to it (e.g. bubble this and pass it as a Drupal setting that can be used by JS).

The breadcrumbs display is based on the blocks machine name as we don’t have the block label in the Gutenberg backend validation context, but it should match the label in most cases (so `link-list` becomes `Link list`).

If we want more flexibility, we need to think about a solution to expose the block label to the backend. Examples:
- set it in each validation plugin but this would require duplication and extra maintenance
- some DOM parsing could also work.

But we might also think about full client side validation as well so this is an MVP to add context.

## Related Issue(s)

#1320 

## How has this been tested?

Manually, on a project, validator tests to be done in #1293 

Example
<img width="615" alt="Capture d’écran 2023-03-28 à 22 18 01" src="https://user-images.githubusercontent.com/525003/228483254-3ad6ef8e-b726-4b4b-af38-119e4eeb1246.png">

