### PR TITLE
feat(SLB-170): publisher status button improvement

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.permissions.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.permissions.yml
@@ -1,2 +1,4 @@
 trigger a gatsby build:
   title: 'Trigger a Gatsby Build'
+access publisher:
+  title: 'Access Publisher'

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.routing.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.routing.yml
@@ -8,3 +8,9 @@ entity.graphql_server.build_form:
     _permission: 'administer graphql configuration+trigger a gatsby build'
   options:
     _admin_route: TRUE
+silverback_gatsby.build:
+  path: '/silverback_gatsby/ajax/build'
+  defaults:
+    _controller: '\Drupal\silverback_gatsby\Controller\BuildController::build'
+  requirements:
+    _permission: 'trigger a gatsby build'

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Controller/BuildController.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Controller/BuildController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\AlertCommand;
+use Drupal\silverback_gatsby\GatsbyBuildTriggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class BuildController extends ControllerBase {
+
+  protected GatsbyBuildTriggerInterface $buildTrigger;
+
+  /**
+   * Constructs a BuildController object.
+   *
+   * @param \Drupal\silverback_gatsby\GatsbyBuildTriggerInterface $buildTrigger
+   */
+  public function __construct(GatsbyBuildTriggerInterface $buildTrigger) {
+    $this->buildTrigger = $buildTrigger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('silverback_gatsby.build_trigger'),
+    );
+  }
+
+  /**
+   * Triggers a Gatsby build for the default GraphQL server.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   */
+  public function build() {
+    $response = new AjaxResponse();
+    $message = $this->buildTrigger->triggerDefaultServerLatestBuild();
+    $response->addCommand(new AlertCommand($message));
+    return $response;
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyBuildTrigger.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyBuildTrigger.php
@@ -89,6 +89,26 @@ class GatsbyBuildTrigger implements GatsbyBuildTriggerInterface {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public function triggerDefaultServerLatestBuild() : TranslatableMarkup {
+    $servers = $this->entityTypeManager->getStorage('graphql_server')->loadMultiple();
+    $silverbackGatsbyServers = array_filter($servers, function (ServerInterface $server) {
+      $configuration = $server->get('schema_configuration')[$server->get('schema')];
+      return !empty($configuration['extensions']['silverback_gatsby']);
+    });
+    $silverbackGatsbyServer = reset($silverbackGatsbyServers);
+
+    if ($silverbackGatsbyServer instanceof ServerInterface) {
+      return $this->triggerLatestBuild($silverbackGatsbyServer->id());
+    }
+
+    $message = $this->t('No default server found.');
+    $this->messenger->addError($message);
+    return $message;
+  }
+
+  /**
    * Check on the frontend if the latest build already occurred.
    *
    * If the build url is not configured, presume false so the build

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyBuildTriggerInterface.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyBuildTriggerInterface.php
@@ -26,12 +26,27 @@ interface GatsbyBuildTriggerInterface {
    *   The server id.
    *
    * @return TranslatableMarkup
-   *   The resut message.
+   *   The result message.
    */
   public function triggerLatestBuild(string $server) : TranslatableMarkup;
+
+  /**
+   * Trigger a build for the default server.
+   *
+   * The default server is selected based on the enabled silverback_gatsby
+   * extension. If there are multiple, the first one is selected.
+   *
+   * Compares the latest build id with the one on the frontend to not
+   * trigger unnecessary builds.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   *   The result message.
+   */
+  public function triggerDefaultServerLatestBuild() : TranslatableMarkup;
 
   /**
    * Send out notifications about potential updates to all Gatsby servers.
    */
   public function sendUpdates() : void;
+
 }

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/README.md
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/README.md
@@ -1,0 +1,7 @@
+# Silverback Publisher Monitor
+
+Enables a Toolbar drop button that displays:
+
+- The build status
+- A button to trigger a build if the `trigger a gatsby build` permission applies
+- A link to access Publisher if the `access publisher` permission applies

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/css/indicator.css
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/css/indicator.css
@@ -6,6 +6,10 @@
   right: 1px;
 }
 
