### PR TITLE
chore: do not notify if lagoon env vars are missing

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/notify.ts
+++ b/packages/npm/@amazeelabs/publisher/src/notify.ts
@@ -28,8 +28,14 @@ const processMessage = (notificationText: string): string => {
 };
 
 const notify = async (notificationText: string): Promise<void> => {
-  if (slackWebhookUrl === '' || slackChannel === '') {
-    // Slack webhook and channel are not configured yet.
+  if (
+    slackWebhookUrl === '' ||
+    slackChannel === '' ||
+    publisherUrl === '' ||
+    lagoonEnvironment === '' ||
+    lagoonProject === ''
+  ) {
+    // Environment is not configured yet, do not notify.
   } else {
     await slackWebhook.send({
       username: 'Publisher Bot',


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

Check for Lagoon environment variables to notify.

## Motivation and context

During the Lagoon build process or if we restart it, it can happen that the environment variables are not available yet and / or Node as well.
It results in a false positive error notification.

## How has this been tested?

Not tested, as it is quite hard to reproduce.