### PR TITLE
chore: introduce "view publisher status" permission

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.permissions.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.permissions.yml
@@ -1,3 +1,5 @@
+view publisher status:
+  title: 'View Publisher status'
 trigger a gatsby build:
   title: 'Trigger a Gatsby Build'
 access publisher:

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.post_update.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.post_update.php
@@ -1,0 +1,15 @@
+<?php
+
+use Drupal\user\Entity\Role;
+
+/**
+ * Introduce "view publisher status" permission.
+ */
+function silverback_gatsby_post_update_introduce_view_publisher_status_permission(&$sandbox): void {
+  foreach (Role::loadMultiple() as $role) {
+    // The status was visible for everyone who could see the toolbar.
+    if ($role->hasPermission('access toolbar')) {
+      $role->grantPermission('view publisher status')->save();
+    }
+  }
+}

--- a/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.module
+++ b/packages/composer/amazeelabs/silverback_publisher_monitor/silverback_publisher_monitor.module
@@ -45,6 +45,9 @@ function silverback_publisher_monitor_page_attachments(&$variables) {
 function silverback_publisher_monitor_toolbar() {
   $items = [];
   $currentUser = \Drupal::currentUser();
+  if (!$currentUser->hasPermission('view publisher status')) {
+    return $items;
+  }
   $hasTriggerBuildPermission = $currentUser->hasPermission('trigger a gatsby build');
   $hasAccessPublisherPermission = $currentUser->hasPermission('access publisher');
 


### PR DESCRIPTION
## Package(s) involved

- `silverback_gatsby`
- `silverback_publisher_monitor`

## Motivation and context

To make it possible to completely hide Publisher from toolbar.

## How has this been tested?

Manually.
