### PR TITLE
fix: gutenberg media handling

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GraphQL/DataProducer/EditorBlockMedia.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GraphQL/DataProducer/EditorBlockMedia.php
@@ -3,10 +3,17 @@
 namespace Drupal\silverback_gutenberg\Plugin\GraphQL\DataProducer;
 
 use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql\GraphQL\Buffers\EntityBuffer;
 use Drupal\graphql\GraphQL\Execution\FieldContext;
 use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
 use Drupal\layout_builder_fieldblock_test\ContextProvider\FakeViewModeContext;
 use Drupal\media\Entity\Media;
+use GraphQL\Deferred;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 
 /**
@@ -26,31 +33,127 @@ use Drupal\media\Entity\Media;
  *   }
  * )
  */
-class EditorBlockMedia extends DataProducerPluginBase {
-  public function resolve(
-    $block,
-    FieldContext $field
-  ) {
-    $mediaId = $block['attrs']['mediaEntityIds'][0] ?? NULL;
+class EditorBlockMedia extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
 
-    if (!$mediaId) {
-      return NULL;
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity repository service.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * The entity buffer service.
+   *
+   * @var \Drupal\graphql\GraphQL\Buffers\EntityBuffer
+   */
+  protected $entityBuffer;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @codeCoverageIgnore
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('entity.repository'),
+      $container->get('graphql.buffer.entity')
+    );
+  }
+
+  /**
+   * EntityLoad constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration array.
+   * @param string $pluginId
+   *   The plugin id.
+   * @param array $pluginDefinition
+   *   The plugin definition array.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entityRepository
+   *   The entity repository service.
+   * @param \Drupal\graphql\GraphQL\Buffers\EntityBuffer $entityBuffer
+   *   The entity buffer service.
+   *
+   * @codeCoverageIgnore
+   */
+  public function __construct(
+    array $configuration,
+          $pluginId,
+    array $pluginDefinition,
+    EntityTypeManagerInterface $entityTypeManager,
+    EntityRepositoryInterface $entityRepository,
+    EntityBuffer $entityBuffer
+  ) {
+    parent::__construct($configuration, $pluginId, $pluginDefinition);
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityRepository = $entityRepository;
+    $this->entityBuffer = $entityBuffer;
+  }
+
+  public function resolve($block, FieldContext $context): ?Deferred {
+    $id = $block['attrs']['mediaEntityIds'][0] ?? NULL;
+
+    if (!$id) {
+      return new Deferred(function () { return NULL; });
     }
-    $media = Media::load($mediaId);
-    // Try to get the embedded item in the current language or use whatever
-    // we get as a fallback.
-    if (!$media) {
-      \Drupal::logger('graphql_gutenberg')->notice("Cannot load media by ID '{$mediaId}'");
-      return NULL;
-    }
-    $documentLanguage = $field->getContextValue('document_language');
-    if ($media->hasTranslation($documentLanguage)) {
-      $media = $media->getTranslation($documentLanguage);
-    }
-    if ($media) {
-      $field->addCacheableDependency($media);
-    }
-    return $media;
+
+    $resolver = $this->entityBuffer->add('media', $id);
+    $language = $context->getContextValue('document_language');
+
+    return new Deferred(function () use ($language, $resolver, $context) {
+      if (!$entity = $resolver()) {
+        // If there is no entity with this id, add the list cache tags so that
+        // the cache entry is purged whenever a new entity of this type is
+        // saved.
+        $type = $this->entityTypeManager->getDefinition('media');
+        /** @var \Drupal\Core\Entity\EntityTypeInterface $type */
+        $tags = $type->getListCacheTags();
+        $context->addCacheTags($tags);
+        return NULL;
+      }
+
+      $context->addCacheableDependency($entity);
+      if (isset($bundles) && !in_array($entity->bundle(), $bundles)) {
+        // If the entity is not among the allowed bundles, don't return it.
+        return NULL;
+      }
+
+      // Get the correct translation.
+      if (
+        isset($language) &&
+        $language !== $entity->language()->getId() &&
+        $entity instanceof TranslatableInterface &&
+        $entity->hasTranslation($language)
+      ) {
+        $entity = $entity->getTranslation($language);
+        $entity->addCacheContexts(["static:language:{$language}"]);
+      }
+
+      // Check if the passed user (or current user if none is passed) has access
+      // to the entity, if not return NULL.
+      /** @var \Drupal\Core\Access\AccessResultInterface $accessResult */
+      $accessResult = $entity->access(NULL, NULL, TRUE);
+      $context->addCacheableDependency($accessResult);
+      if ($accessResult->isForbidden()) {
+        return NULL;
+      }
+
+      return $entity;
+    });
   }
 
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/graphql/queries/editor.gql
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/graphql/queries/editor.gql
@@ -10,6 +10,7 @@ fragment Page on Page {
       image {
         alt
       }
+      imageAlt
     }
     ... on Columns {
       columns {
@@ -20,6 +21,10 @@ fragment Page on Page {
 }
 
 query {
-  en { ...Page }
-  de { ...Page }
+  en {
+    ...Page
+  }
+  de {
+    ...Page
+  }
 }

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/graphql/schema.graphqls
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/graphql/schema.graphqls
@@ -25,6 +25,9 @@ type Text @type(id: "core/paragraph") {
 type Figure @type(id: "custom/figure") {
   caption: String @resolveEditorBlockAttribute(key: "caption")
   image: Image @resolveEditorBlockMedia
+  imageAlt: String
+    @resolveEditorBlockMedia
+    @resolveProperty(path: "field_media_image.alt")
 }
 
 type Image {

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/graphql/schema.graphqls
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/graphql/schema.graphqls
@@ -1,21 +1,22 @@
 type Query {
   en: Page @loadEntity(type: "node", id: "1")
-  de: Page @loadEntity(type: "node", id: "1") @resolveEntityTranslation(lang: "de")
+  de: Page
+    @loadEntity(type: "node", id: "1")
+    @resolveEntityTranslation(lang: "de")
 }
 
 type Page {
   title: String! @resolveProperty(path: "title.value")
-  content: [Blocks]! @resolveEditorBlocks(path: "body.value", aggregated: ["core/paragraph", "core/list"])
+  content: [Blocks]!
+    @resolveEditorBlocks(
+      path: "body.value"
+      aggregated: ["core/paragraph", "core/list"]
+    )
 }
 
-union Blocks @resolveEditorBlockType =
-  | Text
-  | Figure
-  | Columns
+union Blocks @resolveEditorBlockType = Text | Figure | Columns
 
-union ColumnBlocks @resolveEditorBlockType =
-  | Text
-  | Figure
+union ColumnBlocks @resolveEditorBlockType = Text | Figure
 
 type Text @type(id: "core/paragraph") {
   content: String @resolveEditorBlockMarkup

--- a/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/EditorDirectivesTest.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/tests/src/Kernel/EditorDirectivesTest.php
@@ -124,7 +124,7 @@ class EditorDirectivesTest extends GraphQLTestBase {
       [
         'blockName' => 'core/group',
         'attrs' => [],
-        'innerContent' => [null, null],
+        'innerContent' => [null, null, null],
         'innerBlocks' => [
           [
             'blockName' => 'custom/figure',
@@ -134,7 +134,17 @@ class EditorDirectivesTest extends GraphQLTestBase {
               'mediaEntityIds' => [$media->id()],
             ],
             'innerBlocks' => [],
-          ], [
+          ],
+          [
+            'blockName' => 'custom/figure',
+            'innerContent' => [],
+            'attrs' => [
+              'caption' => 'This image does not exist',
+              'mediaEntityIds' => ['666'],
+            ],
+            'innerBlocks' => [],
+          ],
+          [
             'blockName' => 'custom/columns',
             'innerContent' => [null, null],
             'attrs' => [],
@@ -175,7 +185,7 @@ class EditorDirectivesTest extends GraphQLTestBase {
     $query = $this->getQueryFromFile('editor.gql');
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheContexts(['static:language:de']);
-    $metadata->addCacheTags(['node:1', 'media:1']);
+    $metadata->addCacheTags(['node:1', 'media:1', 'media_list']);
     $this->assertResults($query, ['id' => '1:en'], [
       'en' => [
         'title' => 'Editor test',
@@ -190,6 +200,13 @@ class EditorDirectivesTest extends GraphQLTestBase {
             'image' => [
               'alt' => 'Screaming hairy armadillo'
             ],
+            'imageAlt' => 'Screaming hairy armadillo'
+          ],
+          [
+            '__typename' => 'Figure',
+            'caption' => 'This image does not exist',
+            'image' => NULL,
+            'imageAlt' => NULL,
           ],
           [
             '__typename' => 'Columns',
@@ -214,6 +231,13 @@ class EditorDirectivesTest extends GraphQLTestBase {
             'image' => [
               'alt' => 'Screaming hairy armadillo DE'
             ],
+            'imageAlt' => 'Screaming hairy armadillo DE'
+          ],
+          [
+            '__typename' => 'Figure',
+            'caption' => 'This image does not exist',
+            'image' => NULL,
+            'imageAlt' => NULL,
           ],
           [
             '__typename' => 'Columns',


### PR DESCRIPTION
## Package(s) involved

* `amazeelabs/silverback_gutenberg`

## Description of changes

Change the Gutenberg media resolver to use entity buffer.

## Motivation and context

The initial bug was that `@resolveProperty` fails when chained directly after `@resolveEditorBlockMedia` when the media entity does not exist.

Turns out that `$builder->compose` only aborts on `NULL` values when they are emitted by a `Deferred` result. 

Therefore I changed the EditorBlockMedia resolver to use EntityBuffer (for better performance) and also return a deferred result, which causes the query to return null correctly. Test cases for that have been added.

Another finding was that the `media_list` cache tag was missing up until now, which might have caused caching issues.


- [x] Kernel tests