### PR TITLE
chore: make the update handler faster

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTestBase.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTestBase.php
@@ -165,5 +165,7 @@ abstract class EntityFeedTestBase extends GraphQLTestBase {
       'page',
       TRUE
     );
+
+    $this->container->get('silverback_gatsby.update_handler')->schemaCache = NULL;
   }
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/MenuFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/MenuFeedTest.php
@@ -49,6 +49,8 @@ class MenuFeedTest extends GraphQLTestBase {
       'id' => 'access_denied',
       'label' => 'Access denied',
     ])->save();
+
+    $this->container->get('silverback_gatsby.update_handler')->schemaCache = NULL;
   }
 
   protected function createMenuItem(string $label, string $url, MenuLinkContentInterface $parent = null, $menu = 'main') : MenuLinkContentInterface {


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

Added static cache to `GatsbyUpdateHandler`.

## Motivation and context

1. Migration of a project to the silverback directives made the schema heavier, so `GatsbyUpdateHandler::handle` became slower.
2. It was noticed on a project that [`LocaleStorageDecorator::save`](https://github.com/AmazeeLabs/silverback-mono/blob/a3ccc285ba1477527ec1e0c18a2cc820a97bad2b/packages/composer/amazeelabs/silverback_gatsby/src/LocaleStorageDecorator.php#L81-L90) triggers `GatsbyUpdateHandler::handle` 500+ times after a cache clear on some pages.

## How has this been tested?

Existing unit tests. Manually on a project.
