### PR TITLE
Gatsby node directives

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
@@ -137,7 +137,7 @@ respective field. Any unknown directives are simply ignores.
 
 ### Available directives
 
-#### `@resolveBy`
+#### `@resolveBy(fn: String!)`
 
 Loads a javascript function from a package and executes it to resolve the field.
 
@@ -146,6 +146,15 @@ type Employee {
   role @resolveBy(fn: "@custom/cms#resolveRole"): String!
 }
 ```
+
+#### `@gatsbyNodes(type: String!)`
+
+Load all nodes of a given type or interface. Can be used for "get all" use cases
+for Gatsby's page creation.
+
+#### `@gatsbyNode(type: String!, id: String!)`
+
+Load a single Gatsby node. Mostly used for displaying a single page.
 
 ### Custom directives
 

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/directives.graphql
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/directives.graphql
@@ -1,2 +1,4 @@
 directive @sourceFrom(fn: String) on OBJECT
 directive @resolveBy(fn: String) repeatable on FIELD_DEFINITION
+directive @gatsbyNodes(type: String) on FIELD_DEFINITION
+directive @gatsbyNode(type: String, id: String) on FIELD_DEFINITION

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/directives.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/directives.ts
@@ -1,0 +1,29 @@
+import { registerDirective } from './helpers/schema';
+import { SilverbackResolver } from './types';
+
+export function directives(register: registerDirective) {
+  register('gatsbyNode', (async (
+    _,
+    { type, id }: { type: string; id: string },
+    context,
+  ) => {
+    return await context.nodeModel.findOne({
+      type: type,
+      query: {
+        filter: {
+          id: {
+            eq: id,
+          },
+        },
+      },
+    });
+  }) satisfies SilverbackResolver);
+
+  register('gatsbyNodes', (async (_, { type }: { type: string }, context) => {
+    return (
+      await context.nodeModel.findAll({
+        type: type,
+      })
+    ).entries;
+  }) satisfies SilverbackResolver);
+}

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -16,6 +16,7 @@ import { INodeDeleteEvent } from 'gatsby-graphql-source-toolkit/dist/types';
 import { buildSchema } from 'graphql';
 import { loadConfig } from 'graphql-config';
 
+import { directives } from './directives.js';
 import { createPages as createGatsbyPages } from './helpers/create-pages.js';
 import { createQueryExecutor } from './helpers/create-query-executor.js';
 import { createSourcingConfig } from './helpers/create-sourcing-config.js';
@@ -301,6 +302,7 @@ export const createResolvers: GatsbyNode['createResolvers'] = async (
   }
 
   if (options.schema_configuration) {
+    directives(registerDirectiveImplementation);
     if (options.directive_providers) {
       for (const spec of options.directive_providers) {
         spec(registerDirectiveImplementation);

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.test.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.test.ts
@@ -40,14 +40,8 @@ describe('extractResolverMapping', () => {
         value: [['echo', { msg: 'value from schema' }]],
         argument: [['echo', { msg: '$msg' }]],
         parent: [
-          ['echo', { msg: 'parent value' }],
+          ['resolveBy', { fn: '@amazeelabs/test-directives#parentValue' }],
           ['echo', { msg: '$' }],
-        ],
-        allContacts: [
-          ['resolveBy', { fn: '@amazeelabs/test-directives#allContacts' }],
-        ],
-        getPerson: [
-          ['resolveBy', { fn: '@amazeelabs/test-directives#getPerson' }],
         ],
       },
     });
@@ -73,9 +67,9 @@ describe('cleanSchema', () => {
       type Query {
         value: String @echo(msg: \\"value from schema\\")
         argument(msg: String!): String @echo(msg: \\"$msg\\")
-        parent: String @echo(msg: \\"parent value\\") @echo(msg: \\"$\\")
-        allContacts: [Contact] @resolveBy(fn: \\"@amazeelabs/test-directives#allContacts\\")
-        getPerson(id: ID!): Person @resolveBy(fn: \\"@amazeelabs/test-directives#getPerson\\")
+        parent: String @resolveBy(fn: \\"@amazeelabs/test-directives#parentValue\\") @echo(msg: \\"$\\")
+        allContacts: [Contact] @gatsbyNodes(type: \\"Contact\\")
+        getPerson(id: ID!): Person @gatsbyNode(type: \\"Contact\\", id: \\"$id\\")
       }
       union Person = Customer | Employee
       interface Contact {

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.ts
@@ -184,6 +184,8 @@ export async function buildResolver(
           return directives[name](
             parent,
             processDirectiveArguments(parent, args, spec),
+            context,
+            info,
           );
         };
       }),

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/test/schema/schema.graphql
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/test/schema/schema.graphql
@@ -4,10 +4,8 @@ type Query {
   value: String @echo(msg: "value from schema")
   argument(msg: String!): String @echo(msg: "$msg")
   parent: String @echo(msg: "parent value") @echo(msg: "$")
-  allContacts: [Contact]
-    @resolveBy(fn: "@amazeelabs/test-directives#allContacts")
-  getPerson(id: ID!): Person
-    @resolveBy(fn: "@amazeelabs/test-directives#getPerson")
+  allContacts: [Contact] @gatsbyNodes(type: "Contact")
+  getPerson(id: ID!): Person @gatsbyNode(type: "Contact", id: "$id")
 }
 
 union Person = Customer | Employee

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/test/schema/schema.graphql
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/test/schema/schema.graphql
@@ -3,7 +3,9 @@ scalar Email
 type Query {
   value: String @echo(msg: "value from schema")
   argument(msg: String!): String @echo(msg: "$msg")
-  parent: String @echo(msg: "parent value") @echo(msg: "$")
+  parent: String
+    @resolveBy(fn: "@amazeelabs/test-directives#parentValue")
+    @echo(msg: "$")
   allContacts: [Contact] @gatsbyNodes(type: "Contact")
   getPerson(id: ID!): Person @gatsbyNode(type: "Contact", id: "$id")
 }

--- a/packages/tests/test-directives/src/index.ts
+++ b/packages/tests/test-directives/src/index.ts
@@ -72,23 +72,3 @@ export const sourceCustomers: SilverbackSource<Customer> = () => {
   ];
 };
 
-export const allContacts: SilverbackResolver = async (_, __, context) => {
-  return (
-    await context.nodeModel.findAll({
-      type: 'Contact',
-    })
-  ).entries;
-};
-
-export const getPerson: SilverbackResolver = async (_, args, context) => {
-  return await context.nodeModel.findOne({
-    type: 'Contact',
-    query: {
-      filter: {
-        id: {
-          eq: args.id,
-        },
-      },
-    },
-  });
-};

--- a/packages/tests/test-directives/src/index.ts
+++ b/packages/tests/test-directives/src/index.ts
@@ -72,3 +72,4 @@ export const sourceCustomers: SilverbackSource<Customer> = () => {
   ];
 };
 
+export const parentValue: SilverbackResolver = () => 'parent value';


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/gatsby-source-silverback`

## Description of changes

Add directives for simple loading of Gatsby nodes.
In the process, also makes `@resolveBy` chainable.

## Motivation and context

Provide a solution for 80% of "createPages" and "loadPage" queries.

## How has this been tested?

- [x] Manually
- [ ] Unit tests
- [x] Integration tests
