### PR TITLE
perf(cloudinary): use local data-uri's for test images

### DIFF
--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.test.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.test.ts
@@ -165,8 +165,8 @@ describe('buildResponsiveImage()', () => {
       {
         "height": 1200,
         "sizes": "(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px",
-        "src": "https://placehold.co/1600x1200/000/FFF",
-        "srcset": "https://placehold.co/780x585/000/FFF 780w, https://placehold.co/1100x825/000/FFF 1100w",
+        "src": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1600\\" height=\\"1200\\" viewBox=\\"0 0 6400 4800\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">600x400</text></svg>",
+        "srcset": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"780\\" height=\\"585\\" viewBox=\\"0 0 3120 2340\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">600x400</text></svg> 780w, data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1100\\" height=\\"825\\" viewBox=\\"0 0 4400 3300\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">600x400</text></svg> 1100w",
         "width": 1600,
       }
     `);
@@ -194,8 +194,8 @@ describe('buildResponsiveImage()', () => {
       {
         "height": 1200,
         "sizes": "(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px",
-        "src": "https://placehold.co/1600x1200/000/FFF",
-        "srcset": "https://placehold.co/780x585/000/FFF 780w, https://placehold.co/1100x825/000/FFF 1100w",
+        "src": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1600\\" height=\\"1200\\" viewBox=\\"0 0 6400 4800\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">600x400</text></svg>",
+        "srcset": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"780\\" height=\\"585\\" viewBox=\\"0 0 3120 2340\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">600x400</text></svg> 780w, data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1100\\" height=\\"825\\" viewBox=\\"0 0 4400 3300\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">600x400</text></svg> 1100w",
         "width": 1600,
       }
     `);

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
@@ -187,15 +187,15 @@ const buildSrcSetString = (
 const getCloudinaryImageUrl = (
   credentials: CloudinaryCredentials,
   originalImage: string,
-  config?: { width?: number; height?: number; transform?: string },
+  config?: { width: number; height?: number; transform?: string },
 ): string => {
   const cloudName = credentials.cloudname;
   const apiKey = credentials.key;
   const apiSecret = credentials.secret;
   if (cloudName === 'test') {
-    return `https://placehold.co/${config?.width}x${
-      config?.height || (config?.width || 1000) * 0.75
-    }/${apiKey}/${apiSecret}`;
+    const width = config?.width || 1000;
+    const height = config?.height || width * 0.75;
+    return `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width*4} ${height*4}"><rect width="100%" height="100%" fill="%23${apiKey}"></rect><text fill="%23${apiSecret}" x="50%" y="50%" style="font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;">600x400</text></svg>`;
   }
   if (cloudName === 'local') {
     return originalImage;


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/cloudinary-responsive-image`

## Description of changes

Use inline data-uri's instead of loading images from placehold.co

## Motivation and context

More stability
