### PR TITLE
Tweaks and validation improvements for campaign urls

### DIFF
--- a/apps/silverback-drupal/config/sync/views.view.campaign_urls.yml
+++ b/apps/silverback-drupal/config/sync/views.view.campaign_urls.yml
@@ -578,29 +578,27 @@ display:
       sorts: {  }
       arguments: {  }
       filters:
-        campaign_url_source:
-          id: campaign_url_source
-          table: campaign_url
-          field: campaign_url_source
+        combine:
+          id: combine
+          table: views
+          field: combine
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: campaign_url
-          entity_field: campaign_url_source
-          plugin_id: string
+          plugin_id: combine
           operator: contains
           value: ''
           group: 1
           exposed: true
           expose:
-            operator_id: campaign_url_source_op
-            label: Source
+            operator_id: combine_op
+            label: 'Campaign URL'
             description: ''
             use_operator: false
-            operator: campaign_url_source_op
+            operator: combine_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: campaign_url_source
+            identifier: combine
             required: false
             remember: false
             multiple: false
@@ -622,50 +620,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        campaign_url_destination:
-          id: campaign_url_destination
-          table: campaign_url
-          field: campaign_url_destination
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: campaign_url
-          entity_field: campaign_url_destination
-          plugin_id: string
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: campaign_url_destination_op
-            label: Destination
-            description: ''
-            use_operator: false
-            operator: campaign_url_destination_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: campaign_url_destination
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              gatsby_preview: '0'
-              gatsby_build: '0'
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
+          fields:
+            campaign_url_source: campaign_url_source
+            campaign_url_destination: campaign_url_destination
       style:
         type: table
         options:

--- a/packages/composer/amazeelabs/silverback_campaign_urls/config/install/views.view.campaign_urls.yml
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/config/install/views.view.campaign_urls.yml
@@ -575,29 +575,27 @@ display:
       sorts: {  }
       arguments: {  }
       filters:
-        campaign_url_source:
-          id: campaign_url_source
-          table: campaign_url
-          field: campaign_url_source
+        combine:
+          id: combine
+          table: views
+          field: combine
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: campaign_url
-          entity_field: campaign_url_source
-          plugin_id: string
+          plugin_id: combine
           operator: contains
           value: ''
           group: 1
           exposed: true
           expose:
-            operator_id: campaign_url_source_op
-            label: Source
+            operator_id: combine_op
+            label: 'Campaign URL'
             description: ''
             use_operator: false
-            operator: campaign_url_source_op
+            operator: combine_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: campaign_url_source
+            identifier: combine
             required: false
             remember: false
             multiple: false
@@ -619,50 +617,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        campaign_url_destination:
-          id: campaign_url_destination
-          table: campaign_url
-          field: campaign_url_destination
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: campaign_url
-          entity_field: campaign_url_destination
-          plugin_id: string
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: campaign_url_destination_op
-            label: Destination
-            description: ''
-            use_operator: false
-            operator: campaign_url_destination_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: campaign_url_destination
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              gatsby_preview: '0'
-              gatsby_build: '0'
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
+          fields:
+            campaign_url_source: campaign_url_source
+            campaign_url_destination: campaign_url_destination
       style:
         type: table
         options:

--- a/packages/composer/amazeelabs/silverback_campaign_urls/package.json
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/package.json
@@ -13,6 +13,7 @@
     "@amazeelabs/sync-composer-version": "workspace:*"
   },
   "scripts": {
+    "test:unit": "cd ../../../../apps/silverback-drupal && vendor/phpunit/phpunit/phpunit web/modules/contrib/silverback_campaign_urls",
     "version": "sync-composer-version"
   }
 }

--- a/packages/composer/amazeelabs/silverback_campaign_urls/src/Entity/CampaignUrl.php
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/src/Entity/CampaignUrl.php
@@ -36,6 +36,9 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *     "canonical" = "/admin/config/search/campaign_url/edit/{campaign_url}",
  *     "delete-form" = "/admin/config/search/campaign_url/delete/{campaign_url}",
  *     "edit-form" = "/admin/config/search/campaign_url/edit/{campaign_url}",
+ *   },
+ *   constraints = {
+ *     "UniqueCampaignUrlSource" = {}
  *   }
  * )
  */
