### PR TITLE
feat: gutenberg blocks validator for cardinality

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorInterface.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\GutenbergValidation;
+
+interface GutenbergCardinalityValidatorInterface {
+
+  /**
+   * @var int
+   *   Value that can be used for the maximum.
+   */
+  const CARDINALITY_UNLIMITED = -1;
+
+  /**
+   * @var string
+   *  Specifies if the cardinality check is not limited to a given block type.
+   */
+  const CARDINALITY_ANY = 'any';
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\silverback_gutenberg\GutenbergValidation;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 /**
  * Cardinality validator helper.
  */
@@ -50,7 +52,7 @@ trait GutenbergCardinalityValidatorTrait {
    *
    * @return array
    */
-  public function validateCardinality(array $block, array $expected_children) {
+  public function validateCardinality(array $block, array $expected_children): array {
     // Nothing to validate.
     if (empty($expected_children)) {
       return [
@@ -136,7 +138,7 @@ trait GutenbergCardinalityValidatorTrait {
    *
    * @return array|void
    */
-  private function validateEmptyInnerBlocks (array $expected_children) {
+  private function validateEmptyInnerBlocks (array $expected_children): array {
     $missingBlocksMessages = [];
     foreach ($expected_children as $child) {
       if ($child['min'] > 0) {
@@ -167,7 +169,7 @@ trait GutenbergCardinalityValidatorTrait {
    *
    * @return array
    */
-  private function validateAnyInnerBlocks(array $inner_blocks, array $expected_children) {
+  private function validateAnyInnerBlocks(array $inner_blocks, array $expected_children): array {
     $min = $expected_children['min'];
     $max = $expected_children['max'];
     $count = count($inner_blocks['innerBlocks']);
@@ -200,7 +202,7 @@ trait GutenbergCardinalityValidatorTrait {
     ];
   }
 
-  private function getExpectedQuantityErrorMessage(array $child_block): string {
+  private function getExpectedQuantityErrorMessage(array $child_block): string|TranslatableMarkup {
     $messageParams = [
       '%label' => $child_block['blockLabel'],
       '@min' => $child_block['min'],

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\GutenbergValidation;
+
+/**
+ * Cardinality validator helper.
+ */
+trait GutenbergCardinalityValidatorTrait {
+
+  /**
+   * Validates the cardinality of the inner blocks of a block.
+   *
+   * This helper can be called from the validateContent() method of a validator.
+   *
+   * Example to validate the cardinality of all inner blocks (any, no matter the name).
+   * @code
+   * [
+   *   'validationType' => GutenbergCardinalityValidatorInterface::CARDINALITY_ANY,
+   *   'min' => 0,
+   *   'max' => 3,
+   * ]
+   * @endcode
+   *
+   * Example to validate by block name:
+   * @code
+   * [
+   *   [
+   *     'blockName' => 'core/paragraph',
+   *     'blockLabel' => $this->t('Paragraph'),
+   *     'min' => 0,
+   *     'max' => 3,
+   *   ],
+   *   [
+   *     'blockName' => 'core/embed',
+   *     'blockLabel' => $this->t('Embed'),
+   *     'min' => 1,
+   *     'max' => 2,
+   *   ],
+   *   [
+   *     'blockName' => 'core/block',
+   *     'blockLabel' => $this->t('Reusable block'),
+   *     'min' => 1,
+   *     'max' => GutenbergCardinalityValidatorInterface::CARDINALITY_UNLIMITED,
+   *   ],
+   * ];
+   * @endcode
+   *
+   * @param array $block
+   * @param array $expected_children
+   *
+   * @return array
+   */
+  public function validateCardinality(array $block, array $expected_children) {
+    // Nothing to validate.
+    if (empty($expected_children)) {
+      return [
+        'is_valid' => TRUE,
+        'message' => '',
+      ];
+    }
+
+    // Check if the quantity validation is any block, no matter the name.
+    if (
+      !empty($expected_children['validationType']) &&
+      $expected_children['validationType'] === GutenbergCardinalityValidatorInterface::CARDINALITY_ANY) {
+      return $this->validateAnyInnerBlocks($block, $expected_children);
+    }
+
+    // Exit early if there are no inner blocks.
+    if (empty($block['innerBlocks'])) {
+      return $this->validateEmptyInnerBlocks($expected_children);
+    }
+
+    // Count blocks, then check if the quantity for each is correct.
+    $countInnerBlockInstances = [];
+    foreach ($block['innerBlocks'] as $innerBlock) {
+      if (!isset($countInnerBlockInstances[$innerBlock['blockName']])) {
+        $countInnerBlockInstances[$innerBlock['blockName']] = 0;
+      }
+      $countInnerBlockInstances[$innerBlock['blockName']]++;
+    }
+
+    foreach ($expected_children as $child) {
+      if (!isset($countInnerBlockInstances[$child['blockName']]) && $child['min'] > 0) {
+        $message = $this->getExpectedQuantityErrorMessage($child);
+        return [
+          'is_valid' => FALSE,
+          'message' => $message,
+        ];
+      }
+      // Minimum is set to 0, so we don't care if the block is not present.
+      if (!isset($countInnerBlockInstances[$child['blockName']]) && $child['min'] === 0) {
+        return [
+          'is_valid' => TRUE,
+          'message' => '',
+        ];
+      }
+      if ($countInnerBlockInstances[$child['blockName']] < $child['min']) {
+        return [
+          'is_valid' => FALSE,
+          'message' => \Drupal::translation()->formatPlural($child['max'],
+            '%label: at least @min block is required.',
+            '%label: at least @min blocks are required.',
+            [
+              '%label' => $child['blockLabel'],
+              '@min' => $child['min'],
+            ]),
+        ];
+      }
+      if ($child['max'] !== GutenbergCardinalityValidatorInterface::CARDINALITY_UNLIMITED && $countInnerBlockInstances[$child['blockName']] > $child['max']) {
+        return [
+          'is_valid' => FALSE,
+          'message' => \Drupal::translation()->formatPlural($child['max'],
+            '%label: at most @max block is allowed.',
+            '%label: at most @max blocks are allowed.',
+            [
+              '%label' => $child['blockLabel'],
+              '@max' => $child['max'],
+            ]),
+        ];
+      }
+    }
+
+    return [
+      'is_valid' => TRUE,
+      'message' => '',
+    ];
+  }
+
+  /**
+   * Check if it's fine to not have any inner blocks.
+   *
+   * Returns a message with all expected children blocks if needed.
+   *
+   * @param array $expected_children
+   *
+   * @return array|void
+   */
+  private function validateEmptyInnerBlocks (array $expected_children) {
+    $missingBlocksMessages = [];
+    foreach ($expected_children as $child) {
+      if ($child['min'] > 0) {
+        $message = $this->getExpectedQuantityErrorMessage($child);
+        $missingBlocksMessages[] = $message;
+      }
+    }
+    if (!empty($missingBlocksMessages)) {
+      $errorMessage = t('Required blocks are missing.');
+      $errorMessage .= ' ' . implode(' ', $missingBlocksMessages);
+      return [
+        'is_valid' => FALSE,
+        'message' => $errorMessage,
+      ];
+    }
+
+    return [
+      'is_valid' => TRUE,
+      'message' => '',
+    ];
+  }
+
+  /**
+   * Validates the cardinality of any inner blocks.
+   *
+   * @param array $inner_blocks
+   * @param array $expected_children
+   *
+   * @return array
+   */
+  private function validateAnyInnerBlocks(array $inner_blocks, array $expected_children) {
+    $min = $expected_children['min'];
+    $max = $expected_children['max'];
+    $count = count($inner_blocks['innerBlocks']);
+    if ($count < $min) {
+      return [
+        'is_valid' => FALSE,
+        'message' => \Drupal::translation()->formatPlural($max,
+          'At least @min block is required.',
+          'At least @min blocks are required.',
+          [
+            '@min' => $min,
+          ]),
+      ];
+    }
+    if ($max !== GutenbergCardinalityValidatorInterface::CARDINALITY_UNLIMITED && $count > $max) {
+      return [
+        'is_valid' => FALSE,
+        'message' => \Drupal::translation()->formatPlural($max,
+          'At most @max block is allowed.',
+          'At most @max blocks are allowed.',
+          [
+            '@max' => $max,
+          ]),
+      ];
+    }
+
+    return [
+      'is_valid' => TRUE,
+      'message' => '',
+    ];
+  }
+
+  private function getExpectedQuantityErrorMessage(array $child_block): string {
+    $messageParams = [
+      '%label' => $child_block['blockLabel'],
+      '@min' => $child_block['min'],
+      '@max' => $child_block['max'] > 0 ? $child_block['max'] : t('unlimited'),
+    ];
+    $result = t('%label: there should be between @min and @max blocks.', $messageParams);
+    if ($child_block['min'] === $child_block['max']) {
+      $result = \Drupal::translation()->formatPlural($child_block['min'],
+        '%label: there should be exactly @min block.',
+        '%label: there should be exactly @min blocks.',
+        $messageParams);
+    }
+    return $result;
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
@@ -100,7 +100,7 @@ trait GutenbergCardinalityValidatorTrait {
       if ($countInnerBlockInstances[$child['blockName']] < $child['min']) {
         return [
           'is_valid' => FALSE,
-          'message' => \Drupal::translation()->formatPlural($child['max'],
+          'message' => \Drupal::translation()->formatPlural($child['min'],
             '%label: at least @min block is required.',
             '%label: at least @min blocks are required.',
             [
@@ -176,7 +176,7 @@ trait GutenbergCardinalityValidatorTrait {
     if ($count < $min) {
       return [
         'is_valid' => FALSE,
-        'message' => \Drupal::translation()->formatPlural($max,
+        'message' => \Drupal::translation()->formatPlural($min,
           'At least @min block is required.',
           'At least @min blocks are required.',
           [

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorBase.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorBase.php
@@ -10,14 +10,14 @@ abstract class GutenbergValidatorBase implements GutenbergValidatorInterface {
   /**
    * {@inheritDoc}
    */
-  public function validateContent($block) {
+  public function validateContent(array $block = []): array {
     return [];
   }
 
   /**
    * {@inheritDoc}
    */
-  public function validatedFields($block = []) {
+  public function validatedFields(array $block = []): array {
     return [];
   }
 

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorInterface.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorInterface.php
@@ -16,7 +16,7 @@ interface GutenbergValidatorInterface {
    *
    * @return bool
    */
-  public function applies(array $block);
+  public function applies(array $block): bool;
 
   /**
    * Returns an array with the validation rules for each field that should be
@@ -41,7 +41,7 @@ interface GutenbergValidatorInterface {
    *
    * @return array
    */
-  public function validatedFields(array $block = []);
+  public function validatedFields(array $block = []): array;
 
   /**
    * Validates the content of a block. Useful in case the validator should
@@ -53,13 +53,13 @@ interface GutenbergValidatorInterface {
    * Example:
    * @code
    * array(
-   *   'is_valid' => TRUE,
+   *   'is_valid' => FALSE,
    *   'message' => 'Field name is not valid'
    * );
    * @endcode
    *
    * @return array
    */
-  public function validateContent($block);
+  public function validateContent(array $block = []): array;
 
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorRuleInterface.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergValidatorRuleInterface.php
@@ -15,6 +15,6 @@ interface GutenbergValidatorRuleInterface {
    *
    * @return bool
    */
-  public function validate($value, $fieldLabel);
+  public function validate($value, $fieldLabel): bool;
 
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/GutenbergValidator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/Validation/Constraint/GutenbergValidator.php
@@ -106,7 +106,7 @@ class GutenbergValidator extends ConstraintValidator implements ContainerInjecti
    * Validates a set of Gutenberg blocks (and their inner blocks) against a set
    * of validator plugins.
    *
-   * @param $block
+   * @param array $blocks
    * @param array $plugins
    */
   public function validateBlocks(array $blocks, array $plugins) {

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/modules/silverback_gutenberg_test_validator/silverback_gutenberg_test_validator.info.yml
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/modules/silverback_gutenberg_test_validator/silverback_gutenberg_test_validator.info.yml
@@ -1,0 +1,8 @@
+name: Silverback Gutenberg Test Validator
+type: module
+description: 'Support module for Silverback Gutenberg validators plugin system testing.'
+package: 'Silverback Testing'
+core_version_requirement: ^8 || ^9 || ^10
+
+dependencies:
+  - silverback_gutenberg:silverback_gutenberg

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/modules/silverback_gutenberg_test_validator/src/Plugin/Validation/GutenbergValidator/ColumnValidator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/modules/silverback_gutenberg_test_validator/src/Plugin/Validation/GutenbergValidator/ColumnValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\silverback_gutenberg_test_validator\Plugin\Validation\GutenbergValidator;
+
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergCardinalityValidatorInterface;
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergCardinalityValidatorTrait;
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Validate test plugin for the ANY cardinality.
+ *
+ * @GutenbergValidator(
+ *   id="column_validator",
+ *   label = @Translation("Column validator"),
+ * )
+ */
+class ColumnValidator extends GutenbergValidatorBase {
+
+  use GutenbergCardinalityValidatorTrait;
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function applies(array $block): bool {
+    return $block['blockName'] === 'core/column';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validateContent(array $block = []): array {
+    $expectedChildren = [
+      'validationType' => GutenbergCardinalityValidatorInterface::CARDINALITY_ANY,
+      'min' => 1,
+      'max' => 2,
+    ];
+    return $this->validateCardinality($block, $expectedChildren);
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/modules/silverback_gutenberg_test_validator/src/Plugin/Validation/GutenbergValidator/GroupValidator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/modules/silverback_gutenberg_test_validator/src/Plugin/Validation/GutenbergValidator/GroupValidator.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\silverback_gutenberg_test_validator\Plugin\Validation\GutenbergValidator;
+
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergCardinalityValidatorTrait;
+use Drupal\silverback_gutenberg\GutenbergValidation\GutenbergValidatorBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Validate test plugin for multiple types of inner blocks.
+ *
+ * @GutenbergValidator(
+ *   id="group_validator",
+ *   label = @Translation("Group validator"),
+ * )
+ */
+class GroupValidator extends GutenbergValidatorBase {
+
+  use GutenbergCardinalityValidatorTrait;
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function applies(array $block): bool {
+    return $block['blockName'] === 'core/group';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validateContent(array $block = []): array {
+    $expectedChildren = [
+      [
+        'blockName' => 'core/paragraph',
+        'blockLabel' => $this->t('Paragraph'),
+        'min' => 1,
+        'max' => 2,
+      ],
+      [
+        'blockName' => 'core/list',
+        'blockLabel' => $this->t('List'),
+        'min' => 1,
+        'max' => 1,
+      ],
+    ];
+    return $this->validateCardinality($block, $expectedChildren);
+  }
+
+}


### PR DESCRIPTION
## Package(s) involved

`silverback_gutenberg`

## Description of changes

- Add a cardinality validator that uses the `validateContent()` method as it applies to multiple blocks
- Documentation update for validators, including a pattern that can be applied to custom blocks for client side cardinality limitation

## Motivation and context

Improves EX

## Related Issue(s)

#1321

Potential follow-up: add an operator for multiple cardinality checks.
Example: check if there is at least 1 `core/paragraph` AND | OR 1 `core/list` inner block.
This use case is partially implemented with the ANY cardinality, so we could see if there are more use cases for that.

## How has this been tested?

Manually, test module for the plugin system. PHPUnit tests to be added in #1293
