### PR TITLE
fix: fix images decoding

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-silverback-cloudinary/src/resolvers/responsive_image.ts
+++ b/packages/npm/@amazeelabs/gatsby-silverback-cloudinary/src/resolvers/responsive_image.ts
@@ -33,7 +33,7 @@ export const resolveResponsiveImage = (
       // Make sure to not send an already URI encoded string as the image src,
       // otherwise we endup having double encoded src values, because the
       // cloudinary SDK also encodes the URI.
-      src: decodeURI(responsiveImage.src || '')
+      src: decodeURIComponent(responsiveImage.src || '')
     },
     config,
   );


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/gatsby-silverback-cloudinary`

## Motivation and context

It was noticed that images with the plus sign in the filename still produce the double encoding issue.

Looks like `decodeURIComponent` should work better

## How has this been tested?

https://codesandbox.io/s/gracious-wozniak-pvtzn9?file=/src/index.mjs
