### PR TITLE
fix: fix graphql server config form

### DIFF
--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
@@ -135,31 +135,27 @@ class DirectableSchema extends ComposableSchema {
   }
 
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $extensions = $this->extensionManager->getDefinitions();
+    $form = parent::buildConfigurationForm($form, $form_state);
 
-    $form[$this->pluginId]['extensions'] = [
-      '#type' => 'checkboxes',
-      '#required' => FALSE,
-      '#title' => $this->t('Enabled extensions'),
-      '#options' => [],
-      '#default_value' => $this->configuration[$this->pluginId]['extensions'] ?? [],
-    ];
-
-    foreach ($extensions as $key => $extension) {
-      $form[$this->pluginId]['extensions']['#options'][$key] = $extension['name'] ?? $extension['id'];
-
-      if (!empty($extension['description'])) {
-        $form[$this->pluginId]['extensions'][$key]['#description'] = $extension['description'];
-      }
-    }
-    $form[$this->pluginId]['schema_definition'] = [
+    $form['schema_definition'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Schema definition'),
-      '#default_value' => $this->configuration[$this->pluginId]['schema_definition'],
+      '#default_value' => $this->configuration['schema_definition'],
       '#description' => $this->t(
         'Path to the schema definition file. Relative to webroot.'
       ),
     ];
+
+    // Preserve config values coming from plugins (the ones that are not present on the form).
+    foreach (array_keys($this->configuration) as $key) {
+      if (!isset($form[$key])) {
+        $form[$key] = [
+          '#type' => 'value',
+          '#value' => $this->configuration[$key],
+        ];
+      }
+    }
+
     return $form;
   }
 


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql_directives`

## Description of changes

Fixes for `DirectableSchema::buildConfigurationForm`:

- Do not prefix settings with `$this->pluginId` - this is done automatically
- Reuse `extensions` part from the parent class
- Preserve extension's settings on form submit

## Related Issue(s)

https://github.com/AmazeeLabs/silverback-template/issues/3

## How has this been tested?

Manually
