### PR TITLE
Remove EXTERNAL_PREVIEW_BASE_URL env var

### DIFF
--- a/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
+++ b/packages/composer/amazeelabs/silverback_external_preview/silverback_external_preview.module
@@ -14,8 +14,9 @@ function silverback_external_preview_toolbar() {
   $toolbar_items = [];
   /** @var \Drupal\silverback_external_preview\ExternalPreviewLink $externalPreviewLink */
   $externalPreviewLink = Drupal::service('silverback_external_preview.external_preview_link');
+  $externalPreviewSettings = \Drupal::configFactory()->get('silverback_external_preview.settings');
   $currentUser = \Drupal::currentUser();
-  if (getenv('EXTERNAL_PREVIEW_BASE_URL') && $currentUser->hasPermission('use external preview')) {
+  if ($externalPreviewSettings->get('preview_host') && $externalPreviewSettings->get('live_host') && $currentUser->hasPermission('use external preview')) {
     $routeMatch = Drupal::routeMatch();
     /* @var $url Url */
     $url = $externalPreviewLink->getPreviewUrl($routeMatch);


### PR DESCRIPTION
## Package(s) involved

silverback_external_preview

## Description of changes

The check to show the external preview link in the toolbar is now using the config value instead of the env var, and the module now works according to its readme.

## Related Issue(s)

https://github.com/AmazeeLabs/silverback-mono/issues/1357

## How has this been tested?

Locally, manually.
