### PR TITLE
feat(gatsby-fragments): delete fragments before generating

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-fragments/.gitignore
+++ b/packages/npm/@amazeelabs/gatsby-fragments/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 index.cjs
+tests/fragments/*.fragment.ts

--- a/packages/npm/@amazeelabs/gatsby-fragments/README.md
+++ b/packages/npm/@amazeelabs/gatsby-fragments/README.md
@@ -69,3 +69,11 @@ fragment ContentPage on ContentPage {
 
 After `generate`, the initial file will be set back to the original version with
 `__typename` replaced by `__typename:_original_typename`.
+
+## Development
+
+To manually test on sample fragments.
+
+```
+pnpm ./cli.cjs generate --path ./tests/fragments
+```

--- a/packages/npm/@amazeelabs/gatsby-fragments/README.md
+++ b/packages/npm/@amazeelabs/gatsby-fragments/README.md
@@ -7,21 +7,28 @@ and the frontend (Gatsby) for use cases like instant preview.
 
 ## Execute one time
 
-```npx @amazeelabs/gatsby-fragments generate --path "path/to/fragment-files"```
+`npx @amazeelabs/gatsby-fragments generate --path "path/to/fragment-files"`
 
 ## Setup on a project
 
-1. Decide which fragments should be used by both backend and frontend (typically: content types, media, ...)
+1. Decide which fragments should be used by both backend and frontend
+   (typically: content types, media, ...)
 2. Move these fragments in a dedicated directory, e.g. `src/fragments/commons`
-3. Convert possibly existing Gatsby GraphQL Drupal `.ts` fragment files to vendor agnostic `.gql` files
+3. Convert possibly existing Gatsby GraphQL Drupal `.ts` fragment files to
+   vendor agnostic `.gql` files
 4. Gitignore the generated `*.fragment.ts` files from this common directory
-5. Setup the `generate` fragments script in Gatsby package.json. Example: `"generate-fragments": "node gatsby-fragments generate --path './src/fragments/commons' && eslint \"./src/fragments/commons/**/*.fragment.ts\" --fix && prettier --write \"./src/fragments/commons/**/*.fragment.ts\"",`
-6. This script could be added to the `codegen` one, but it needs to be executed first, so generated fragments can then be used by codegen. Example: `"codegen": "pnpm generate-fragments && graphql-codegen --config codegen.yml"`
-8. Fragments in the common directory can now be executed by both Gatsby and Drupal GraphQL
+5. Setup the `generate` fragments script in Gatsby package.json. Example:
+   `"generate-fragments": "node gatsby-fragments generate --path './src/fragments/commons' && eslint \"./src/fragments/commons/**/*.fragment.ts\" --fix && prettier --write \"./src/fragments/commons/**/*.fragment.ts\"",`
+6. This script could be added to the `codegen` one, but it needs to be executed
+   first, so generated fragments can then be used by codegen. Example:
+   `"codegen": "pnpm generate-fragments && graphql-codegen --config codegen.yml"`
+7. Fragments in the common directory can now be executed by both Gatsby and
+   Drupal GraphQL
 
 ### Step 3. example:
 
 Sample existing Drupal Gatsby specific fragment
+
 ```typescript
 import { graphql } from 'gatsby';
 
@@ -30,7 +37,7 @@ export const fragment = graphql`
     __typename
     drupalId
     langcode
-    title    
+    title
     articleReference {
       ... on DrupalContentArticle {
         drupalId
@@ -38,10 +45,12 @@ export const fragment = graphql`
         title
       }
     }
