### PR TITLE
fix: do not block server when copying/removing files

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildSave.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildSave.ts
@@ -33,7 +33,7 @@ export const buildSaveTask: TaskJob = async (controller) => {
     }
     const target = path.resolve(saveTo, dirName);
     try {
-      fs.copySync(source, target, {
+      await fs.copy(source, target, {
         overwrite: true,
       });
     } catch (e) {

--- a/packages/npm/@amazeelabs/publisher/src/core/tasks/clean/cleanRun.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tasks/clean/cleanRun.ts
@@ -17,7 +17,7 @@ export const cleanRunTask: TaskJob = async (controller) => {
     core.output$.next('Removing saved builds', 'info');
     const savedBuildsPath = path.resolve(persistentBuilds.saveTo);
     try {
-      fs.removeSync(savedBuildsPath);
+      await fs.remove(savedBuildsPath);
     } catch (e) {
       core.output$.next(`Failed to remove ${savedBuildsPath}`, 'error');
       return false;


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/publisher`

## Motivation and context

It was found that `/___status/elements.js` cannot be loaded while Publisher loads/saves the build. And this was blocking Drupal UI 😅 

## How has this been tested?

It was not 😬 