@@ -47,7 +50,7 @@ class CampaignUrl extends ContentEntityBase implements CampaignUrlInterface {
 
     $fields['campaign_url_source'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Source'))
-      ->setDescription(t('Please provide the source path for this campaign URL. Usually, this is either a relative URL (starting with /) or an absolute path. But it can be basically any arbitrary source path that your specific hosting provider can understand.'))
+      ->setDescription(t('Please provide the source path for this campaign URL. You can enter an internal path (starting with "/") or an external URL such as http://example.com. However, it can be any arbitrary source path that your hosting provider understands.'))
       ->setRequired(TRUE)
       ->setSetting('max_length', 1024)
       ->setDisplayOptions('form', [
@@ -58,7 +61,7 @@ class CampaignUrl extends ContentEntityBase implements CampaignUrlInterface {
 
     $fields['campaign_url_destination'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Destination'))
-      ->setDescription(t('Same as <em>Source</em>, this is usually a relative or absolute URL. But it can be any destination path that the hosting provider can understand.'))
+      ->setDescription(t('Same as <em>Source</em>, you can enter an internal path (starting with "/") or an external URL such as http://example.com. However, it can be any destination path that your hosting provider understands.'))
       ->setRequired(TRUE)
       ->setSetting('max_length', 1024)
       ->setDisplayOptions('form', [

--- a/packages/composer/amazeelabs/silverback_campaign_urls/src/Plugin/Validation/Constraint/UniqueCampaignUrlSourceConstraint.php
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/src/Plugin/Validation/Constraint/UniqueCampaignUrlSourceConstraint.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\silverback_campaign_urls\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validation constraint for unique campaign url source.
+ *
+ * @Constraint(
+ *   id = "UniqueCampaignUrlSource",
+ *   label = @Translation("Unique campaign url source.", context = "Validation"),
+ * )
+ */
+class UniqueCampaignUrlSourceConstraint extends Constraint {
+
+  public $message = 'The campaign url %campaign_url is already in use.';
+}

--- a/packages/composer/amazeelabs/silverback_campaign_urls/src/Plugin/Validation/Constraint/UniqueCampaignUrlSourceConstraintValidator.php
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/src/Plugin/Validation/Constraint/UniqueCampaignUrlSourceConstraintValidator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\silverback_campaign_urls\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the UniqueCampaignUrlSourceConstraint constraint
+ */
+class UniqueCampaignUrlSourceConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Creates a new UniqueCampaignUrlSourceConstraintValidator instance.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validate($entity, Constraint $constraint) {
+    /** @var \Drupal\silverback_campaign_urls\Entity\CampaignUrlInterface $entity */
+    $source = $entity->getSource();
+    $query = $this->entityTypeManager->getStorage('campaign_url')->getQuery();
+    $query->condition('campaign_url_source', $source);
+    if (!$entity->isNew()) {
+      $query->condition('cid', $entity->id(), '<>');
+    }
+    $query->accessCheck(FALSE);
+    $result = $query->execute();
+    if (!empty($result)) {
+      $this->context->buildViolation($constraint->message, [
+        '%campaign_url' => $source,
+      ])->addViolation();
+    }
+  }
+}

--- a/packages/composer/amazeelabs/silverback_campaign_urls/tests/src/Kernel/CampaignUrlValidationTest.php
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/tests/src/Kernel/CampaignUrlValidationTest.php
@@ -26,7 +26,7 @@ class CampaignUrlValidationTest extends EntityKernelTestBase {
       'campaign_url_destination' => '/campaign_destination',
     ]);
     $violations = $campaign->validate();
-    $this->assertCount(0, $violations, 'No violations when validating a the first campaign url.');
+    $this->assertCount(0, $violations, 'No violations when validating the first campaign url.');
     $campaign->save();
 
     $secondCampaign = CampaignUrl::create([
@@ -34,7 +34,7 @@ class CampaignUrlValidationTest extends EntityKernelTestBase {
       'campaign_url_destination' => '/second_campaign_destination',
     ]);
     $violations = $secondCampaign->validate();
-    $this->assertCount(0, $violations, 'No violations when validating a the second campaign url.');
+    $this->assertCount(0, $violations, 'No violations when validating the second campaign url.');
     $secondCampaign->save();
 
     $thirdCampaign = CampaignUrl::create([

--- a/packages/composer/amazeelabs/silverback_campaign_urls/tests/src/Kernel/CampaignUrlValidationTest.php
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/tests/src/Kernel/CampaignUrlValidationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\Tests\silverback_campaign_urls\Kernel;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\silverback_campaign_urls\Entity\CampaignUrl;
+
+/**
+ * Tests campaign urls validation constraints.
+ */
+class CampaignUrlValidationTest extends EntityKernelTestBase {
+
+  protected static $modules = ['silverback_campaign_urls'];
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('campaign_url');
+  }
+
+  public function testValidation() {
+    $campaign = CampaignUrl::create([
+      'campaign_url_source' => '/campaign_test',
+      'campaign_url_destination' => '/campaign_destination',
+    ]);
+    $violations = $campaign->validate();
+    $this->assertCount(0, $violations, 'No violations when validating a the first campaign url.');
+    $campaign->save();
+
+    $secondCampaign = CampaignUrl::create([
+      'campaign_url_source' => '/second_campaign_test',
+      'campaign_url_destination' => '/second_campaign_destination',
+    ]);
+    $violations = $secondCampaign->validate();
+    $this->assertCount(0, $violations, 'No violations when validating a the second campaign url.');
+    $secondCampaign->save();
+
+    $thirdCampaign = CampaignUrl::create([
+      'campaign_url_source' => '/campaign_test',
+      'campaign_url_destination' => '/third_campaign_destination',
+    ]);
+    $violations = $thirdCampaign->validate();
+    $this->assertCount(1, $violations, 'Violation found when trying to create a campaign with an already existing source.');
+    $this->assertEquals('The campaign url <em class="placeholder">/campaign_test</em> is already in use.', $violations[0]->getMessage());
+
+    $existingCampaign = CampaignUrl::load($campaign->id());
+    $violations = $existingCampaign->validate();
+    $this->assertCount(0, $violations, 'No violations when editing a campaign and keeping its source.');
+
+    $existingCampaign->set('campaign_url_source', '/second_campaign_test');
+    $violations = $existingCampaign->validate();
+    $this->assertCount(1, $violations, 'Violation found when trying to update a campaign with an already existing source.');
+    $this->assertEquals('The campaign url <em class="placeholder">/second_campaign_test</em> is already in use.', $violations[0]->getMessage());
+  }
+}


### PR DESCRIPTION
## Package(s) involved

silverback_campaign_urls

## Description of changes

As per the feedback in https://amazeelabs.atlassian.net/browse/SLB-180, the following were implemented:
- update descriptions for the source and destination fields
- merge the source and destination search fields into one single field, on the filter form
- validate that the campaign source url is unique.

## Related Issue(s)

[Campaign URLs](https://amazeelabs.atlassian.net/browse/SLB-180)

## How has this been tested?

Kernel tests
