### PR TITLE
fix: scroll to top when using webform inline confirmation

### DIFF
--- a/packages/composer/amazeelabs/silverback_iframe/src/WebformSubmissionForm.php
+++ b/packages/composer/amazeelabs/silverback_iframe/src/WebformSubmissionForm.php
@@ -105,10 +105,17 @@ class WebformSubmissionForm extends Original {
 
       case WebformInterface::CONFIRMATION_INLINE:
       default:
-        // Replace the iframe with message.
         $this->respondWithCommand([
-          'action' => 'replaceWithMessages',
-          'messages' => [$this->getMessage()],
+          // Scroll first, so we still get the iframe reference.
+          [
+            'action' => 'scroll',
+            'scroll' => 'top',
+          ],
+          // Replace the iframe with message.
+          [
+            'action' => 'replaceWithMessages',
+            'messages' => [$this->getMessage()],
+          ],
         ], $form_state);
         break;
     }


### PR DESCRIPTION
## Package(s) involved

`silverback_iframe`

## Description of changes

Scroll to top when using Webform inline confirmation.

## How has this been tested?

Manually.