### PR TITLE
UUID field to campaign urls

### DIFF
--- a/packages/composer/amazeelabs/silverback_campaign_urls/src/Entity/CampaignUrl.php
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/src/Entity/CampaignUrl.php
@@ -30,6 +30,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *   entity_keys = {
  *     "id" = "cid",
  *     "label" = "campaign_url_source",
+ *     "uuid" = "uuid",
  *   },
  *   links = {
  *     "canonical" = "/admin/config/search/campaign_url/edit/{campaign_url}",


### PR DESCRIPTION
## Package(s) involved

amazeelabs/silverback_campaign_urls

## Description of changes

The Campaign URL entities have now a uuid field so that they can be exported with the default content module

## How has this been tested?

Locally, manually
