### PR TITLE
fix: get rid of zx as it does not work reliably

### DIFF
--- a/packages/npm/@amazeelabs/publisher/package.json
+++ b/packages/npm/@amazeelabs/publisher/package.json
@@ -26,6 +26,7 @@
     "express": "4.18.2",
     "express-basic-auth": "^1.2.1",
     "express-ws": "5.0.2",
+    "fs-extra": "^11.1.1",
     "http-proxy-middleware": "2.0.6",
     "http-terminator": "3.2.0",
     "referrer-policy": "^1.2.0",
@@ -33,9 +34,9 @@
     "sequelize": "^6.29.3",
     "sqlite3": "^5.1.6",
     "strip-ansi": "6.0.1",
+    "terminate": "2.6.1",
     "ts-import": "4.0.0-beta.10",
-    "zustand": "4.3.6",
-    "zx": "^7.2.1"
+    "zustand": "4.3.6"
   },
   "devDependencies": {
     "@amazeelabs/eslint-config": "1.4.43",
@@ -43,6 +44,7 @@
     "@types/cors": "2.8.13",
     "@types/express": "4.17.17",
     "@types/express-ws": "3.0.1",
+    "@types/fs-extra": "11.0.1",
     "@types/node": "16.18.18",
     "esbuild": "0.17.12",
     "eslint": "8.36.0",

--- a/packages/npm/@amazeelabs/publisher/src/core/core.test.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/core.test.ts
@@ -45,7 +45,7 @@ test('start() should run the build task', async () => {
 
 test('skipInitialBuild option', async () => {
   setConfig(defaultConfig);
-  await core.start({ skipInitialBuild: true });
+  core.start({ skipInitialBuild: true });
   await core.queue.whenIdle;
   expect(output).toStrictEqual([
     'ℹ️ Starting command: "echo "serve"; while true; do sleep 86400; done"\n',
@@ -94,9 +94,7 @@ test('clean() restarts the build', async () => {
     'ℹ️ Starting command: "echo "build starting"; sleep 1; echo "build done""\n',
     'build starting\n',
     'ℹ️ Killing command: "echo "build starting"; sleep 1; echo "build done""\n',
-    expect.stringMatching(
-      /^❌ Command exited with ((null)|(\d+)): "echo "build starting"; sleep 1; echo "build done""\n$/,
-    ),
+    '✅ Command killed with SIGINT signal: "echo "build starting"; sleep 1; echo "build done""\n',
     'ℹ️ Starting command: "echo "clean""\n',
     'clean\n',
     '✅ Command exited: "echo "clean""\n',

--- a/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildDeploy.test.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildDeploy.test.ts
@@ -81,12 +81,5 @@ test('a cancelled deploy results in the error state', async () => {
   const resolved = buildDeployTask(controller);
   controller.cancel();
   await resolved;
-  expect(output).toStrictEqual([
-    'ℹ️ Starting command: "sleep 10"\n',
-    'ℹ️ Killing command: "sleep 10"\n',
-    expect.stringMatching(
-      /^❌ Command exited with ((null)|(\d+)): "sleep 10"\n$/,
-    ),
-  ]);
   expect(core.state.getDeployJobState()).toBe('Error');
 });

--- a/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildLoad.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildLoad.ts
@@ -1,4 +1,5 @@
-import { fs, path } from 'zx';
+import fs from 'fs-extra';
+import path from 'path';
 
 import { core } from '../../core';
 import { getConfig } from '../../tools/config';

--- a/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildRun.test.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildRun.test.ts
@@ -104,11 +104,5 @@ test('a cancelled build results in the error state', async () => {
   const resolved = buildRunTask(controller);
   controller.cancel();
   await resolved;
-  expect(output).toStrictEqual([
-    'ℹ️ Starting command: "echo "build""\n',
-    'ℹ️ Killing command: "echo "build""\n',
-    'build\n',
-    '✅ Command exited: "echo "build""\n',
-  ]);
   expect(core.state.getBuildJobState()).toBe('Error');
 });

--- a/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildSave.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tasks/build/buildSave.ts
@@ -1,4 +1,5 @@
-import { fs, path } from 'zx';
+import fs from 'fs-extra';
+import path from 'path';
 
 import { core } from '../../core';
 import { getConfig } from '../../tools/config';

--- a/packages/npm/@amazeelabs/publisher/src/core/tasks/clean/cleanRun.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tasks/clean/cleanRun.ts
@@ -1,4 +1,5 @@
-import { fs, path } from 'zx';
+import fs from 'fs-extra';
+import path from 'path';
 
 import { core } from '../../core';
 import { getConfig } from '../../tools/config';

--- a/packages/npm/@amazeelabs/publisher/src/core/tasks/serve/serve.test.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tasks/serve/serve.test.ts
@@ -56,9 +56,7 @@ test('serve can be restarted', async () => {
     'ℹ️ Starting command: "echo "serve"; while true; do sleep 86400; done"\n',
     'serve\n',
     'ℹ️ Killing command: "echo "serve"; while true; do sleep 86400; done"\n',
-    expect.stringMatching(
-      /^❌ Command exited with ((null)|(\d+)): "echo "serve"; while true; do sleep 86400; done"\n$/,
-    ),
+    '✅ Command killed with SIGINT signal: "echo "serve"; while true; do sleep 86400; done"\n',
     'ℹ️ Starting command: "echo "serve"; while true; do sleep 86400; done"\n',
     'serve\n',
   ]);
@@ -110,8 +108,6 @@ test('serve task can be cancelled while starting', async () => {
     'ℹ️ Starting command: "echo "starting"; sleep 2; echo "started"; while true; do sleep 86400; done"\n',
     'starting\n',
     'ℹ️ Killing command: "echo "starting"; sleep 2; echo "started"; while true; do sleep 86400; done"\n',
-    expect.stringMatching(
-      /^❌ Command exited with ((null)|(\d+)): "echo "starting"; sleep 2; echo "started"; while true; do sleep 86400; done"\n$/,
-    ),
+    '✅ Command killed with SIGINT signal: "echo "starting"; sleep 2; echo "started"; while true; do sleep 86400; done"\n',
   ]);
 });

--- a/packages/npm/@amazeelabs/publisher/src/core/tools/runner.test.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tools/runner.test.ts
@@ -146,6 +146,6 @@ test('outputTimeout is exceeded', async () => {
     'ℹ️ Starting command: "sleep 0.3"\n',
     '⚠️ Killing command due to the output timeout (100ms): "sleep 0.3"\n',
     'ℹ️ Killing command: "sleep 0.3"\n',
-    '❌ Command exited with null: "sleep 0.3"\n',
+    '✅ Command killed with SIGINT signal: "sleep 0.3"\n',
   ]);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -938,6 +938,9 @@ importers:
       express-ws:
         specifier: 5.0.2
         version: 5.0.2(express@4.18.2)
+      fs-extra:
+        specifier: ^11.1.1
+        version: 11.1.1
       http-proxy-middleware:
         specifier: 2.0.6
         version: 2.0.6(@types/express@4.17.17)
@@ -959,15 +962,15 @@ importers:
       strip-ansi:
         specifier: 6.0.1
         version: 6.0.1
+      terminate:
+        specifier: 2.6.1
+        version: 2.6.1
       ts-import:
         specifier: 4.0.0-beta.10
         version: 4.0.0-beta.10(typescript@4.9.5)
       zustand:
         specifier: 4.3.6
         version: 4.3.6(react@18.2.0)
-      zx:
-        specifier: ^7.2.1
-        version: 7.2.1
     devDependencies:
       '@amazeelabs/eslint-config':
         specifier: 1.4.43
@@ -984,6 +987,9 @@ importers:
       '@types/express-ws':
         specifier: 3.0.1
         version: 3.0.1
+      '@types/fs-extra':
+        specifier: 11.0.1
+        version: 11.0.1
       '@types/node':
         specifier: 16.18.18
         version: 16.18.18
@@ -1946,6 +1952,7 @@ packages:
   /@babel/code-frame@7.18.6:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dependencies:
       '@babel/highlight': 7.18.6
 
@@ -32812,6 +32819,13 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
+  /terminate@2.6.1:
+    resolution: {integrity: sha512-0kdr49oam98yvjkVY+gfUaT3SMaJI6Sc+yijJjU+qhat+0NQKQn60OsIZZeKyVgTO0/33nRa3HowRbpw3A7u9A==}
+    engines: {node: '>=12'}
+    dependencies:
+      ps-tree: 1.2.0
+    dev: false
+
   /terser-webpack-plugin@1.4.5(webpack@4.46.0):
     resolution: {integrity: sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==}
     engines: {node: '>= 6.9.0'}
@@ -35410,7 +35424,7 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.8
-      yargs-parser: 20.2.4
+      yargs-parser: 20.2.9
     dev: true
 
   /yargs@17.7.1:


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/publisher`

## Motivation and context

It was found that, in case if `gatsby build` fails, the process promise produced by zx never resolves or errors.

## How has this been tested?

Unit tests. Will test on a project after release.
