### PR TITLE
Declare the bundle field on campaign url entities

### DIFF
--- a/packages/composer/amazeelabs/silverback_campaign_urls/src/Entity/CampaignUrl.php
+++ b/packages/composer/amazeelabs/silverback_campaign_urls/src/Entity/CampaignUrl.php
@@ -31,6 +31,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *     "id" = "cid",
  *     "label" = "campaign_url_source",
  *     "uuid" = "uuid",
+ *     "bundle" = "type",
  *   },
  *   links = {
  *     "canonical" = "/admin/config/search/campaign_url/edit/{campaign_url}",
@@ -109,6 +110,15 @@ class CampaignUrl extends ContentEntityBase implements CampaignUrlInterface {
       ->setLabel(t('Updated'))
       ->setDescription(t('The date when the campaign URL was last updated.'));
     return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function preCreate(EntityStorageInterface $storage, array &$values) {
+    $values += [
+      'type' => 'campaign_url',
+    ];
   }
 
   /**


### PR DESCRIPTION
## Package(s) involved

silverback_campaign_urls

## Description of changes

We also need to declare the bundle field in the entity annotation, even if we don't plan to have multiple bundles, and the default should just fallback to the entity type name.

## How has this been tested?

Manually.
