### PR TITLE
fix(publisher): missing state does not throw

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/core/tools/oAuth2.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tools/oAuth2.ts
@@ -297,11 +297,11 @@ export const persistState = (state: string, req: Request): void => {
 export const stateMatches = (req: Request): boolean => {
   const persistedState = req.session.state;
   if (persistedState === undefined) {
-    throw new Error('Missing state.');
+    return false;
   }
   const encodedState = req.query.state as string;
   if (encodedState === undefined) {
-    throw new Error('Missing state.');
+    return false;
   }
   const decodedState = Buffer.from(encodedState, 'base64').toString('ascii');
   return persistedState === decodedState;


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

Return false instead of throwing.

## Motivation and context

When throwing, a missing state will cause Publisher to restart.

## How has this been tested?

Manually.