### PR TITLE
Fix menu resolving

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/MenuFeed.php
@@ -227,9 +227,15 @@ class MenuFeed extends FeedBase implements ContainerFactoryPluginInterface {
         $this->builder->context('current_menu_language', $langcode),
         $resolver,
         $this->builder->callback(function ($value, $args, ResolveContext $context, ResolveInfo $info, FieldContext $fieldContext) {
-        $value->__language = $fieldContext->getContextValue('current_menu_language');
-        return $value;
-      }));
+          $langcode = $fieldContext->getContextValue('current_menu_language');
+          if ($langcode !== $value->language()->getId()) {
+            $clone = clone $value;
+            $clone->set('langcode', $langcode);
+            return $clone;
+          }
+          return $value;
+        })
+      );
     }
     return $resolver;
   }

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/queries/multilingual-menus.gql
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/queries/multilingual-menus.gql
@@ -1,19 +1,8 @@
 query MultilingualMenus {
-  loadMainMenu(id: "main:de") {
-    items {
-      id
-      parent
-      label
-      url
-    }
-    translations {
-      langcode
-      items {
-        id
-        parent
-        label
-        url
-      }
-    }
+  en: loadMainMenu(id: "main:en") {
+    id
+  }
+  de: loadMainMenu(id: "main:de") {
+    id
   }
 }

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/MenuFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/MenuFeedTest.php
@@ -160,4 +160,23 @@ class MenuFeedTest extends GraphQLTestBase {
       new GatsbyUpdate('VisibleMainMenu', 'main'),
     ], $diff);
   }
+
+  public function testTranslatableMenu() {
+    $this->container
+      ->get('content_translation.manager')
+      ->setEnabled('menu_link_content', 'menu_link_content', TRUE);
+
+    $query = $this->getQueryFromFile('multilingual-menus.gql');
+    $this->assertResults($query, [], [
+      'en' => [
+        'id' => 'main:en',
+      ],
+      'de' => [
+        'id' => 'main:de',
+      ],
+    ], $this->defaultCacheMetaData()
+      ->addCacheContexts(['languages:language_interface'])
+      ->addCacheTags(['config:system.menu.main'])
+    );
+  }
 }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql_directives`

## Motivation and context

It was noticed that menu related `load*` queries were ignoring the passed menu language. This was messing up Gatsby's partial builds. Gatsby was not reacting to changes in menu item translations.

## Related Issue(s)

https://github.com/AmazeeLabs/silverback-mono/issues/1274

## How has this been tested?

Added a unit test case. Tested manually on silverback-template.
