### PR TITLE
feat(publisher): add publisher proxy header

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/server.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server.ts
@@ -149,6 +149,12 @@ const runServer = async (): Promise<HttpTerminator> => {
       createProxyMiddleware({
         target,
         changeOrigin: true,
+        onProxyReq: (proxyReq) => {
+          // Add a header to identify the request as a proxy request.
+          // This can be used to prevent redirect loops when the proxy target
+          // redirects to the proxy itself.
+          proxyReq.setHeader('SLB-Publisher-Proxy', 'true');
+        },
       }),
     );
   });


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

Add header to the express proxy middleware.

## Motivation and context

This can be used to prevent redirect loops when the proxy target redirects to the proxy itself.

## How has this been tested?

Manually.
