### PR TITLE
fix(gatsby): ignore reverse proxy when generating session names

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/SilverbackGatsbyServiceProvider.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/SilverbackGatsbyServiceProvider.php
@@ -31,5 +31,13 @@ class SilverbackGatsbyServiceProvider extends ServiceProviderBase {
       $definitions['silverback_gatsby.locale.storage'] = $localeDecoratorDefinition;
       $container->addDefinitions($definitions);
     }
+
+
+    // Swap the session configuration service with a custom one.
+    if ($container->hasDefinition('session_configuration')) {
+      $definition = $container->getDefinition('session_configuration');
+      $definition->setClass('Drupal\silverback_gatsby\SilverbackGatsbySessionConfiguration');
+    }
+
   }
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/SilverbackGatsbySessionConfiguration.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/SilverbackGatsbySessionConfiguration.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\silverback_gatsby;
+
+use Drupal\Core\Session\SessionConfiguration;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Decorator for the core session configuration service.
+ */
+class SilverbackGatsbySessionConfiguration extends SessionConfiguration {
+  /**
+   * Remove X-Forwarded-* headers from the request, so they
+   * don't affect the session name. Otherwise session information
+   * is lost when using a reverse proxy and direct access simultaneously.
+   * 
+   * Use case: User login-in via the backend domain and send requests from
+   * the frontend that include X-Forwarded-* headers to create image urls
+   * with the frontend domain. Without this, the dynamic request would not
+   * be authenticated any more because the session name would be different,
+   * because `$request->getHost()` would return the X-Forwarded-Host.
+   */
+  protected function getUnprefixedName(Request $request) {
+    $cleaned = clone $request;
+    $cleaned->headers->remove('X-Forwarded-Proto');
+    $cleaned->headers->remove('X-Forwarded-Host');
+    $cleaned->headers->remove('X-Forwarded-Port');
+    return parent::getUnprefixedName($cleaned);
+  }
+}


### PR DESCRIPTION
To make sure requests with- and without reverse proxy can share the same
session.

## Package(s) involved

`amazeelabs/silverback_gatsby`



## Description of changes

Replace the session configuration service and make sure it ignores X-Forwarded-* headers.

## Motivation and context

The preview workflow requires the users to log into the backend and send requests with `X-Forwarded-*` headers from the frontend-ui. Images should be served with the frontend domain, thats why the `X-Forwarded-*` headers are necessary. But that causes Drupal to have a different Host and therefore session name, and authentication would be lost.