-  }`;
+  }
+`;
 ```
 
 Becomes GraphQL vendor agnostic
+
 ```graphql
 fragment ContentPage on ContentPage {
   __typename

--- a/packages/npm/@amazeelabs/gatsby-fragments/src/generate.test.ts
+++ b/packages/npm/@amazeelabs/gatsby-fragments/src/generate.test.ts
@@ -34,13 +34,14 @@ describe('generate', () => {
     },
   };
 
-  const filesAmountEquality = (path:string) => sync(`${path}/*.gql`).length === sync(`${path}/*.fragment.ts`).length;
+  const filesAmountEquality = (path: string) =>
+    sync(`${path}/*.gql`).length === sync(`${path}/*.fragment.ts`).length;
 
-  const typeScriptFilesContains = (path: string, pattern:string) => {
+  const typeScriptFilesContains = (path: string, pattern: string) => {
     const files = sync(`${path}/*.ts`);
     let result = true;
     for (const filePath of files) {
-      const content = readFileSync(filePath, {encoding: 'utf-8'});
+      const content = readFileSync(filePath, { encoding: 'utf-8' });
       result = content.includes(pattern);
     }
     return result;
@@ -61,7 +62,9 @@ describe('generate', () => {
   it('all typescript fragments contains original typename', async () => {
     mock(gqlMocks);
     await generate({ path: fragmentsPath });
-    expect(typeScriptFilesContains(fragmentsPath, '__typename:_original_typename')).toBe(true);
+    expect(
+      typeScriptFilesContains(fragmentsPath, '__typename:_original_typename'),
+    ).toBe(true);
   });
 
   it('all typescript fragments contains Drupal prefix', async () => {

--- a/packages/npm/@amazeelabs/gatsby-fragments/src/generate.ts
+++ b/packages/npm/@amazeelabs/gatsby-fragments/src/generate.ts
@@ -5,10 +5,10 @@ import path from 'path';
 export const defaultFragmentsPath = './src/fragments/commons';
 
 export type Options = {
-  path?: string
+  path?: string;
 };
 
-export const generate = (options:Options) => {
+export const generate = (options: Options) => {
   const fragmentsPath = options?.path || defaultFragmentsPath;
 
   if (!existsSync(fragmentsPath)) {
@@ -17,15 +17,21 @@ export const generate = (options:Options) => {
 
   const files = sync(`${fragmentsPath}/**/*.gql`);
   for (const filePath of files) {
-    const gqlData = readFileSync(filePath, {encoding: 'utf-8'});
+    const gqlData = readFileSync(filePath, { encoding: 'utf-8' });
     const fileDirectory: string = path.dirname(filePath);
     const gqlFileName: string = path.basename(filePath);
-    const tsFileName: string = `${gqlFileName.substring(0, gqlFileName.lastIndexOf('.'))}.fragment.ts`;
+    const tsFileName: string = `${gqlFileName.substring(
+      0,
+      gqlFileName.lastIndexOf('.'),
+    )}.fragment.ts`;
     const tsFilePath: string = path.resolve(fileDirectory, tsFileName);
 
     let tsData: string = gqlData;
     // Use _original_typename for relevant __typename.
-    tsData = tsData = tsData.replace(/__typename/g, '__typename:_original_typename');
+    tsData = tsData = tsData.replace(
+      /__typename/g,
+      '__typename:_original_typename',
+    );
     // Prefix with Drupal.
     tsData = tsData.replace(/\son\s(\w+)\s{/g, ' on Drupal$1 {');
     tsData = `import { graphql } from 'gatsby';

--- a/packages/npm/@amazeelabs/gatsby-fragments/src/generate.ts
+++ b/packages/npm/@amazeelabs/gatsby-fragments/src/generate.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { sync } from 'glob';
 import path from 'path';
 
@@ -13,6 +13,13 @@ export const generate = (options: Options) => {
 
   if (!existsSync(fragmentsPath)) {
     throw `Directory "${fragmentsPath}" does not exist.`;
+  }
+
+  // Delete files first, as some .gql files may be removed
+  // and this will cause Gatsby build errors.
+  const generatedFragments = sync(`${fragmentsPath}/**/*.fragment.ts`);
+  for (const filePath of generatedFragments) {
+    unlinkSync(filePath);
   }
 
   const files = sync(`${fragmentsPath}/**/*.gql`);

--- a/packages/npm/@amazeelabs/gatsby-fragments/src/index.ts
+++ b/packages/npm/@amazeelabs/gatsby-fragments/src/index.ts
@@ -1,10 +1,15 @@
 import { program } from 'commander';
 
-import { defaultFragmentsPath, generate } from "./generate";
+import { defaultFragmentsPath, generate } from './generate';
 
 program.name('gatsby-fragments');
-program.command('generate')
-  .option('-p, --path <string>', 'Optional path to TypeScript fragment files.', defaultFragmentsPath)
+program
+  .command('generate')
+  .option(
+    '-p, --path <string>',
+    'Optional path to TypeScript fragment files.',
+    defaultFragmentsPath,
+  )
   .action(generate);
 
 program.parse();

--- a/packages/npm/@amazeelabs/gatsby-fragments/tests/fragments/ContentArticle.gql
+++ b/packages/npm/@amazeelabs/gatsby-fragments/tests/fragments/ContentArticle.gql
@@ -1,0 +1,7 @@
+fragment ContentBlog on ContentBlog {
+  __typename
+  title
+  headerImage {
+    ...MediaImage
+  }
+}

--- a/packages/npm/@amazeelabs/gatsby-fragments/tests/fragments/ContentPage.gql
+++ b/packages/npm/@amazeelabs/gatsby-fragments/tests/fragments/ContentPage.gql
@@ -1,0 +1,9 @@
+fragment ContentPage on ContentPage {
+  __typename
+  title
+  articleReference {
+    ... on ContentArticle {
+      title
+    }
+  }
+}

--- a/packages/npm/@amazeelabs/gatsby-fragments/tests/fragments/MediaImage.gql
+++ b/packages/npm/@amazeelabs/gatsby-fragments/tests/fragments/MediaImage.gql
@@ -1,0 +1,4 @@
+fragment MediaImage on MediaImage {
+  __typename
+  url
+}


### PR DESCRIPTION
## Package(s) involved

`gatsby-fragments`

## Description of changes

In several commits

- prettier
- add some test files and development docs for manual testing
- delete fragments before generating

Follow-up of https://github.com/AmazeeLabs/silverback-mono/pull/1097

## Motivation and context

When switching tickets on client projects, it happens quite often that we need to run codegen / schema update / fragment generation, because the schema is changing. In this case, `.gql` fragments related to the features are being deleted but the corresponding `.fragment.ts` are left behind. Then this produces local build errors.

A simple way to prevent that is to delete before generating.

## How has this been tested?

Unit tests are green, manually.
