### PR TITLE
refactor(cloudinary): simplify development setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "composer.workingPath": "apps/silverback-drupal"
+    "composer.workingPath": "apps/silverback-drupal",
+    "php.validate.executablePath": "/usr/bin/php",
+    "phpunit.phpunit": "apps/silverback-drupal/vendor/bin/phpunit"
 }

--- a/packages/composer/amazeelabs/silverback_cloudinary/src/Plugin/GraphQL/DataProducer/ResponsiveImage.php
+++ b/packages/composer/amazeelabs/silverback_cloudinary/src/Plugin/GraphQL/DataProducer/ResponsiveImage.php
@@ -82,7 +82,7 @@ class ResponsiveImage extends DataProducerPluginBase {
     if (empty($sizes)) {
       return '';
     }
-    $sizeEntries = array_reduce($sizes, function($carry, $sizesElement) {
+    $sizeEntries = array_reduce($sizes, function ($carry, $sizesElement) {
       // Each size must have exactly 2 elements.
       if (count($sizesElement) !== 2) {
         return $carry;
@@ -118,7 +118,7 @@ class ResponsiveImage extends DataProducerPluginBase {
     if (empty($sizes)) {
       return '';
     }
-    $srcSetEntries = array_reduce($sizes, function($carry, $sizesElement) use ($defaultDimensions, $originalUrl, $transform) {
+    $srcSetEntries = array_reduce($sizes, function ($carry, $sizesElement) use ($defaultDimensions, $originalUrl, $transform) {
       // Each size must have exactly 2 elements.
       if (count($sizesElement) !== 2) {
         return $carry;
@@ -155,6 +155,11 @@ class ResponsiveImage extends DataProducerPluginBase {
    * @return string
    */
   protected function getCloudinaryImageUrl($originalUrl, array $config = []) {
+    // If the cloud name is "local" return the original image.
+    // For local testing.
+    if (strpos(getenv('CLOUDINARY_URL'), '@local')) {
+      return $originalUrl;
+    }
     $image = (new ImageTag($originalUrl));
     // We do not want the additional '_a" query parameter on the urls. If we
     // do not set it to FALSE, every image url will have a additional '_a' query

--- a/packages/composer/amazeelabs/silverback_cloudinary/src/Plugin/GraphQL/Directive/ResponsiveImage.php
+++ b/packages/composer/amazeelabs/silverback_cloudinary/src/Plugin/GraphQL/Directive/ResponsiveImage.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Drupal\silverback_cloudinary\Plugin\GraphQL\Directive;
+
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
 use Drupal\graphql\GraphQL\ResolverBuilder;

--- a/packages/composer/amazeelabs/silverback_cloudinary/tests/src/Kernel/DataProducer/ResponsiveImageTest.php
+++ b/packages/composer/amazeelabs/silverback_cloudinary/tests/src/Kernel/DataProducer/ResponsiveImageTest.php
@@ -25,8 +25,7 @@ class ResponsiveImageTest extends GraphQLTestBase {
    * @covers \Drupal\silverback_cloudinary\Plugin\GraphQL\DataProducer\ResponsiveImage::resolve
    * @dataProvider responsiveImageProvider
    */
-  public function testResponsiveImage($image, $expected, $width = NULL, $height = NULL, $sizes = NULL, $transform = NULL): void
-  {
+  public function testResponsiveImage($image, $expected, $width = NULL, $height = NULL, $sizes = NULL, $transform = NULL): void {
     $result = $this->executeDataProducer('responsive_image', [
       'image' => $image,
       'width' => $width,

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.test.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.test.ts
@@ -109,6 +109,37 @@ describe('buildResponsiveImage()', () => {
     });
   });
 
+  it('returns the original image url when cloudname is "local"', () => {
+    const result = JSON.parse(
+      buildResponsiveImage(
+        {
+          cloudname: 'local',
+          key: '000',
+          secret: 'FFF',
+        },
+        imageProps,
+        {
+          width: 1600,
+          height: 1200,
+          sizes: [
+            [800, 780],
+            [1200, 1100],
+          ],
+        },
+      ),
+    );
+    expect(result).toStrictEqual({
+      src: `${imageProps.src}`,
+      width: 1600,
+      height: 1200,
+      sizes: '(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px',
+      srcset: [
+        `${imageProps.src} 780w`,
+        `${imageProps.src} 1100w`,
+      ].join(', '),
+    });
+  });
+
   it('retrieves a placeholder image when the cloudname is "test"', () => {
     const result = JSON.parse(
       buildResponsiveImage(

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
@@ -197,6 +197,9 @@ const getCloudinaryImageUrl = (
       config?.height || (config?.width || 1000) * 0.75
     }/${apiKey}/${apiSecret}`;
   }
+  if (cloudName === 'local') {
+    return originalImage;
+  }
   const image = new CloudinaryImage(
     originalImage,
     {

--- a/packages/npm/@amazeelabs/scalars/src/index.tsx
+++ b/packages/npm/@amazeelabs/scalars/src/index.tsx
@@ -1,11 +1,17 @@
 import {
-    Link as LinkComponent,
-    navigate as navigateFunction,
+  Link as LinkComponent,
+  navigate as navigateFunction,
 } from '@amazeelabs/bridge';
 import type { Element } from 'hast';
 import { selectAll } from 'hast-util-select';
 import qs, { StringifiableRecord } from 'query-string';
-import React, { AnchorHTMLAttributes, ComponentType, createElement, DetailedHTMLProps , Fragment } from 'react';
+import React, {
+  AnchorHTMLAttributes,
+  ComponentType,
+  createElement,
+  DetailedHTMLProps,
+  Fragment,
+} from 'react';
 import rehypeParse from 'rehype-parse';
 import rehypeReact from 'rehype-react';
 import rehypeSlug from 'rehype-slug';
@@ -16,187 +22,193 @@ export { useLocation } from '@amazeelabs/bridge';
 
 declare const Url: unique symbol;
 export type Url = string & {
-    _opaque: typeof Url;
+  _opaque: typeof Url;
 };
 
 type LinkOverrideProps = {
-    query?: StringifiableRecord;
-    fragment?: string;
+  query?: StringifiableRecord;
+  fragment?: string;
 };
 
 type LinkTransitionProps = {
-    transition?: string;
-    reverse?: boolean;
+  transition?: string;
+  reverse?: boolean;
 };
 
 type LinkDisplayProps = {
-    activeClassName?: string;
+  activeClassName?: string;
 };
 
 export function overrideUrlParameters(
-    url: string,
-    query?: StringifiableRecord,
-    fragment?: string,
+  url: string,
+  query?: StringifiableRecord,
+  fragment?: string,
 ): string {
-    if (url[0] === '/') {
-        return overrideUrlParameters(`relative://${url}`, query, fragment).replace(
-            'relative://',
-            '',
-        );
-    }
-    const parsed = qs.parseUrl(url);
-    return qs.stringifyUrl(
-        {
-            url: parsed.url,
-            fragmentIdentifier:
-                typeof fragment === 'undefined' ? parsed.fragmentIdentifier : fragment,
-            query: { ...parsed.query, ...query },
-        },
-        {
-            skipNull: true,
-        },
+  if (url[0] === '/') {
+    return overrideUrlParameters(`relative://${url}`, query, fragment).replace(
+      'relative://',
+      '',
     );
+  }
+  const parsed = qs.parseUrl(url);
+  return qs.stringifyUrl(
+    {
+      url: parsed.url,
+      fragmentIdentifier:
+        typeof fragment === 'undefined' ? parsed.fragmentIdentifier : fragment,
+      query: { ...parsed.query, ...query },
+    },
+    {
+      skipNull: true,
+    },
+  );
 }
 
 export type LinkProps = Omit<
-    DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
-    'href'
+  DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
+  'href'
 > & { href: Url } & LinkOverrideProps &
-    LinkTransitionProps &
-    LinkDisplayProps;
+  LinkTransitionProps &
+  LinkDisplayProps;
 
 export function Link({ href, query, fragment, ...props }: LinkProps) {
-    const target = overrideUrlParameters(href, query, fragment);
-    return <LinkComponent href={target} {...props} />;
+  const target = overrideUrlParameters(href, query, fragment);
+  return <LinkComponent href={target} {...props} />;
 }
 
 export function navigate(
-    href: Url,
-    config: {
-        query?: StringifiableRecord;
-        fragment?: string;
-        transition?: string;
-        reverse?: boolean;
-    },
+  href: Url,
+  config: {
+    query?: StringifiableRecord;
+    fragment?: string;
+    transition?: string;
+    reverse?: boolean;
+  },
 ) {
-    navigateFunction(overrideUrlParameters(href, config.query, config.fragment));
+  navigateFunction(overrideUrlParameters(href, config.query, config.fragment));
 }
 
 declare const ImageSource: unique symbol;
 export type ImageSource = string & {
-    _opaque: typeof ImageSource;
+  _opaque: typeof ImageSource;
 };
 
 type ImageSourceStructure = {
+  src: string;
+  srcset: string;
+  sizes: string;
+  width: number;
+  height: number;
+  sources: Array<{
+    media: string;
     src: string;
     srcset: string;
-    sizes: string;
     width: number;
     height: number;
-    sources: Array<{
-        media: string;
-        src: string;
-        srcset: string;
-        width: number;
-        height: number;
-    }>;
+  }>;
 };
 
 export function Image({
-    source,
-    priority,
-    alt,
-    ...props
+  source,
+  priority,
+  alt,
+  ...props
 }: {
-    source: ImageSource;
-    alt: string;
-    priority?: boolean;
-    className?: string;
+  source: ImageSource;
+  alt: string;
+  priority?: boolean;
+  className?: string;
 }) {
-    const { srcset, ...imageData } = JSON.parse(source) as ImageSourceStructure;
-    return (
-        <img
-            decoding={priority ? 'sync' : 'async'}
-            loading={priority ? 'eager' : 'lazy'}
-            srcSet={srcset}
-            {...imageData}
-            alt={alt}
-            {...props}
-        />
-    );
+  const { srcset, ...imageData } = JSON.parse(source) as ImageSourceStructure;
+  return (
+    <img
+      decoding={priority ? 'sync' : 'async'}
+      loading={priority ? 'eager' : 'lazy'}
+      srcSet={srcset}
+      {...imageData}
+      // Set object fit to "cover", to never
+      // distort an image, even if the width
+      // and height don't match.
+      // This is the case when an image is
+      // loaded unprocessed for testing.
+      style={{ objectFit: 'cover' }}
+      alt={alt}
+      {...props}
+    />
+  );
 }
 
 declare const Timestamp: unique symbol;
 export type Timestamp = string & {
-    _opaque: typeof Timestamp;
+  _opaque: typeof Timestamp;
 };
 
 export function timestamp(input: Timestamp) {
-    return new Date(input);
+  return new Date(input);
 }
 
 declare const Markup: unique symbol;
 export type Markup = string & {
-    _opaque: typeof Markup;
+  _opaque: typeof Markup;
 };
 
 const rehypeAddClasses: Plugin<[{ [key: string]: string }], Element> =
-    (settings) => (tree) => {
-        Object.keys(settings || {}).forEach((matcher) => {
-            const cls = settings[matcher];
-            selectAll(matcher, tree).forEach((node) => {
-                if (!node.properties) {
-                    node.properties = { class: cls };
-                } else {
-                    node.properties.class = [node.properties.class, cls].join();
-                }
-                node.properties['class'] = cls;
-            });
-        });
-    };
+  (settings) => (tree) => {
+    Object.keys(settings || {}).forEach((matcher) => {
+      const cls = settings[matcher];
+      selectAll(matcher, tree).forEach((node) => {
+        if (!node.properties) {
+          node.properties = { class: cls };
+        } else {
+          node.properties.class = [node.properties.class, cls].join();
+        }
+        node.properties['class'] = cls;
+      });
+    });
+  };
 
 export function Html({
-    markup,
-    classNames,
-    components,
-    plugins,
+  markup,
+  classNames,
+  components,
+  plugins,
 }: {
-    markup: Markup;
-    classNames?: {
-        [key: string]: string;
-    };
-    components?: Partial<{
-        [TagName in keyof JSX.IntrinsicElements]:
-        | keyof JSX.IntrinsicElements
-        | ComponentType<{ node: Element } & JSX.IntrinsicElements[TagName]>;
-    }>;
-    plugins?: Pluggable[];
+  markup: Markup;
+  classNames?: {
+    [key: string]: string;
+  };
+  components?: Partial<{
+    [TagName in keyof JSX.IntrinsicElements]:
+      | keyof JSX.IntrinsicElements
+      | ComponentType<{ node: Element } & JSX.IntrinsicElements[TagName]>;
+  }>;
+  plugins?: Pluggable[];
 }) {
-    return unified()
-        .use(rehypeParse, { fragment: true })
-        .use(rehypeAddClasses, classNames || {})
-        .use(rehypeSlug)
-        .use(plugins || [])
-        .use(rehypeReact, {
-            Fragment,
-            createElement,
-            passNode: true,
-            components: {
-                ...{
-                    a: (props) => {
-                        const { children, href, ...rest } = omit(props, ['node']);
-                        return createElement(
-                            Link,
-                            {
-                                href: (href || '/') as Url,
-                                ...rest,
-                            },
-                            children,
-                        );
-                    },
-                    ...components,
-                },
-            },
-        })
-        .processSync(markup).result;
+  return unified()
+    .use(rehypeParse, { fragment: true })
+    .use(rehypeAddClasses, classNames || {})
+    .use(rehypeSlug)
+    .use(plugins || [])
+    .use(rehypeReact, {
+      Fragment,
+      createElement,
+      passNode: true,
+      components: {
+        ...{
+          a: (props) => {
+            const { children, href, ...rest } = omit(props, ['node']);
+            return createElement(
+              Link,
+              {
+                href: (href || '/') as Url,
+                ...rest,
+              },
+              children,
+            );
+          },
+          ...components,
+        },
+      },
+    })
+    .processSync(markup).result;
 }


### PR DESCRIPTION
If the cloudinary cloud name is set to "local", the original image
source is used in any case, but with different width and height
attributes. Images are then rendered with `object-fit: cover`, to
simulate cropping. That way, the service worker should not be necessary.

## Package(s) involved

<!-- type the name of the package(s) involved in this pull request -->

## Description of changes

<!-- a brief summary of your code changes -->

## Motivation and context

<!-- why is this PR necessary? is someone experiencing bugs or is a new feature being implemented? -->

## Related Issue(s)

<!-- make sure you link with either an `#issue-number` or directly with `[link-text](url)` -->

## How has this been tested?

<!-- locally? written tests? -->
