### PR TITLE
fix(react): declare all shared react packages as side-effect free

### DIFF
--- a/packages/npm/@amazeelabs/bridge/package.json
+++ b/packages/npm/@amazeelabs/bridge/package.json
@@ -6,6 +6,7 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "private": false,
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/npm/@amazeelabs/react-intl-rsc/package.json
+++ b/packages/npm/@amazeelabs/react-intl-rsc/package.json
@@ -7,6 +7,7 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "private": false,
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/npm/@amazeelabs/scalars/package.json
+++ b/packages/npm/@amazeelabs/scalars/package.json
@@ -6,6 +6,7 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "private": false,
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Package(s) involved

* `@amazeelabs/bridge`
* `@amazeelabs/scalars`
* `@amazeelabs/react-intl-rsc`


## Description of changes

Add `sideEffects: false` to all module definitions to fix webpack issues.