+.silverback-publisher-indicator-tab .dropbutton__item .ajax-progress {
+  display: none;
+}
+
 .silverback-publisher-indicator-tab .dropbutton__toggle {
   height: 36px !important;
   margin-top: -1.5px;

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/css/indicator.css
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/css/indicator.css
@@ -1,11 +1,21 @@
 .silverback-publisher-indicator-tab {
   float: right !important;
-  margin-top: -2px;
-  background: #f5f5f5;
-
+  z-index: 1000;
+  position: relative;
+  top: 3px;
+  right: 1px;
 }
 
-.silverback-publisher-indicator-tab .toolbar-item {
-  display: block;
+.silverback-publisher-indicator-tab .dropbutton__toggle {
+  height: 36px !important;
+  margin-top: -1.5px;
+}
+
+.silverback-publisher-indicator-tab .dropbutton-action {
+  margin-right: 15px !important;
+}
+
+.silverback-publisher-indicator-tab .dropbutton__item .toolbar-item {
   color: #565656 !important;
+  margin-top: -17px;
 }

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/css/indicator.css
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/css/indicator.css
@@ -1,25 +1,36 @@
 .silverback-publisher-indicator-tab {
   float: right !important;
+  margin-top: -2px;
+  background: #f5f5f5;
+}
+
+.silverback-publisher-indicator-tab .toolbar-item {
+  display: block;
+  color: #565656 !important;
+}
+
+.silverback-publisher-drop-button {
+  float: right !important;
   z-index: 1000;
   position: relative;
   top: 3px;
   right: 1px;
 }
 
-.silverback-publisher-indicator-tab .dropbutton__item .ajax-progress {
+.silverback-publisher-drop-button .dropbutton__item .ajax-progress {
   display: none;
 }
 
-.silverback-publisher-indicator-tab .dropbutton__toggle {
+.silverback-publisher-drop-button .dropbutton__toggle {
   height: 36px !important;
   margin-top: -1.5px;
 }
 
-.silverback-publisher-indicator-tab .dropbutton-action {
+.silverback-publisher-drop-button .dropbutton-action {
   margin-right: 15px !important;
 }
 
-.silverback-publisher-indicator-tab .dropbutton__item .toolbar-item {
+.silverback-publisher-drop-button .dropbutton__item .toolbar-item {
   color: #565656 !important;
   margin-top: -17px;
 }

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.info.yml
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.info.yml
@@ -3,4 +3,6 @@ type: module
 description: 'Adds a build indicator to show the status of Publisher builds'
 package: Silverback
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || ^10
+dependencies:
+  - silverback_gatsby:silverback_gatsby

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.module
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.module
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Url;
+
 /**
  * Retrieve the url publisher is available at.
  * Defaults to http://localhost:8000.
@@ -39,22 +41,72 @@ function silverback_publisher_monitor_page_attachments(&$variables) {
 function silverback_publisher_monitor_toolbar() {
   $items = [];
 
-  $items['silverback_publisher_monitor'] = [
-    '#type' => 'toolbar_item',
-    'tab' => [
-      '#type' => 'html_tag',
-      '#tag' => 'publisher-status',
-      '#cache' => [
-        'max-age' => 0,
-      ],
-      '#attributes' => [
-        'url' => publisher_url(),
-        'labelStarting' => t('Starting build'),
-        'labelReady' => t('Website is up-to-date'),
-        'labelError' => t('Fatal Error'),
-        'labelUpdating' => t('Website is updating'),
+  $statusElement = [
+    '#type' => 'html_tag',
+    '#tag' => 'publisher-status',
+    '#cache' => [
+      'max-age' => 0,
+    ],
+    '#attributes' => [
+      'class' => 'toolbar-item',
+      'url' => publisher_url(),
+      'labelStarting' => t('Starting build'),
+      'labelReady' => t('Website is up-to-date'),
+      'labelError' => t('Fatal Error'),
+      'labelUpdating' => t('Website is updating'),
+    ],
+  ];
+
+  $buildLink = [
+    '#type' => 'link',
+    '#title' => t('Queue Gatsby build'),
+    '#url' => Url::fromRoute('silverback_gatsby.build'),
+    '#options' => [
+      'attributes' => [
+        'class' => ['use-ajax'],
       ],
     ],
+  ];
+
+  $logsLink = [
+    '#type' => 'link',
+    '#title' => t('Publisher logs'),
+    '#url' => Url::fromUri(publisher_url() . '/___status'),
+    '#options' => [
+      'attributes' => [
+        'target' => '_blank',
+      ],
+    ],
+  ];
+
+  $dropButton = [
+    '#type' => 'dropbutton',
+    '#dropbutton_type' => 'small',
+    '#links' => [
+      'status' => [
+        // Placeholder to render html_tag element.
+        // Could be replaced by a websocker integration with Drupal
+        // instead of getting the status element from Publisher.
+        'title' => $statusElement,
+      ],
+      // Default #links children does not support options,
+      // so prepare a link render array and use the title
+      // as a placeholder.
+      // We could do some more advanced overrides or introduce
+      // a new type that extends dropbutton, but keeping
+      // it simple for now.
+      'build' => [
+        'title' => $buildLink,
+      ],
+      'logs' => [
+        'title' => $logsLink,
+      ],
+    ],
+  ];
+
+  $items['silverback_publisher_monitor'] = [
+    '#type' => 'toolbar_item',
+    'tab' => $dropButton,
     '#wrapper_attributes' => [
       'class' => ['silverback-publisher-indicator-tab'],
     ],

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.module
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.module
@@ -40,6 +40,7 @@ function silverback_publisher_monitor_page_attachments(&$variables) {
  */
 function silverback_publisher_monitor_toolbar() {
   $items = [];
+  $currentUser = \Drupal::currentUser();
 
   $statusElement = [
     '#type' => 'html_tag',
@@ -66,6 +67,7 @@ function silverback_publisher_monitor_toolbar() {
         'class' => ['use-ajax'],
       ],
     ],
+    '#access' => $currentUser->hasPermission('trigger a gatsby build'),
   ];
 
   $logsLink = [
@@ -77,6 +79,7 @@ function silverback_publisher_monitor_toolbar() {
         'target' => '_blank',
       ],
     ],
+    '#access' => $currentUser->hasPermission('access publisher'),
   ];
 
   $dropButton = [

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.module
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.module
@@ -41,6 +41,8 @@ function silverback_publisher_monitor_page_attachments(&$variables) {
 function silverback_publisher_monitor_toolbar() {
   $items = [];
   $currentUser = \Drupal::currentUser();
+  $hasTriggerBuildPermission = $currentUser->hasPermission('trigger a gatsby build');
+  $hasAccessPublisherPermission = $currentUser->hasPermission('access publisher');
 
   $statusElement = [
     '#type' => 'html_tag',
@@ -58,60 +60,70 @@ function silverback_publisher_monitor_toolbar() {
     ],
   ];
 
-  $buildLink = [
-    '#type' => 'link',
-    '#title' => t('Queue Gatsby build'),
-    '#url' => Url::fromRoute('silverback_gatsby.build'),
-    '#options' => [
-      'attributes' => [
-        'class' => ['use-ajax'],
-      ],
-    ],
-    '#access' => $currentUser->hasPermission('trigger a gatsby build'),
-  ];
+  // Fallback to the status element if no permissions are set.
+  // As we don't want to have a drop button without any links.
+  $tab = [$statusElement];
+  $wrapperClass = 'silverback-publisher-indicator-tab';
 
-  $logsLink = [
-    '#type' => 'link',
-    '#title' => t('Publisher logs'),
-    '#url' => Url::fromUri(publisher_url() . '/___status'),
-    '#options' => [
-      'attributes' => [
-        'target' => '_blank',
+  if ($hasTriggerBuildPermission || $hasAccessPublisherPermission) {
+    $buildLink = [
+      '#type' => 'link',
+      '#title' => t('Queue Gatsby build'),
+      '#url' => Url::fromRoute('silverback_gatsby.build'),
+      '#options' => [
+        'attributes' => [
+          'class' => ['use-ajax'],
+        ],
       ],
-    ],
-    '#access' => $currentUser->hasPermission('access publisher'),
-  ];
+      '#access' => $hasTriggerBuildPermission,
+    ];
 
-  $dropButton = [
-    '#type' => 'dropbutton',
-    '#dropbutton_type' => 'small',
-    '#links' => [
-      'status' => [
-        // Placeholder to render html_tag element.
-        // Could be replaced by a websocker integration with Drupal
-        // instead of getting the status element from Publisher.
-        'title' => $statusElement,
+    $logsLink = [
+      '#type' => 'link',
+      '#title' => t('Publisher logs'),
+      '#url' => Url::fromUri(publisher_url() . '/___status'),
+      '#options' => [
+        'attributes' => [
+          'target' => '_blank',
+        ],
       ],
-      // Default #links children does not support options,
-      // so prepare a link render array and use the title
-      // as a placeholder.
-      // We could do some more advanced overrides or introduce
-      // a new type that extends dropbutton, but keeping
-      // it simple for now.
-      'build' => [
-        'title' => $buildLink,
+      '#access' => $hasAccessPublisherPermission,
+    ];
+
+    $dropButton = [
+      '#type' => 'dropbutton',
+      '#dropbutton_type' => 'small',
+      '#links' => [
+        'status' => [
+          // Placeholder to render html_tag element.
+          // Could be replaced by a websocker integration with Drupal
+          // instead of getting the status element from Publisher.
+          'title' => $statusElement,
+        ],
+        // Default #links children does not support options,
+        // so prepare a link render array and use the title
+        // as a placeholder.
+        // We could do some more advanced overrides or introduce
+        // a new type that extends dropbutton, but keeping
+        // it simple for now.
+        'build' => [
+          'title' => $buildLink,
+        ],
+        'logs' => [
+          'title' => $logsLink,
+        ],
       ],
-      'logs' => [
-        'title' => $logsLink,
-      ],
-    ],
-  ];
+    ];
+
+    $tab = $dropButton;
+    $wrapperClass = 'silverback-publisher-drop-button';
+  }
 
   $items['silverback_publisher_monitor'] = [
     '#type' => 'toolbar_item',
-    'tab' => $dropButton,
+    'tab' => $tab,
     '#wrapper_attributes' => [
-      'class' => ['silverback-publisher-indicator-tab'],
+      'class' => [$wrapperClass],
     ],
     '#weight' => 2000,
   ];


### PR DESCRIPTION
## Package(s) involved

`silverback_publisher_monitor`

## Description of changes

Wrap status button in a dropbutton along with
- Start Gatsby build
- Access to Publisher UI

## Related Issue(s)

https://github.com/AmazeeLabs/silverback-mono/issues/1139

## How has this been tested?

Manually