### PR TITLE
Improve-routing-apis

### DIFF
--- a/packages/npm/@amazeelabs/scalars/src/index.tsx
+++ b/packages/npm/@amazeelabs/scalars/src/index.tsx
@@ -24,8 +24,8 @@ export type Url = string & {
 };
 
 type LinkOverrideProps = {
-  query?: StringifiableRecord;
-  fragment?: string;
+  search?: StringifiableRecord;
+  hash?: string;
 };
 
 type LinkTransitionProps = {
@@ -39,14 +39,14 @@ type LinkDisplayProps = {
 
 export function overrideUrlParameters(
   url: string,
-  query?: StringifiableRecord,
-  fragment?: string,
+  search?: StringifiableRecord,
+  hash?: string,
 ): Url {
   if (url[0] === '/') {
     return overrideUrlParameters(
       `relative://${url}` as Url,
-      query,
-      fragment,
+      search,
+      hash,
     ).replace('relative://', '') as Url;
   }
   const parsed = qs.parseUrl(url);
@@ -54,8 +54,8 @@ export function overrideUrlParameters(
     {
       url: parsed.url,
       fragmentIdentifier:
-        typeof fragment === 'undefined' ? parsed.fragmentIdentifier : fragment,
-      query: { ...parsed.query, ...query },
+        typeof hash === 'undefined' ? parsed.fragmentIdentifier : hash,
+      query: { ...parsed.query, ...search },
     },
     {
       skipNull: true,
@@ -70,8 +70,8 @@ export type LinkProps = Omit<
   LinkTransitionProps &
   LinkDisplayProps;
 
-export function Link({ href, query, fragment, ...props }: LinkProps) {
-  const target = overrideUrlParameters(href, query, fragment);
+export function Link({ href, search, hash, ...props }: LinkProps) {
+  const target = overrideUrlParameters(href, search, hash);
   return <LinkComponent href={target} {...props} />;
 }
 
@@ -82,8 +82,8 @@ export function useLocation() {
   }
   return {
     ...location,
-    navigate: (url: Url, query?: StringifiableRecord, fragment?: string) => {
-      location.navigate(overrideUrlParameters(url, query, fragment));
+    navigate: (url: Url, search?: StringifiableRecord, hash?: string) => {
+      location.navigate(overrideUrlParameters(url, search, hash));
     },
   };
 }

--- a/packages/npm/@amazeelabs/scalars/src/link.test.ts
+++ b/packages/npm/@amazeelabs/scalars/src/link.test.ts
@@ -1,51 +1,73 @@
 import { describe, expect, it } from 'vitest';
 
-import { overrideUrlParameters } from './';
+import { overrideUrlParameters, Url } from './';
 
 describe('overrideUrlParameters', () => {
   it('works with an absolute url', () => {
-    expect(overrideUrlParameters('https://example.com', {}, '')).toBe(
+    expect(overrideUrlParameters('https://example.com' as Url, {}, '')).toBe(
       'https://example.com',
     );
   });
 
   it('works with a relative url', () => {
-    expect(overrideUrlParameters('/foo', {}, '')).toBe('/foo');
+    expect(overrideUrlParameters('/foo' as Url, {}, '')).toBe('/foo');
   });
 
   it('allows to add search parameters', () => {
-    expect(overrideUrlParameters('/foo', { a: 'x' }, '')).toBe('/foo?a=x');
+    expect(overrideUrlParameters('/foo' as Url, { a: 'x' }, '')).toBe(
+      '/foo?a=x',
+    );
   });
 
   it('allows to remove search parameters', () => {
-    expect(overrideUrlParameters('/foo?a=x', { a: null }, '')).toBe('/foo');
+    expect(overrideUrlParameters('/foo?a=x' as Url, { a: null }, '')).toBe(
+      '/foo',
+    );
   });
 
   it('allows to override search parameters', () => {
-    expect(overrideUrlParameters('/foo?a=x', { a: 'y' }, '')).toBe('/foo?a=y');
+    expect(overrideUrlParameters('/foo?a=x' as Url, { a: 'y' }, '')).toBe(
+      '/foo?a=y',
+    );
   });
 
   it('leaves search parameters that are not overridden', () => {
-    expect(overrideUrlParameters('/foo?a=x&b=x', { b: 'y' }, '')).toBe(
+    expect(overrideUrlParameters('/foo?a=x&b=x' as Url, { b: 'y' }, '')).toBe(
       '/foo?a=x&b=y',
     );
   });
 
   it('allows to add a hash', () => {
-    expect(overrideUrlParameters('/foo', {}, 'bar')).toBe('/foo#bar');
+    expect(overrideUrlParameters('/foo' as Url, {}, 'bar')).toBe('/foo#bar');
   });
 
   it('allows to override a hash', () => {
-    expect(overrideUrlParameters('/foo#bar', {}, 'baz')).toBe('/foo#baz');
+    expect(overrideUrlParameters('/foo#bar' as Url, {}, 'baz')).toBe(
+      '/foo#baz',
+    );
   });
 
   it('allows to remove a hash', () => {
-    expect(overrideUrlParameters('/foo#bar', {}, '')).toBe('/foo');
+    expect(overrideUrlParameters('/foo#bar' as Url, {}, '')).toBe('/foo');
   });
 
   it('leaves the hash when overriding search parameters', () => {
-    expect(overrideUrlParameters('/foo?a=x#bar', { b: 'y' }, 'bar')).toBe(
-      '/foo?a=x&b=y#bar',
-    );
+    expect(
+      overrideUrlParameters('/foo?a=x#bar' as Url, { b: 'y' }, 'bar'),
+    ).toBe('/foo?a=x&b=y#bar');
+  });
+
+  it('allows to use a Location object', () => {
+    expect(
+      overrideUrlParameters(
+        {
+          pathname: '/foo',
+          search: new URLSearchParams('?a=x'),
+          hash: 'bar',
+        },
+        { b: 'y' },
+        'baz',
+      ),
+    ).toEqual('/foo?a=x&b=y#baz');
   });
 });

--- a/packages/npm/@amazeelabs/scalars/src/link.test.ts
+++ b/packages/npm/@amazeelabs/scalars/src/link.test.ts
@@ -13,37 +13,37 @@ describe('overrideUrlParameters', () => {
     expect(overrideUrlParameters('/foo', {}, '')).toBe('/foo');
   });
 
-  it('allows to add query arguments', () => {
+  it('allows to add search parameters', () => {
     expect(overrideUrlParameters('/foo', { a: 'x' }, '')).toBe('/foo?a=x');
   });
 
-  it('allows to remove query arguments', () => {
+  it('allows to remove search parameters', () => {
     expect(overrideUrlParameters('/foo?a=x', { a: null }, '')).toBe('/foo');
   });
 
-  it('allows to override query arguments', () => {
+  it('allows to override search parameters', () => {
     expect(overrideUrlParameters('/foo?a=x', { a: 'y' }, '')).toBe('/foo?a=y');
   });
 
-  it('leaves query arguments that are not overridden', () => {
+  it('leaves search parameters that are not overridden', () => {
     expect(overrideUrlParameters('/foo?a=x&b=x', { b: 'y' }, '')).toBe(
       '/foo?a=x&b=y',
     );
   });
 
-  it('allows to add a fragment', () => {
+  it('allows to add a hash', () => {
     expect(overrideUrlParameters('/foo', {}, 'bar')).toBe('/foo#bar');
   });
 
-  it('allows to override a fragment', () => {
+  it('allows to override a hash', () => {
     expect(overrideUrlParameters('/foo#bar', {}, 'baz')).toBe('/foo#baz');
   });
 
-  it('allows to remove a fragment', () => {
+  it('allows to remove a hash', () => {
     expect(overrideUrlParameters('/foo#bar', {}, '')).toBe('/foo');
   });
 
-  it('leaves the fragment when overriding query arguments', () => {
+  it('leaves the hash when overriding search parameters', () => {
     expect(overrideUrlParameters('/foo?a=x#bar', { b: 'y' }, 'bar')).toBe(
       '/foo?a=x&b=y#bar',
     );


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/scalars`

## Description of changes

* `Link` and `navigate` accept `Location` objects (the output of `useLocation`) as inputs for the target.
* `Location` objects are streamlined to match the `Url` api and reduce required code
  * `query` has been renamed to `search` and emits either undefined or an `URLSearchParams` object
  * `fragment` has been renamed to `hash` and is either undefined or a string without the leading `#`

## Motivation and context

To allow convenient usage like:

```tsx
const loc = useLocation();
const page = loc.search?.get('page') || 1;

<Link href={loc} search={{page: page + 1}}>Next</Link>

navigate(loc, {keyword: 'foobar'});

```


## How has this been tested?

Unit tests.