### PR TITLE
fix: allow to use custom SLB-Forwarded-* headers

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.services.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.services.yml
@@ -2,39 +2,49 @@ services:
   silverback_gatsby.feed_manager:
     class: Drupal\silverback_gatsby\Plugin\FeedPluginManager
     arguments:
-      - 'Plugin/Gatsby/Feed'
-      - '@container.namespaces'
-      - '@module_handler'
+      - "Plugin/Gatsby/Feed"
+      - "@container.namespaces"
+      - "@module_handler"
       - '\Drupal\silverback_gatsby\Plugin\FeedInterface'
       - '\Drupal\silverback_gatsby\Annotation\GatsbyFeed'
 
   silverback_gatsby.build_trigger:
     class: Drupal\silverback_gatsby\GatsbyBuildTrigger
     arguments:
-      - '@http_client'
-      - '@messenger'
-      - '@entity_type.manager'
+      - "@http_client"
+      - "@messenger"
+      - "@entity_type.manager"
 
   silverback_gatsby.update_trigger:
     class: Drupal\silverback_gatsby\GatsbyUpdateTrigger
     arguments:
-      - '@http_client'
-      - '@messenger'
-      - '@entity_type.manager'
+      - "@http_client"
+      - "@messenger"
+      - "@entity_type.manager"
 
   silverback_gatsby.update_tracker:
     class: Drupal\silverback_gatsby\GatsbyUpdateTracker
-    arguments: ['@database', '@current_user', '@silverback_gatsby.build_trigger']
+    arguments:
+      ["@database", "@current_user", "@silverback_gatsby.build_trigger"]
 
   silverback_gatsby.update_handler:
     class: Drupal\silverback_gatsby\GatsbyUpdateHandler
     arguments:
-    - '@entity_type.manager'
-    - '@silverback_gatsby.update_tracker'
-    - '@silverback_gatsby.update_trigger'
+      - "@entity_type.manager"
+      - "@silverback_gatsby.update_tracker"
+      - "@silverback_gatsby.update_trigger"
 
   silverback_gatsby.menu_tree_storage:
     class: Drupal\silverback_gatsby\MenuTreeStorageDecorator
     decorates: menu.tree_storage
     public: false
-    arguments: ['@silverback_gatsby.menu_tree_storage.inner', '@silverback_gatsby.update_handler']
+    arguments:
+      [
+        "@silverback_gatsby.menu_tree_storage.inner",
+        "@silverback_gatsby.update_handler",
+      ]
+
+  silverback_gatsby.reverse_proxy_middleware:
+    class: Drupal\silverback_gatsby\SilverbackReverseProxyMiddleware
+    tags:
+      - { name: http_middleware, priority: 500 }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/SilverbackReverseProxyMiddleware.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/SilverbackReverseProxyMiddleware.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\silverback_gatsby;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Custom reverse proxy middleweare.
+ * 
+ * Rewrites custom reverse proxy headers to standard ones.
+ * Lagoon won't allow X-Forwarded-* headers from unknown proxies
+ * and Netlify does not provide an IP range. Therefore we send
+ * custom SLB-Forwarded-* headers and write them into X-Forwarded-*
+ * using this middleware.
+ */
+class SilverbackReverseProxyMiddleware implements HttpKernelInterface {
+
+  /**
+   * The inner kernel to which the request will be passed.
+   *
+   * @var \Symfony\Component\HttpKernel\HttpKernelInterface
+   */
+  protected $app;
+
+  /**
+   * Constructs a HostChanger object.
+   *
+   * @param \Symfony\Component\HttpKernel\HttpKernelInterface $app
+   *   The inner kernel to which the request will be passed.
+   */
+  public function __construct(HttpKernelInterface $app) {
+    $this->app = $app;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = TRUE): Response {
+    foreach (['Proto', 'Host', 'Port', 'For'] as $header) {
+      if ($request->headers->has('SLB-Forwarded-' . $header)) {
+        $request->headers->set('X-Forwarded-' . $header, $request->headers->get('SLB-Forwarded-' . $header));
+      }
+    }
+    // Pass the request to the next middleware.
+    return $this->app->handle($request, $type, $catch);
+  }
+}

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -41,6 +41,9 @@ const getForwardedHeaders = (url: URL) => ({
   'X-Forwarded-Proto': url.protocol === 'https:' ? 'https' : 'http',
   'X-Forwarded-Host': url.hostname,
   'X-Forwarded-Port': url.port,
+  'SLB-Forwarded-Proto': url.protocol === 'https:' ? 'https' : 'http',
+  'SLB-Forwarded-Host': url.hostname,
+  'SLB-Forwarded-Port': url.port,
 });
 
 export const sourceNodes: GatsbyNode['sourceNodes'] = async (


### PR DESCRIPTION
Lagoon will override `X-Forwarded-*` headers when they are coming from Netlify.

Therefore we use `SLB-Forwarded-*` versions that are written into `X-Forwarded-*` using a http middleware.