### PR TITLE
chore: add the bundle parameter to the campaign_url entity directive

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -376,7 +376,7 @@ type FirstLevelMainMenu @menu(menu_id: "main", max_level: 1) {
 
 type GatsbyStringTranslation @stringTranslation(contextPrefix: "gatsby")
 
-type CampaignUrl @entity(type: "campaign_url") {
+type CampaignUrl @entity(type: "campaign_url", bundle: "campaign_url") {
   source: String! @resolveProperty(path: "campaign_url_source.value")
   destination: String! @resolveProperty(path: "campaign_url_destination.value")
   statusCode: Int! @resolveProperty(path: "status_code.value")

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -376,7 +376,7 @@ type FirstLevelMainMenu @menu(menu_id: "main", max_level: 1) {
 
 type GatsbyStringTranslation @stringTranslation(contextPrefix: "gatsby")
 
-type CampaignUrl @entity(type: "campaign_url") {
+type CampaignUrl @entity(type: "campaign_url", bundle: "campaign_url") {
   source: String! @resolveProperty(path: "campaign_url_source.value")
   destination: String! @resolveProperty(path: "campaign_url_destination.value")
   statusCode: Int! @resolveProperty(path: "status_code.value")

--- a/packages/composer/amazeelabs/silverback_campaign_urls/graphql/silverback_campaign_urls.base.graphqls
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/graphql/silverback_campaign_urls.base.graphqls
@@ -1,4 +1,4 @@
-type CampaignUrl @entity(type: "campaign_url") {
+type CampaignUrl @entity(type: "campaign_url", bundle: "campaign_url") {
   source: String! @resolveProperty(path: "campaign_url_source.value")
   destination: String! @resolveProperty(path: "campaign_url_destination.value")
   statusCode: Int! @resolveProperty(path: "status_code.value")

--- a/packages/composer/amazeelabs/silverback_campaign_urls/src/Entity/CampaignUrl.php
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/src/Entity/CampaignUrl.php
@@ -50,7 +50,7 @@ class CampaignUrl extends ContentEntityBase implements CampaignUrlInterface {
 
     $fields['campaign_url_source'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Source'))
-      ->setDescription(t('Please provide the source path for this campaign URL. You can enter an internal path (starting with "/") or an external URL such as http://example.com. However, it can be any arbitrary source path that your hosting provider understands.'))
+      ->setDescription(t('Please provide the source path for this campaign URL. You can enter an internal path (starting with "/") or an external URL such as https://example.com. However, it can be any arbitrary source path that your hosting provider understands.'))
       ->setRequired(TRUE)
       ->setSetting('max_length', 1024)
       ->setDisplayOptions('form', [
@@ -61,7 +61,7 @@ class CampaignUrl extends ContentEntityBase implements CampaignUrlInterface {
 
     $fields['campaign_url_destination'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Destination'))
-      ->setDescription(t('Same as <em>Source</em>, you can enter an internal path (starting with "/") or an external URL such as http://example.com. However, it can be any destination path that your hosting provider understands.'))
+      ->setDescription(t('Same as <em>Source</em>, you can enter an internal path (starting with "/") or an external URL such as https://example.com. However, it can be any destination path that your hosting provider understands. If the site is multilingual, the language parameter has to be in the path (e.g.: <em>/en/test</em>)'))
       ->setRequired(TRUE)
       ->setSetting('max_length', 1024)
       ->setDisplayOptions('form', [


### PR DESCRIPTION
## Package(s) involved

silverback_campaign_urls

## Description of changes

Adds the bundle parameter to the CampaingUrl entity directive, in the schema, otherwise the Gatsby EntityFeed::getUpdateIds() will not trigger an update event, since it checks for a bundle to be present there.

It also updates the description of the Campaign URL destination field.

## Related Issue(s)

[Campaign URLs](https://amazeelabs.atlassian.net/browse/SLB-180)

## How has this been tested?

Manually.
