### PR TITLE
fix(cloudinary): properly handle decap image urls in mock worker

### DIFF
--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/mock-cloudinary-worker.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/mock-cloudinary-worker.ts
@@ -8,7 +8,7 @@ function assertFetchEvent(event: Event): asserts event is FetchEvent {
 self.addEventListener('fetch', async (event) => {
   assertFetchEvent(event);
   const info = parseCloudinaryUrl(event.request.url);
-  if (!info) {
+  if (!info || !info.applies) {
     // No need to handle this request.
     return;
   }

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/worker-lib.test.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/worker-lib.test.ts
@@ -20,6 +20,25 @@ describe('parseCloudinaryUrl', () => {
       )!.debug,
     ).toBeFalsy();
   });
+  it('returns applies=true if the cloudname is "debug" or "demo"', () => {
+    expect(
+      parseCloudinaryUrl(
+        'https://res.cloudinary.com/demo/image/fetch/abc/f_auto/w_500/r_max//landscape.jpg',
+      )!.applies,
+    ).toBeTruthy();
+    expect(
+      parseCloudinaryUrl(
+        'https://res.cloudinary.com/debug/image/fetch/abc/f_auto/w_500/r_max//landscape.jpg',
+      )!.applies,
+    ).toBeTruthy();
+  });
+  it('returns applies=false if the cloudname is anything else', () => {
+    expect(
+      parseCloudinaryUrl(
+        'https://res.cloudinary.com/anythingelse/image/fetch/abc/f_auto/w_500/r_max//landscape.jpg',
+      )!.applies,
+    ).toBeFalsy();
+  });
   it('extracts a relative image source', () => {
     expect(
       parseCloudinaryUrl(
@@ -33,6 +52,13 @@ describe('parseCloudinaryUrl', () => {
         'https://res.cloudinary.com/debug/image/fetch/abc/f_auto/w_500/r_max/https://example.com/landscape.jpg',
       )!.src,
     ).toBe('https://example.com/landscape.jpg');
+  });
+  it('extracts a decap image source', () => {
+    expect(
+      parseCloudinaryUrl(
+        'https://res.cloudinary.com/debug/image/fetch/abc/f_auto/w_500/r_max/blob:http://localhost:5173/b003e521-e6cf-4ee0-a33e-fbf542e64e57',
+      )!.src,
+    ).toBe('blob:http://localhost:5173/b003e521-e6cf-4ee0-a33e-fbf542e64e57');
   });
   it('extracts no transform', () => {
     expect(

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/worker-lib.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/worker-lib.ts
@@ -1,10 +1,10 @@
 export function parseCloudinaryUrl(url: string) {
   const prefix = 'https://res.cloudinary.com/';
   const config = url.substring(prefix.length);
-  let pos = config.indexOf('/http') + 1;
-  if (pos === 0) {
-    pos = config.indexOf('//') + 1;
-  }
+  const pos =
+    config.indexOf('/http') + 1 ||
+    config.indexOf('/blob:http') + 1 ||
+    config.indexOf('//') + 1;
   const source = config.substring(pos);
   const match =
     /(?<cloudname>.*?)\/image\/fetch\/.*?\/f_auto\/?(?<transform>.*)/.exec(
@@ -31,6 +31,7 @@ export function parseCloudinaryUrl(url: string) {
   }
   return {
     debug: match.groups!.cloudname === 'debug',
+    applies: ['debug', 'demo'].includes(match.groups!.cloudname),
     src: source as string,
     transform: match.groups!.transform as string,
     width,


### PR DESCRIPTION
... and add a flag to skip mocking entirely

## Package(s) involved

`@amazeelabs/cloudinary-responsive-image`
## Description of changes

* add a "applies" flag that is true for "debug" and "demo" cloud names to skip mocking entirely
* handle `blob:http//...` urls in decap preview correctly

## Motivation and context

Use mock image worker in decap previews.

## How has this been tested?

[x] unit tests