### PR TITLE
fix: support directives on enums

### DIFF
--- a/apps/silverback-drupal/generated/extra.composed.graphqls
+++ b/apps/silverback-drupal/generated/extra.composed.graphqls
@@ -2,79 +2,79 @@
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Arg".
 """
-directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
 """
-directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
 """
-directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
 """
-directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemId".
 """
-directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemLabel".
 """
-directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemParentId".
 """
-directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemUrl".
 """
-directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
 """
-directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
 """
-directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMarkup".
 """
-directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMedia".
 """
-directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockType".
 """
-directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Apply all directives on the right to output on the left.
@@ -87,7 +87,7 @@ Directive for the responsive_image data producer.
 Provided by the "silverback_cloudinary" module.
 Implemented in "Drupal\silverback_cloudinary\Plugin\GraphQL\Directive\ResponsiveImage".
 """
-directive @responsiveImage(width: Int, height: Int, sizes: [[Int!]!], transform: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @responsiveImage(width: Int, height: Int, sizes: [[Int!]!], transform: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Load a given entity by it's path or type and id or uuid
@@ -95,7 +95,7 @@ Load a given entity by it's path or type and id or uuid
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLoad".
 """
-directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Mark a type as member of a generic.
@@ -109,12 +109,12 @@ Parse a gutenberg document into block data.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlocks".
 """
-directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provide a default value for a given type.
 """
-directive @default repeatable on UNION | SCALAR | OBJECT | INTERFACE
+directive @default repeatable on UNION | ENUM | SCALAR | OBJECT | INTERFACE
 
 """
 Provide a static value as JSON string.
@@ -122,7 +122,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.
@@ -130,7 +130,7 @@ Pull a specific typed-data property from an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityProperty".
 """
-directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Resolve a path to an Url object.
@@ -138,7 +138,7 @@ Resolve a path to an Url object.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Route".
 """
-directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve a specific translation of an entity.
@@ -146,7 +146,7 @@ Retrieve a specific translation of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslation".
 """
-directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve all translations of an entity.
@@ -154,7 +154,7 @@ Retrieve all translations of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslations".
 """
-directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an editor block attribute.
@@ -162,7 +162,7 @@ Retrieve an editor block attribute.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockAttribute".
 """
-directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities bundle.
@@ -170,7 +170,7 @@ Retrieve an entities bundle.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityBundle".
 """
-directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities id.
@@ -178,7 +178,7 @@ Retrieve an entities id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityId".
 """
-directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities label.
@@ -186,7 +186,7 @@ Retrieve an entities label.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLabel".
 """
-directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities type id.
@@ -194,7 +194,7 @@ Retrieve an entities type id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityType".
 """
-directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities url path.
@@ -202,7 +202,7 @@ Retrieve an entities url path.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityPath".
 """
-directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities uuid.
@@ -210,7 +210,7 @@ Retrieve an entities uuid.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityUuid".
 """
-directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an object or map property.
@@ -218,7 +218,7 @@ Retrieve an object or map property.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop".
 """
-directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve the language of an entity.
@@ -226,7 +226,7 @@ Retrieve the language of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLanguage".
 """
-directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Seek a specific element in a list.
@@ -234,7 +234,7 @@ Seek a specific element in a list.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Seek".
 """
-directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 schema {
   query: Query

--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -2,79 +2,79 @@
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Arg".
 """
-directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
 """
-directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
 """
-directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
 """
-directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemId".
 """
-directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemLabel".
 """
-directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemParentId".
 """
-directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemUrl".
 """
-directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
 """
-directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
 """
-directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMarkup".
 """
-directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMedia".
 """
-directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockType".
 """
-directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Apply all directives on the right to output on the left.
@@ -87,7 +87,7 @@ Directive for the responsive_image data producer.
 Provided by the "silverback_cloudinary" module.
 Implemented in "Drupal\silverback_cloudinary\Plugin\GraphQL\Directive\ResponsiveImage".
 """
-directive @responsiveImage(width: Int, height: Int, sizes: [[Int!]!], transform: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @responsiveImage(width: Int, height: Int, sizes: [[Int!]!], transform: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Load a given entity by it's path or type and id or uuid
@@ -95,7 +95,7 @@ Load a given entity by it's path or type and id or uuid
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLoad".
 """
-directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Mark a type as member of a generic.
@@ -109,12 +109,12 @@ Parse a gutenberg document into block data.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlocks".
 """
-directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provide a default value for a given type.
 """
-directive @default repeatable on UNION | SCALAR | OBJECT | INTERFACE
+directive @default repeatable on UNION | ENUM | SCALAR | OBJECT | INTERFACE
 
 """
 Provide a static value as JSON string.
@@ -122,7 +122,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.
@@ -130,7 +130,7 @@ Pull a specific typed-data property from an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityProperty".
 """
-directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Resolve a path to an Url object.
@@ -138,7 +138,7 @@ Resolve a path to an Url object.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Route".
 """
-directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve a specific translation of an entity.
@@ -146,7 +146,7 @@ Retrieve a specific translation of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslation".
 """
-directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve all translations of an entity.
@@ -154,7 +154,7 @@ Retrieve all translations of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslations".
 """
-directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an editor block attribute.
@@ -162,7 +162,7 @@ Retrieve an editor block attribute.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockAttribute".
 """
-directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities bundle.
@@ -170,7 +170,7 @@ Retrieve an entities bundle.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityBundle".
 """
-directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities id.
@@ -178,7 +178,7 @@ Retrieve an entities id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityId".
 """
-directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities label.
@@ -186,7 +186,7 @@ Retrieve an entities label.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLabel".
 """
-directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities type id.
@@ -194,7 +194,7 @@ Retrieve an entities type id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityType".
 """
-directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities url path.
@@ -202,7 +202,7 @@ Retrieve an entities url path.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityPath".
 """
-directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities uuid.
@@ -210,7 +210,7 @@ Retrieve an entities uuid.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityUuid".
 """
-directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an object or map property.
@@ -218,7 +218,7 @@ Retrieve an object or map property.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop".
 """
-directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve the language of an entity.
@@ -226,7 +226,7 @@ Retrieve the language of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLanguage".
 """
-directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Seek a specific element in a list.
@@ -234,7 +234,7 @@ Seek a specific element in a list.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Seek".
 """
-directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 schema {
   query: Query

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -2,79 +2,79 @@
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Arg".
 """
-directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
 """
-directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
 """
-directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
 """
-directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemId".
 """
-directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemLabel".
 """
-directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemParentId".
 """
-directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemUrl".
 """
-directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
 """
-directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
 """
-directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMarkup".
 """
-directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMedia".
 """
-directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockType".
 """
-directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Apply all directives on the right to output on the left.
@@ -87,7 +87,7 @@ Directive for the responsive_image data producer.
 Provided by the "silverback_cloudinary" module.
 Implemented in "Drupal\silverback_cloudinary\Plugin\GraphQL\Directive\ResponsiveImage".
 """
-directive @responsiveImage(width: Int, height: Int, sizes: [[Int!]!], transform: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @responsiveImage(width: Int, height: Int, sizes: [[Int!]!], transform: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Load a given entity by it's path or type and id or uuid
@@ -95,7 +95,7 @@ Load a given entity by it's path or type and id or uuid
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLoad".
 """
-directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Mark a type as member of a generic.
@@ -109,12 +109,12 @@ Parse a gutenberg document into block data.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlocks".
 """
-directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Provide a default value for a given type.
 """
-directive @default repeatable on UNION | SCALAR | OBJECT | INTERFACE
+directive @default repeatable on UNION | ENUM | SCALAR | OBJECT | INTERFACE
 
 """
 Provide a static value as JSON string.
@@ -122,7 +122,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.
@@ -130,7 +130,7 @@ Pull a specific typed-data property from an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityProperty".
 """
-directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Resolve a path to an Url object.
@@ -138,7 +138,7 @@ Resolve a path to an Url object.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Route".
 """
-directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve a specific translation of an entity.
@@ -146,7 +146,7 @@ Retrieve a specific translation of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslation".
 """
-directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve all translations of an entity.
@@ -154,7 +154,7 @@ Retrieve all translations of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslations".
 """
-directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an editor block attribute.
@@ -162,7 +162,7 @@ Retrieve an editor block attribute.
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockAttribute".
 """
-directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities bundle.
@@ -170,7 +170,7 @@ Retrieve an entities bundle.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityBundle".
 """
-directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities id.
@@ -178,7 +178,7 @@ Retrieve an entities id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityId".
 """
-directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities label.
@@ -186,7 +186,7 @@ Retrieve an entities label.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLabel".
 """
-directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities type id.
@@ -194,7 +194,7 @@ Retrieve an entities type id.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityType".
 """
-directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities url path.
@@ -202,7 +202,7 @@ Retrieve an entities url path.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityPath".
 """
-directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an entities uuid.
@@ -210,7 +210,7 @@ Retrieve an entities uuid.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityUuid".
 """
-directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve an object or map property.
@@ -218,7 +218,7 @@ Retrieve an object or map property.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop".
 """
-directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve the language of an entity.
@@ -226,7 +226,7 @@ Retrieve the language of an entity.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLanguage".
 """
-directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Seek a specific element in a list.
@@ -234,7 +234,7 @@ Seek a specific element in a list.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Seek".
 """
-directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT
+directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 schema {
   query: Query

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectiveInterpreter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectiveInterpreter.php
@@ -8,6 +8,7 @@ use Drupal\graphql\GraphQL\ResolverBuilder;
 use GraphQL\Language\AST\ArgumentNode;
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\AST\EnumTypeDefinitionNode;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use GraphQL\Language\AST\ListTypeNode;
@@ -83,7 +84,7 @@ class DirectiveInterpreter {
   public function interpret() {
     // First pass, collect all type and default resolvers.
     foreach ($this->document->definitions as $definition) {
-      if ($definition instanceof ObjectTypeDefinitionNode) {
+      if ($definition instanceof ObjectTypeDefinitionNode || $definition instanceof EnumTypeDefinitionNode) {
         if ($resolver = $this->buildDefaultResolver($definition->directives)) {
           $this->defaultValueMap[$definition->name->value] = $resolver;
         }

--- a/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/DirectivePrinter.php
@@ -32,6 +32,7 @@ class DirectivePrinter {
       'arguments' => new NodeList([]),
       'locations' => new NodeList([
         new NameNode(['value' => DirectiveLocation::UNION]),
+        new NameNode(['value' => DirectiveLocation::ENUM]),
         new NameNode(['value' => DirectiveLocation::SCALAR]),
         new NameNode(['value' => DirectiveLocation::OBJECT]),
         new NameNode(['value' => DirectiveLocation::IFACE]),
@@ -112,6 +113,7 @@ class DirectivePrinter {
           new NameNode(['value' => DirectiveLocation::FIELD_DEFINITION]),
           new NameNode(['value' => DirectiveLocation::SCALAR]),
           new NameNode(['value' => DirectiveLocation::UNION]),
+          new NameNode(['value' => DirectiveLocation::ENUM]),
           new NameNode(['value' => DirectiveLocation::IFACE]),
           new NameNode(['value' => DirectiveLocation::OBJECT]),
         ]),

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/default/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/default/schema.graphqls
@@ -10,12 +10,17 @@ type Query {
   listItem: [String!]! @value(json: "[null]")
   manual: Manual!
   object: Object!
+  locale: Locale!
 }
-
 
 type Object @default @value(json: "{\"magic\": \"its magic\"}") {
   magic: String!
   prop: String! @prop(key: "magic")
   optional: String
   mandatory: String!
+}
+
+enum Locale @default @value(json: "\"DE\"") {
+  EN
+  DE
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/DefaultValueTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/DefaultValueTest.php
@@ -53,6 +53,10 @@ class DefaultValueTest extends GraphQLTestBase {
     ]]);
   }
 
+  public function testDefaultEnum() {
+    $this->assertResults('{ locale }', [], ['locale' => 'DE']);
+  }
+
   public function testManualDefault() {
     $this->assertResults('{ manual }', [], ['manual' => 'foo']);
   }

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectiveInterpreterTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectiveInterpreterTest.php
@@ -366,6 +366,16 @@ class DirectiveInterpreterTest extends UnitTestCase {
     ]);
   }
 
+  public function testDefaultEnumType() {
+    $this->assertResolvers('enum Locale @default @d { EN DE } type Query { locale: Locale! @r }', [
+      'Query' => [
+        'locale' => $this->builder->defaultValue(
+          $this->builder->produce('r'),
+          $this->builder->produce('d'),
+        ),
+      ],
+    ]);
+  }
 
   public function testOptionalMap() {
     $this->assertResolvers('type Query { a: [String] @a @map @b }', [

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectivePrinterTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/DirectivePrinterTest.php
@@ -30,7 +30,7 @@ class DirectivePrinterTest extends UnitTestCase {
         '"""',
         'Provide a default value for a given type.',
         '"""',
-        'directive @default repeatable on UNION | SCALAR | OBJECT | INTERFACE'
+        'directive @default repeatable on UNION | ENUM | SCALAR | OBJECT | INTERFACE'
       ]),
     ];
     $builtin[] = implode("\n", $lines);
@@ -47,7 +47,7 @@ class DirectivePrinterTest extends UnitTestCase {
         'id' => 'todo',
       ],
     ], [
-      'directive @todo repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
+      'directive @todo repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT',
     ]);
   }
 
@@ -61,7 +61,7 @@ class DirectivePrinterTest extends UnitTestCase {
       '"""',
       'Mark a field as not implemented.',
       '"""',
-      'directive @todo repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
+      'directive @todo repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT',
     ]);
   }
 
@@ -76,7 +76,7 @@ class DirectivePrinterTest extends UnitTestCase {
         ],
       ],
     ], [
-      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
+      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT',
     ]);
   }
 
@@ -93,8 +93,8 @@ class DirectivePrinterTest extends UnitTestCase {
         'id' => 'todo',
       ],
     ], [
-      'directive @todo repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
-      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
+      'directive @todo repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT',
+      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT',
     ]);
   }
 
@@ -117,7 +117,7 @@ class DirectivePrinterTest extends UnitTestCase {
       'Provided by the "graphql_directives" module.',
       'Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".',
       '"""',
-      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | INTERFACE | OBJECT',
+      'directive @value(json: String!, function: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT',
     ]);
   }
 }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql_directives`

## Motivation and context

```
MissingDefaultException: Missing @default directive for type MyEnum. Either add a @default directive to MyEnum or turn all occasions of 'MyEnum!' into 'MyEnum'
```

## How has this been tested?

Extended unit tests.
