### PR TITLE
fix: handle null values

### DIFF
--- a/packages/composer/amazeelabs/silverback_cloudinary/src/Plugin/GraphQL/DataProducer/ResponsiveImage.php
+++ b/packages/composer/amazeelabs/silverback_cloudinary/src/Plugin/GraphQL/DataProducer/ResponsiveImage.php
@@ -45,6 +45,9 @@ use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
  */
 class ResponsiveImage extends DataProducerPluginBase {
   public function resolve($image, $width = NULL, $height = NULL, $sizes = NULL, $transform = NULL) {
+    if (!$image) {
+      return NULL;
+    }
     $return = $image;
     $return['originalSrc'] = $image['src'];
     // If no width is given, we just return the original image url.
@@ -64,7 +67,8 @@ class ResponsiveImage extends DataProducerPluginBase {
     }
     $return['src'] = $this->getCloudinaryImageUrl($image['src'], ['width' => $width, 'height' => $height, 'transform' => $transform]);
 
-    return Json::encode(array_filter($return));
+    $return = array_filter($return);
+    return $return ? Json::encode($return) : NULL;
   }
 
   /**

--- a/packages/npm/@amazeelabs/gatsby-silverback-cloudinary/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-silverback-cloudinary/src/gatsby-node.ts
@@ -71,16 +71,18 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
                   },
                   resolve: (source, args) => {
                     try {
-                      return resolveResponsiveImage(source[fieldKey], {
-                        width: args.width,
-                        height: args.height,
-                        sizes: args.sizes,
-                        transform: args.transform,
-                      });
+                      return source[fieldKey]
+                        ? resolveResponsiveImage(source[fieldKey], {
+                            width: args.width,
+                            height: args.height,
+                            sizes: args.sizes,
+                            transform: args.transform,
+                          })
+                        : null;
                     } catch (e) {
                       // @ts-ignore
                       reporter.error(e);
-                      return JSON.stringify({});
+                      return null;
                     }
                   },
                 },


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_cloudinary`
`@amazeelabs/gatsby-silverback-cloudinary`

## Description of changes

Fields of `ImageSource` type can be nullable. Now it's handled.

## Motivation and context

1. To avoid `{ image.source !== '{}' && <Image ... }` checks
2. To get rid of this error
    ```
    TypeError: Cannot read properties of null (reading 'src')
    - responsive_image.js:26 resolveResponsiveImage
    ```

## How has this been tested?

Locally, on a project.
