### PR TITLE
refactor(react): move navigate into useLocation

### DIFF
--- a/packages/npm/@amazeelabs/bridge/src/index.tsx
+++ b/packages/npm/@amazeelabs/bridge/src/index.tsx
@@ -1,37 +1,43 @@
 import React, { AnchorHTMLAttributes, DetailedHTMLProps } from 'react';
 
 export function Link(
-    props: DetailedHTMLProps<
-        AnchorHTMLAttributes<HTMLAnchorElement>,
-        HTMLAnchorElement
-    >,
+  props: DetailedHTMLProps<
+    AnchorHTMLAttributes<HTMLAnchorElement>,
+    HTMLAnchorElement
+  >,
 ) {
-    return (
-        <a href={props.href} className={props.className}>
-            {props.children}
-        </a>
-    );
+  return (
+    <a href={props.href} className={props.className}>
+      {props.children}
+    </a>
+  );
 }
 
-export function navigate(to: string) {
-    window.location.href = to;
-}
+export type Location = {
+  /**
+   * The url path.
+   */
+  pathname: string;
+  /**
+   * The query string, including '?' if not empty.
+   */
+  search: string;
+  /**
+   * The current hash, including '#' if not empty.
+   */
+  hash: string;
 
-type Location = {
-    /**
-     * The url path.
-     */
-    pathname: string;
-    /**
-     * The query string, including '?' if not empty.
-     */
-    search: string;
-    /**
-     * The current hash, including '#' if not empty.
-     */
-    hash: string;
-}
+  /**
+   * Change the location to a given url.
+   */
+  navigate: (to: string) => void;
+};
 
 export function useLocation(): Location | undefined {
-    return window.location;
+  return {
+    ...window.location,
+    navigate(to: string) {
+      window.location.href = to;
+    },
+  };
 }


### PR DESCRIPTION
## Package(s) involved

* `@amazeelabs/bridge`
* `@amazeelabs/scalars`

## Description of changes

Move the `navigate` function into the return of `useLocation`.

## Motivation and context

This gives us more control over how url changes and updates are handled (e.g. being managed in a state instead of navigated directly).
