### PR TITLE
fix: remove dropbutton inline styles

### DIFF
--- a/packages/composer/amazeelabs/silverback_publisher_monitor/css/indicator.css
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/css/indicator.css
@@ -38,6 +38,14 @@
 /**
  * Drupal specific overrides to make the drop button fit in the toolbar.
  */
+.silverback-publisher-drop-button .dropbutton-wrapper {
+  box-shadow: none;
+}
+
+.silverback-publisher-drop-button .dropbutton-widget {
+  background: transparent;
+}
+
 .silverback-publisher-drop-button .dropbutton__item .ajax-progress {
   display: none;
 }

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/js/ws-indicator.js
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/js/ws-indicator.js
@@ -92,6 +92,17 @@
           <div>${message}</div>
         </div>`;
         $indicator.html(output);
+
+        // Make sure to remove any inline style that could be added
+        // by another process. This is needed as the color gets
+        // overwritten with white color.
+        $indicator.removeAttr('style');
+        $dropButton = $('.silverback-publisher-drop-button .dropbutton');
+        $dropButton.removeAttr('style');
+        $dropButtonAction = $(
+          '.silverback-publisher-drop-button .dropbutton-action a',
+        );
+        $dropButtonAction.removeAttr('style');
       };
     },
   };


### PR DESCRIPTION
## Package(s) involved

`silverback_publisher_monitor`

## Description of changes

Remove any inline style that can be added by another process on the dropbutton used for the Publisher monitor.
I could not identify yet which process is appending these styles, so the hotfix is to make sure that we don't want any there.

## Motivation and context

Before the fix
<img width="216" alt="Capture d’écran 2023-06-30 à 11 29 03" src="https://github.com/AmazeeLabs/silverback-mono/assets/525003/aee27c15-cf1d-429b-a07b-471b2928e0f5">

We have inline styles added at several levels.
<img width="852" alt="Capture d’écran 2023-06-30 à 11 31 15" src="https://github.com/AmazeeLabs/silverback-mono/assets/525003/7d2a8315-bec4-4d5e-9d6b-dc22a5cd58cd">

After

<img width="273" alt="Capture d’écran 2023-06-30 à 12 20 52" src="https://github.com/AmazeeLabs/silverback-mono/assets/525003/d1f35985-3368-4042-8304-c9751edcafb5">

## How has this been tested?

Manually, on the `silverback-template` repository.
