### PR TITLE
fix: switch shell to sh as bash isn't available on lagoon

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/core/tools/runner.test.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tools/runner.test.ts
@@ -109,7 +109,7 @@ test('exit code of a failed command is logged', async () => {
   expect(exitCode).toBe(127);
   expect(output).toStrictEqual([
     'ℹ️ Starting command: "I_DO_NOT_EXIST"\n',
-    expect.stringMatching(/I_DO_NOT_EXIST: command not found\n$/),
+    expect.stringMatching(/I_DO_NOT_EXIST.*not found/),
     '❌ Command exited with 127: "I_DO_NOT_EXIST"\n',
   ]);
 });

--- a/packages/npm/@amazeelabs/publisher/src/core/tools/runner.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tools/runner.ts
@@ -22,7 +22,7 @@ export const run = (options: {
   outputTimeout?: number;
 }): Process => {
   core.output$.next(`Starting command: "${options.command}"`, 'info');
-  const process = spawn(`( ${options.command} ) 2>&1`, { shell: '/bin/bash' });
+  const process = spawn(`( ${options.command} ) 2>&1`, { shell: '/bin/sh' });
 
   let outputTimeout: NodeJS.Timeout | undefined;
   const setOutputTimeout = (stop = false): void => {


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/publisher`

## Motivation and context

`bash` is not available by default in `uselagoon/node-18` images. So we switch to `sh`.

## How has this been tested?

Unit tests.
