### PR TITLE
Cloudinary image url encoding

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-silverback-cloudinary/src/resolvers/responsive_image.ts
+++ b/packages/npm/@amazeelabs/gatsby-silverback-cloudinary/src/resolvers/responsive_image.ts
@@ -28,7 +28,13 @@ export const resolveResponsiveImage = (
       key: process.env.CLOUDINARY_API_KEY,
       cloudname: process.env.CLOUDINARY_CLOUDNAME,
     },
-    responsiveImage,
+    {
+      ...responsiveImage,
+      // Make sure to not send an already URI encoded string as the image src,
+      // otherwise we endup having double encoded src values, because the
+      // cloudinary SDK also encodes the URI.
+      src: decodeURI(responsiveImage.src || '')
+    },
     config,
   );
 };


### PR DESCRIPTION
## Package(s) involved

gatsby-silverback-cloudinary

## Description of changes

Decodes the original image src before calling the cloudinary transformation, to avoid double encoding.

## Related Issue(s)

[Cloudinary: double encoding for image urls](https://github.com/AmazeeLabs/silverback-mono/issues/1407)