### PR TITLE
Render test images as svg indicators with backgrounds

### DIFF
--- a/packages/composer/amazeelabs/silverback_cloudinary/src/Plugin/GraphQL/DataProducer/ResponsiveImage.php
+++ b/packages/composer/amazeelabs/silverback_cloudinary/src/Plugin/GraphQL/DataProducer/ResponsiveImage.php
@@ -46,6 +46,7 @@ use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
 class ResponsiveImage extends DataProducerPluginBase {
   public function resolve($image, $width = NULL, $height = NULL, $sizes = NULL, $transform = NULL) {
     $return = $image;
+    $return['originalSrc'] = $image['src'];
     // If no width is given, we just return the original image url.
     if (empty($width)) {
       return Json::encode($return);

--- a/packages/composer/amazeelabs/silverback_cloudinary/tests/src/Kernel/DataProducer/ResponsiveImageTest.php
+++ b/packages/composer/amazeelabs/silverback_cloudinary/tests/src/Kernel/DataProducer/ResponsiveImageTest.php
@@ -47,7 +47,7 @@ class ResponsiveImageTest extends GraphQLTestBase {
       // Case 1. No config parameter sent.
       [
         'image' => ['src' => $image, 'width' => 100, 'height' => 100],
-        'expected' => ['src' => $image, 'width' => 100, 'height' => 100]
+        'expected' => ['originalSrc' => $image, 'src' => $image, 'width' => 100, 'height' => 100]
       ],
       // Case 2. Only ask for a width (so just scale the image).
       [

--- a/packages/composer/amazeelabs/silverback_cloudinary/tests/src/Kernel/DataProducer/ResponsiveImageTest.php
+++ b/packages/composer/amazeelabs/silverback_cloudinary/tests/src/Kernel/DataProducer/ResponsiveImageTest.php
@@ -53,6 +53,7 @@ class ResponsiveImageTest extends GraphQLTestBase {
       [
         'image' => ['src' => $image, 'width' => 1000, 'height' => 500],
         'expected' => [
+          'originalSrc' => $image,
           'width' => 600,
           'height' => 300,
           'src' => $cloudinaryFetchUrl . '/s--1SSv3TAe--/f_auto/q_auto/c_scale,w_600/' . $image,
@@ -63,6 +64,7 @@ class ResponsiveImageTest extends GraphQLTestBase {
       [
         'image' => ['src' => $image, 'width' => 1000, 'height' => 1000],
         'expected' => [
+          'originalSrc' => $image,
           'width' => 600,
           'height' => 400,
           'src' => $cloudinaryFetchUrl . '/s--oQnrp4QO--/f_auto/q_auto/c_fill,g_auto,h_400,w_600/' . $image,
@@ -74,6 +76,7 @@ class ResponsiveImageTest extends GraphQLTestBase {
       [
         'image' => ['src' => $image, 'width' => 1000, 'height' => 1000],
         'expected' => [
+          'originalSrc' => $image,
           'width' => 600,
           'height' => 400,
           'src' => $cloudinaryFetchUrl . '/s--iBYmBJnf--/f_auto/q_auto/c_fill,g_auto,h_400,w_600/c_lfill,h_150,w_150/' . $image
@@ -87,6 +90,7 @@ class ResponsiveImageTest extends GraphQLTestBase {
       [
         'image' => ['src' => $image, 'width' => 2000, 'height' => 1600],
         'expected' => [
+          'originalSrc' => $image,
           'src' => $cloudinaryFetchUrl . '/s--do7-bAD9--/f_auto/q_auto/c_scale,w_1600/' . $image,
           'width' => 1600,
           'height' => 1280,
@@ -108,6 +112,7 @@ class ResponsiveImageTest extends GraphQLTestBase {
       [
         'image' => ['src' => $image, 'width' => 2000, 'height' => 1600],
         'expected' => [
+          'originalSrc' => $image,
           'src' => $cloudinaryFetchUrl . '/s--PYehk6Pp--/f_auto/q_auto/c_fill,g_auto,h_1200,w_1600/co_rgb:000000,e_colorize:90/' . $image,
           'width' => 1600,
           'height' => 1200,

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.test.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.test.ts
@@ -29,6 +29,7 @@ describe('buildResponsiveImage()', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "height": 450,
+        "originalSrc": "http://www.example.com/test_image.png",
         "src": "https://res.cloudinary.com/demo/image/fetch/s--1SSv3TAe--/f_auto/q_auto/c_scale,w_600/http://www.example.com/test_image.png",
         "width": 600,
       }
@@ -45,6 +46,7 @@ describe('buildResponsiveImage()', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "height": 400,
+        "originalSrc": "http://www.example.com/test_image.png",
         "src": "https://res.cloudinary.com/demo/image/fetch/s--oQnrp4QO--/f_auto/q_auto/c_fill,g_auto,h_400,w_600/http://www.example.com/test_image.png",
         "width": 600,
       }
@@ -62,6 +64,7 @@ describe('buildResponsiveImage()', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "height": 400,
+        "originalSrc": "http://www.example.com/test_image.png",
         "src": "https://res.cloudinary.com/demo/image/fetch/s--iBYmBJnf--/f_auto/q_auto/c_fill,g_auto,h_400,w_600/c_lfill,h_150,w_150/http://www.example.com/test_image.png",
         "width": 600,
       }
@@ -81,6 +84,7 @@ describe('buildResponsiveImage()', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "height": 1200,
+        "originalSrc": "http://www.example.com/test_image.png",
         "sizes": "(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px",
         "src": "https://res.cloudinary.com/demo/image/fetch/s--do7-bAD9--/f_auto/q_auto/c_scale,w_1600/http://www.example.com/test_image.png",
         "srcset": "https://res.cloudinary.com/demo/image/fetch/s--MZkCHWuY--/f_auto/q_auto/c_scale,w_780/http://www.example.com/test_image.png 780w, https://res.cloudinary.com/demo/image/fetch/s--xlf_u2mA--/f_auto/q_auto/c_scale,w_1100/http://www.example.com/test_image.png 1100w",
@@ -104,6 +108,7 @@ describe('buildResponsiveImage()', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "height": 1200,
+        "originalSrc": "http://www.example.com/test_image.png",
         "sizes": "(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px",
         "src": "https://res.cloudinary.com/demo/image/fetch/s--PYehk6Pp--/f_auto/q_auto/c_fill,g_auto,h_1200,w_1600/co_rgb:000000,e_colorize:90/http://www.example.com/test_image.png",
         "srcset": "https://res.cloudinary.com/demo/image/fetch/s--0q-v7sf8--/f_auto/q_auto/c_fill,g_auto,h_585,w_780/co_rgb:000000,e_colorize:90/http://www.example.com/test_image.png 780w, https://res.cloudinary.com/demo/image/fetch/s--1PnC9sUX--/f_auto/q_auto/c_fill,g_auto,h_825,w_1100/co_rgb:000000,e_colorize:90/http://www.example.com/test_image.png 1100w",
@@ -134,6 +139,7 @@ describe('buildResponsiveImage()', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "height": 1200,
+        "originalSrc": "http://www.example.com/test_image.png",
         "sizes": "(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px",
         "src": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1600\\" height=\\"1200\\" viewBox=\\"0 0 6400 4800\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1600 x 1200</text></svg>",
         "srcset": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"780\\" height=\\"585\\" viewBox=\\"0 0 3120 2340\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">780 x 585</text></svg> 780w, data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1100\\" height=\\"825\\" viewBox=\\"0 0 4400 3300\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1100 x 825</text></svg> 1100w",
@@ -163,6 +169,7 @@ describe('buildResponsiveImage()', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "height": 1200,
+        "originalSrc": "http://www.example.com/test_image.png",
         "sizes": "(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px",
         "src": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1600\\" height=\\"1200\\" viewBox=\\"0 0 6400 4800\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1600 x 1200</text></svg>",
         "srcset": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"780\\" height=\\"585\\" viewBox=\\"0 0 3120 2340\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">780 x 585</text></svg> 780w, data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1100\\" height=\\"825\\" viewBox=\\"0 0 4400 3300\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1100 x 825</text></svg> 1100w",
@@ -193,6 +200,7 @@ describe('buildResponsiveImage()', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "height": 1200,
+        "originalSrc": "http://www.example.com/test_image.png",
         "sizes": "(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px",
         "src": "http://www.example.com/test_image.png",
         "srcset": "http://www.example.com/test_image.png 780w, http://www.example.com/test_image.png 1100w",

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.test.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.test.ts
@@ -17,7 +17,10 @@ describe('buildResponsiveImage()', () => {
 
   it('asks for the original image', () => {
     const result = JSON.parse(buildResponsiveImage(credentials, imageProps));
-    expect(result).toStrictEqual(imageProps);
+    expect(result).toStrictEqual({
+      originalSrc: 'http://www.example.com/test_image.png',
+      ...imageProps,
+    });
   });
 
   it('asks for a width (scale image)', () => {
@@ -141,8 +144,8 @@ describe('buildResponsiveImage()', () => {
         "height": 1200,
         "originalSrc": "http://www.example.com/test_image.png",
         "sizes": "(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px",
-        "src": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1600\\" height=\\"1200\\" viewBox=\\"0 0 6400 4800\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1600 x 1200</text></svg>",
-        "srcset": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"780\\" height=\\"585\\" viewBox=\\"0 0 3120 2340\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">780 x 585</text></svg> 780w, data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1100\\" height=\\"825\\" viewBox=\\"0 0 4400 3300\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1100 x 825</text></svg> 1100w",
+        "src": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1600\\" height=\\"1200\\" viewBox=\\"0 0 1600 1200\\"><rect x=\\"0\\" y=\\"583\\" width=\\"100%\\" height=\\"30\\" fill=\\"rgba(0,0,0,0.5)\\"></rect><text fill=\\"#EEE\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 1em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1600 x 1200</text></svg>",
+        "srcset": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"780\\" height=\\"585\\" viewBox=\\"0 0 780 585\\"><rect x=\\"0\\" y=\\"275.5\\" width=\\"100%\\" height=\\"30\\" fill=\\"rgba(0,0,0,0.5)\\"></rect><text fill=\\"#EEE\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 1em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">780 x 585</text></svg> 780w, data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1100\\" height=\\"825\\" viewBox=\\"0 0 1100 825\\"><rect x=\\"0\\" y=\\"395.5\\" width=\\"100%\\" height=\\"30\\" fill=\\"rgba(0,0,0,0.5)\\"></rect><text fill=\\"#EEE\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 1em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1100 x 825</text></svg> 1100w",
         "width": 1600,
       }
     `);
@@ -171,8 +174,8 @@ describe('buildResponsiveImage()', () => {
         "height": 1200,
         "originalSrc": "http://www.example.com/test_image.png",
         "sizes": "(max-width: 800px) 780px, (max-width: 1200px) 1100px, 1600px",
-        "src": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1600\\" height=\\"1200\\" viewBox=\\"0 0 6400 4800\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1600 x 1200</text></svg>",
-        "srcset": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"780\\" height=\\"585\\" viewBox=\\"0 0 3120 2340\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">780 x 585</text></svg> 780w, data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1100\\" height=\\"825\\" viewBox=\\"0 0 4400 3300\\"><rect width=\\"100%\\" height=\\"100%\\" fill=\\"%23000\\"></rect><text fill=\\"%23FFF\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1100 x 825</text></svg> 1100w",
+        "src": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1600\\" height=\\"1200\\" viewBox=\\"0 0 1600 1200\\"><rect x=\\"0\\" y=\\"583\\" width=\\"100%\\" height=\\"30\\" fill=\\"rgba(0,0,0,0.5)\\"></rect><text fill=\\"#EEE\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 1em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1600 x 1200</text></svg>",
+        "srcset": "data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"780\\" height=\\"585\\" viewBox=\\"0 0 780 585\\"><rect x=\\"0\\" y=\\"275.5\\" width=\\"100%\\" height=\\"30\\" fill=\\"rgba(0,0,0,0.5)\\"></rect><text fill=\\"#EEE\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 1em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">780 x 585</text></svg> 780w, data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"1100\\" height=\\"825\\" viewBox=\\"0 0 1100 825\\"><rect x=\\"0\\" y=\\"395.5\\" width=\\"100%\\" height=\\"30\\" fill=\\"rgba(0,0,0,0.5)\\"></rect><text fill=\\"#EEE\\" x=\\"50%\\" y=\\"50%\\" style=\\"font-family: sans-serif; font-size: 1em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;\\">1100 x 825</text></svg> 1100w",
         "width": 1600,
       }
     `);
@@ -208,5 +211,4 @@ describe('buildResponsiveImage()', () => {
       }
     `);
   });
-
 });

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
@@ -208,11 +208,7 @@ const getCloudinaryImageUrl = (
   if (cloudName === 'placeholder') {
     const width = config?.width || 1000;
     const height = config?.height || width * 0.75;
-    return `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${
-      width * 4
-    } ${
-      height * 4
-    }"><rect width="100%" height="100%" fill="%23${apiKey}"></rect><text fill="%23${apiSecret}" x="50%" y="50%" style="font-family: sans-serif; font-size: 8em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;">${width} x ${Math.round(height)}</text></svg>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><rect x="0" y="${(height / 2) - 17}" width="100%" height="30" fill="rgba(0,0,0,0.5)"></rect><text fill="#EEE" x="50%" y="50%" style="font-family: sans-serif; font-size: 1em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;">${width} x ${height}</text></svg>`;
   }
   const image = new CloudinaryImage(
     originalImage,

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
@@ -208,7 +208,9 @@ const getCloudinaryImageUrl = (
   if (cloudName === 'placeholder') {
     const width = config?.width || 1000;
     const height = config?.height || width * 0.75;
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><rect x="0" y="${(height / 2) - 17}" width="100%" height="30" fill="rgba(0,0,0,0.5)"></rect><text fill="#EEE" x="50%" y="50%" style="font-family: sans-serif; font-size: 1em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;">${width} x ${height}</text></svg>`;
+    return `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><rect x="0" y="${
+      height / 2 - 17
+    }" width="100%" height="30" fill="rgba(0,0,0,0.5)"></rect><text fill="#EEE" x="50%" y="50%" style="font-family: sans-serif; font-size: 1em;font-weight:bold;text-anchor: middle; dominant-baseline: middle;">${width} x ${height}</text></svg>`;
   }
   const image = new CloudinaryImage(
     originalImage,

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/responsive_image.ts
@@ -11,6 +11,7 @@ export type ResponsiveImageConfig = {
 };
 
 export type ResponsiveImage = {
+  originalSrc: string;
   src: string;
   srcset?: string;
   sizes?: string;
@@ -31,6 +32,7 @@ export const buildResponsiveImage = (
 ): string => {
   const responsiveImage: ResponsiveImage = {
     ...originalImage,
+    originalSrc: originalImage.src,
   };
 
   // If no config object is given, we just return the original image url.

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/worker-lib.test.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/worker-lib.test.ts
@@ -6,18 +6,18 @@ describe('parseCloudinaryUrl', () => {
   it('returns undefined if its not a cloudinary url', () => {
     expect(parseCloudinaryUrl('https://example.com')).toBeUndefined();
   });
-  it('returns local=true if the cloudname is "local"', () => {
+  it('returns test=true if the cloudname is "test"', () => {
     expect(
       parseCloudinaryUrl(
-        'https://res.cloudinary.com/local/image/fetch/abc/f_auto/w_500/r_max//landscape.jpg',
-      )!.local,
+        'https://res.cloudinary.com/test/image/fetch/abc/f_auto/w_500/r_max//landscape.jpg',
+      )!.test,
     ).toBeTruthy();
   });
-  it('returns local=false if the cloudname is anything else', () => {
+  it('returns test=false if the cloudname is anything else', () => {
     expect(
       parseCloudinaryUrl(
         'https://res.cloudinary.com/anythingelse/image/fetch/abc/f_auto/w_500/r_max//landscape.jpg',
-      )!.local,
+      )!.test,
     ).toBeFalsy();
   });
   it('extracts a relative image source', () => {

--- a/packages/npm/@amazeelabs/cloudinary-responsive-image/src/worker-lib.ts
+++ b/packages/npm/@amazeelabs/cloudinary-responsive-image/src/worker-lib.ts
@@ -30,7 +30,7 @@ export function parseCloudinaryUrl(url: string) {
     }
   }
   return {
-    local: match.groups!.cloudname === 'local',
+    test: match.groups!.cloudname === 'test',
     src: source as string,
     transform: match.groups!.transform as string,
     width,

--- a/packages/npm/@amazeelabs/scalars/src/index.tsx
+++ b/packages/npm/@amazeelabs/scalars/src/index.tsx
@@ -180,7 +180,7 @@ export function Image({
     // and height don't match.
     // This is the case when an image is
     // loaded unprocessed for testing.
-    style={{ objectFit: 'cover', maxWidth: '100%', ... (info.test? {
+    style={{ objectFit: 'cover', maxWidth: '100%', ... (info?.test? {
       backgroundImage: `url(${imageData.originalSrc})`,
       backgroundPosition: 'center',
       backgroundSize: 'cover',

--- a/packages/npm/@amazeelabs/scalars/src/index.tsx
+++ b/packages/npm/@amazeelabs/scalars/src/index.tsx
@@ -143,6 +143,7 @@ export type ImageSource = string & {
 };
 
 type ImageSourceStructure = {
+  originalSrc: string;
   src: string;
   srcset: string;
   sizes: string;
@@ -170,40 +171,23 @@ export function Image({
 }) {
   const imageData = JSON.parse(source) as ImageSourceStructure;
   const info = parseCloudinaryUrl(imageData.src);
-  const ratio = imageData.height / imageData.width;
-  return info?.local ? (
-    <svg
-      className={props.className}
-      width={info.width || imageData.width}
-      style={{ maxWidth: '100%' }}
-      viewBox={`0 0 ${info.width || imageData.width} ${
-        info.height || ratio * (info.width || imageData.width)
-      }`}
-      preserveAspectRatio="xMidYMid slice"
-    >
-      <title>{alt}</title>
-      <image
-        href={info.src}
-        width="100%"
-        height="100%"
-        preserveAspectRatio="xMidYMid slice"
-      />
-    </svg>
-  ) : (
-    <img
-      decoding={priority ? 'sync' : 'async'}
-      loading={priority ? 'eager' : 'lazy'}
-      {...imageData}
-      // Set object fit to "cover", to never
-      // distort an image, even if the width
-      // and height don't match.
-      // This is the case when an image is
-      // loaded unprocessed for testing.
-      style={{ objectFit: 'cover', maxWidth: '100%' }}
-      alt={alt}
-      {...props}
-    />
-  );
+  return <img
+    decoding={priority ? 'sync' : 'async'}
+    loading={priority ? 'eager' : 'lazy'}
+    {...imageData}
+    // Set object fit to "cover", to never
+    // distort an image, even if the width
+    // and height don't match.
+    // This is the case when an image is
+    // loaded unprocessed for testing.
+    style={{ objectFit: 'cover', maxWidth: '100%', ... (info.test? {
+      backgroundImage: `url(${imageData.originalSrc})`,
+      backgroundPosition: 'center',
+      backgroundSize: 'cover',
+    }: {}) }}
+    alt={alt}
+    {...props}
+  />;
 }
 
 declare const Timestamp: unique symbol;


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/cloudinary-responsive-image`
`@amazeelabs/scalars`

## Description of changes

Make cloudinary libraries (php and javascript) emit an `originalSrc` property as well. When the cloudinary cloud name is `test` it will be rendered as a cropped background image in front of an inline-svg that simulates image box properties.

## Motivation and context

Simulate cloudinary cropped images without service workers.
