### PR TITLE
feat: make type prefix configurable

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
@@ -52,6 +52,8 @@ The following configuration options are supported:
   in parallel. Defaults to 10.
 - `paginator_page_size` **(optional)**: How many entities to fetch in a single
   GraphQL query. Defaults to 100.
+- `type_prefix` **(optional)**: A prefix to be added to all generated GraphQL
+  types. Defaults to `Drupal`.
 
 The optional credential parameters can be used to enable different workflows. On
 production, they can be omitted to make sure Drupal handles these requests

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -34,6 +34,7 @@ export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
     auth_key: Joi.string().optional(),
     query_concurrency: Joi.number().optional().min(1),
     paginator_page_size: Joi.number().optional().min(2),
+    type_prefix: Joi.string().optional(),
   });
 
 const getForwardedHeaders = (url: URL) => ({

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-sourcing-config.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-sourcing-config.ts
@@ -112,7 +112,8 @@ export const createSourcingConfig = async (
     schema,
     execute,
     paginationAdapters: [LimitOffsetTranslatable],
-    gatsbyTypePrefix: 'Drupal',
+    gatsbyTypePrefix:
+      typeof options.type_prefix === 'string' ? options.type_prefix : 'Drupal',
     gatsbyNodeDefs: buildNodeDefinitions({ gatsbyNodeTypes, documents }),
   };
 };

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
@@ -15,6 +15,8 @@ export type Options = {
   query_concurrency?: number;
   // How many entities to fetch in a single GraphQL query. Defaults to 100.
   paginator_page_size?: number;
+  // The prefix to use for all Gatsby node types. Defaults to "Drupal".
+  type_prefix?: string;
 };
 
 export const validOptions = (options: {


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/gatsby-source-silverback`

## Motivation and context

We want Drupal and Gatsby schemas to match as much as possible. To make the Preview integration easier.

## How has this been tested?

It was not.
