### PR TITLE
Drupal graphql config

### DIFF
--- a/.phpactor.json
+++ b/.phpactor.json
@@ -1,0 +1,13 @@
+{
+  "file_path_resolver.application_root": "%project_root%/apps/silverback-drupal/web",
+  "composer.autoloader_path": "%project_root%/apps/silverback-drupal/vendor/autoload.php",
+  "language_server_phpstan.enabled": false,
+  "language_server_phpstan.bin": "%project_root%/apps/silverback-drupal/vendor/bin/phpstan",
+  "php_code_sniffer.enabled": false,
+  "php_code_sniffer.bin": "%project_root%/apps/silverback-drupal/vendor/bin/phpstan",
+  "prophecy.enabled": true,
+  "code_transform.indentation": "  ",
+  "indexer.supported_extensions": ["php", "inc", "module"],
+  "indexer.include_patterns": ["/**/*.php", "/**/*.inc", "/**/*.module"],
+  "indexer.follow_symlinks": true
+}

--- a/apps/silverback-drupal/composer.json
+++ b/apps/silverback-drupal/composer.json
@@ -56,6 +56,7 @@
         "drupal/test_session": "@dev",
         "drupal/typed_data": "1.0.0-beta2",
         "drupal/webform": "6.2.0-beta6",
+        "fenetikm/autoload-drupal": "^1.0",
         "phpspec/prophecy-phpunit": "2.0.2"
     },
     "conflict": {
@@ -72,10 +73,18 @@
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "fenetikm/autoload-drupal": true
         }
     },
     "extra": {
+        "autoload-drupal": {
+            "modules": [
+                "app/modules/contrib/",
+                "app/modules/custom/",
+                "app/core/modules/"
+            ]
+        },
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"

--- a/apps/silverback-drupal/composer.lock
+++ b/apps/silverback-drupal/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a8731a7cfae66197c1e52cc91941c5f",
+    "content-hash": "33837bef833ade8a797b72662c3f8e54",
     "packages": [
         {
             "name": "amazeelabs/default-content",
-            "version": "1.2.11",
+            "version": "1.2.12",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/default-content",
-                "reference": "3d42d24cbc9f2df945cc0ac5470c0ec2d1df046b"
+                "reference": "3e951df2025e63c45313081dd71f1bb61347845f"
             },
             "require": {
                 "amazeelabs/proxy-default-content": "^1.1.7"
@@ -33,11 +33,11 @@
         },
         {
             "name": "amazeelabs/graphql_directives",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/graphql_directives",
-                "reference": "e344ea6bd7bf2265431bc4cdc6d87b9a0bb14344"
+                "reference": "8365b68422b734b6408c43d1137ff23d6fa28bb9"
             },
             "type": "drupal-module",
             "extra": {
@@ -58,11 +58,11 @@
         },
         {
             "name": "amazeelabs/proxy-default-content",
-            "version": "1.1.7",
+            "version": "1.1.15",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/proxy-default-content",
-                "reference": "9d1d6f2172215ec7e5a8d4837dbe0bb4c5e23e77"
+                "reference": "8cd3616af9451f71520e953e1f4719280c8ef672"
             },
             "require": {
                 "cweagans/composer-patches": "^1.7.3",
@@ -89,11 +89,11 @@
         },
         {
             "name": "amazeelabs/proxy-drupal-core",
-            "version": "1.1.12",
+            "version": "1.1.13",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/proxy-drupal-core",
-                "reference": "ec7ce2f13a9aa0691f57b612b76ec4fe6ea58f59"
+                "reference": "160b9c3dddb64b96c0f66d7ce5b662b1b84a8f89"
             },
             "require": {
                 "cweagans/composer-patches": "^1.7.3",
@@ -121,11 +121,11 @@
         },
         {
             "name": "amazeelabs/proxy-gutenberg",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/proxy-gutenberg",
-                "reference": "f9f9f5403a48ef5df587b4b25ae2aea304b71fa2"
+                "reference": "0fb7030d68ace85ad9d538d8b6a11890bdaefc4a"
             },
             "require": {
                 "cweagans/composer-patches": "^1.7.3",
@@ -148,11 +148,11 @@
         },
         {
             "name": "amazeelabs/silverback-cli",
-            "version": "2.9.4",
+            "version": "2.9.5",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback-cli",
-                "reference": "7cf31717e4a0ae16886c55f066f45d8d0de3d734"
+                "reference": "67befc8ef25d354e1ddc1c472b5bdc5b2473a2ea"
             },
             "require": {
                 "drush/drush": "^10 || ^11",
@@ -197,11 +197,11 @@
         },
         {
             "name": "amazeelabs/silverback_campaign_urls",
-            "version": "1.0.2",
+            "version": "1.0.6",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_campaign_urls",
-                "reference": "b19602869f66537fe442f9494957b15def1ab1f2"
+                "reference": "693a1f7e7f8f5b9731029670ba15fd806214bca7"
             },
             "type": "drupal-module",
             "license": [
@@ -215,11 +215,11 @@
         },
         {
             "name": "amazeelabs/silverback_cdn_redirect",
-            "version": "2.2.4",
+            "version": "2.2.5",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_cdn_redirect",
-                "reference": "44aa5a4316ebd05aa43c0da75a1b5d80432e520e"
+                "reference": "a3001215e89fb633a75fa50c0e5beb8b2f036719"
             },
             "type": "drupal-module",
             "license": [
@@ -233,11 +233,11 @@
         },
         {
             "name": "amazeelabs/silverback_cloudinary",
-            "version": "1.3.0",
+            "version": "1.4.1",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_cloudinary",
-                "reference": "4df689166a03ac0ebd4f58f1c8bf0c984e66681b"
+                "reference": "00ad7072603d07842d15779bca40b437e8eb4370"
             },
             "require": {
                 "cloudinary/cloudinary_php": "^2"
@@ -261,11 +261,11 @@
         },
         {
             "name": "amazeelabs/silverback_external_preview",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_external_preview",
-                "reference": "459bd8a8043575ec3d8ed54cb73c1a9c07ac2637"
+                "reference": "09db49ade1d457569843b336526e78173ee9abf4"
             },
             "type": "drupal-module",
             "license": [
@@ -279,11 +279,11 @@
         },
         {
             "name": "amazeelabs/silverback_gatsby",
-            "version": "2.2.0",
+            "version": "2.3.8",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_gatsby",
-                "reference": "06f1241656297429f63c56ee8deb3d7431758ada"
+                "reference": "c82bb1030d3e2d8c5d64afd727b580aaa76eea02"
             },
             "type": "drupal-module",
             "extra": {
@@ -304,11 +304,11 @@
         },
         {
             "name": "amazeelabs/silverback_graphql_persisted",
-            "version": "1.1.6",
+            "version": "1.1.7",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_graphql_persisted",
-                "reference": "eca60fe07343c72ad96f64433036d6b03d213f54"
+                "reference": "b460f6acff15cffcc88e18469ef57f56643ab74c"
             },
             "type": "drupal-module",
             "license": [
@@ -321,11 +321,11 @@
         },
         {
             "name": "amazeelabs/silverback_gutenberg",
-            "version": "2.4.5",
+            "version": "2.5.4",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_gutenberg",
-                "reference": "502710661b6fc20e5d5157c0d8a6579909738324"
+                "reference": "e2eb132fa74d4ffa0fadf8a2fdb41d8d9f4cd336"
             },
             "require": {
                 "drupal/gutenberg": "^2.7.0"
@@ -342,11 +342,11 @@
         },
         {
             "name": "amazeelabs/silverback_iframe",
-            "version": "1.3.3",
+            "version": "1.3.5",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_iframe",
-                "reference": "d2fd601eee7792722a8027979c65e45a1e3a8481"
+                "reference": "2419bc4e9e64da63a6760d6f5d9d08423d54d634"
             },
             "type": "drupal-module",
             "license": [
@@ -360,11 +360,11 @@
         },
         {
             "name": "amazeelabs/silverback_iframe_theme",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_iframe_theme",
-                "reference": "d896c97997cce0bbae22b8720e94dadc0f2154d5"
+                "reference": "822b280c3182659827d0a6769d06e9234c6faa9a"
             },
             "type": "drupal-theme",
             "license": [
@@ -378,11 +378,11 @@
         },
         {
             "name": "amazeelabs/silverback_translations",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/silverback_translations",
-                "reference": "93f0280309ff120110b65c2488d27b2410d2a8e4"
+                "reference": "d01acd954594ebb4474b0dd2c80f290005dd4a18"
             },
             "type": "drupal-module",
             "license": [
@@ -3677,6 +3677,10 @@
                     "homepage": "https://www.drupal.org/user/262198"
                 },
                 {
+                    "name": "luigisa",
+                    "homepage": "https://www.drupal.org/user/1022312"
+                },
+                {
                     "name": "pmelab",
                     "homepage": "https://www.drupal.org/user/555322"
                 }
@@ -3741,6 +3745,10 @@
                 {
                     "name": "Stephan Zeidler (szeidler)",
                     "homepage": "https://www.drupal.org/u/szeidler"
+                },
+                {
+                    "name": "roborn",
+                    "homepage": "https://www.drupal.org/user/139474"
                 },
                 {
                     "name": "szeidler",
@@ -4059,6 +4067,10 @@
                     "homepage": "https://www.drupal.org/user/53892"
                 },
                 {
+                    "name": "Kristen Pol",
+                    "homepage": "https://www.drupal.org/user/8389"
+                },
+                {
                     "name": "pifagor",
                     "homepage": "https://www.drupal.org/user/2375692"
                 }
@@ -4140,11 +4152,11 @@
         },
         {
             "name": "drupal/test_session",
-            "version": "1.2.64",
+            "version": "1.2.65",
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/drupal/test_session",
-                "reference": "cb13d590c19a14f47bf71b9d2b4ba8eef6068eca"
+                "reference": "d639dbc28b9bb4705771069619dbe4c9bc0f30ad"
             },
             "type": "drupal-module",
             "license": [
@@ -4232,16 +4244,16 @@
                 "drupal/captcha": "^1 || ^2",
                 "drupal/chosen": "3.0.x-dev",
                 "drupal/ckeditor": "1.0.x-dev",
-                "drupal/clientside_validation": "^3 || ^4",
+                "drupal/clientside_validation": "*",
                 "drupal/clientside_validation_jquery": "*",
-                "drupal/devel": "5.x-dev",
+                "drupal/devel": "*",
                 "drupal/entity": "1.x-dev",
-                "drupal/entity_print": "2.x-dev",
+                "drupal/entity_print": "*",
                 "drupal/group": "1.x-dev",
                 "drupal/hal": "1 - 2",
                 "drupal/jquery_ui": "1.x-dev",
-                "drupal/jquery_ui_checkboxradio": "2.x-dev",
-                "drupal/jquery_ui_datepicker": "1.x-dev",
+                "drupal/jquery_ui_checkboxradio": "*",
+                "drupal/jquery_ui_datepicker": "*",
                 "drupal/mailsystem": "4.x-dev",
                 "drupal/metatag": "1.x-dev",
                 "drupal/paragraphs": "1.x-dev",
@@ -4249,7 +4261,7 @@
                 "drupal/smtp": "1.x-dev",
                 "drupal/styleguide": "^1 || ^2",
                 "drupal/telephone_validation": "2.x-dev",
-                "drupal/token": "1.x-dev",
+                "drupal/token": "*",
                 "drupal/variationcache": "1.x-dev",
                 "drupal/webform_access": "*",
                 "drupal/webform_attachment": "*",
@@ -7220,16 +7232,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.19",
+            "version": "1.10.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "af5a296ff02610c1bfb4ddfac9fd4a08657b9046"
+                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/af5a296ff02610c1bfb4ddfac9fd4a08657b9046",
-                "reference": "af5a296ff02610c1bfb4ddfac9fd4a08657b9046",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5302bb402c57f00fb3c2c015bac86e0827e4b691",
+                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691",
                 "shasum": ""
             },
             "require": {
@@ -7278,7 +7290,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-14T15:26:58+00:00"
+            "time": "2023-10-06T14:19:14+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -13087,7 +13099,52 @@
             "time": "2023-01-06T12:12:50+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "fenetikm/autoload-drupal",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fenetikm/autoload-drupal.git",
+                "reference": "14c9f1c6da17c238de41d34585df061a7d5ba2f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fenetikm/autoload-drupal/zipball/14c9f1c6da17c238de41d34585df061a7d5ba2f6",
+                "reference": "14c9f1c6da17c238de41d34585df061a7d5ba2f6",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1|^2",
+                "composer/composer": "*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "fenetikm\\DrupalAutoloadPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "fenetikm\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Welford",
+                    "email": "mail@michaelwelford.com"
+                }
+            ],
+            "description": "Autoload Drupal modules into composer autoloader",
+            "support": {
+                "issues": "https://github.com/fenetikm/autoload-drupal/issues",
+                "source": "https://github.com/fenetikm/autoload-drupal/tree/1.0.0"
+            },
+            "time": "2023-01-23T21:06:34+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
@@ -13120,5 +13177,5 @@
     "platform-overrides": {
         "php": "8.1.13"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/apps/silverback-drupal/composer.lock
+++ b/apps/silverback-drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33837bef833ade8a797b72662c3f8e54",
+    "content-hash": "2be8713e82cc41a92a67930ce2e52182",
     "packages": [
         {
             "name": "amazeelabs/default-content",
@@ -37,7 +37,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer/amazeelabs/graphql_directives",
-                "reference": "8365b68422b734b6408c43d1137ff23d6fa28bb9"
+                "reference": "d95974c65e1d83e66ea77bc62d348258be098c94"
+            },
+            "require": {
+                "webmozart/glob": "^4.6.0"
             },
             "type": "drupal-module",
             "extra": {
@@ -4608,6 +4611,50 @@
                 "source": "https://github.com/enlightn/security-checker/tree/v1.10.0"
             },
             "time": "2022-02-21T22:40:16+00:00"
+        },
+        {
+            "name": "fenetikm/autoload-drupal",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fenetikm/autoload-drupal.git",
+                "reference": "14c9f1c6da17c238de41d34585df061a7d5ba2f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fenetikm/autoload-drupal/zipball/14c9f1c6da17c238de41d34585df061a7d5ba2f6",
+                "reference": "14c9f1c6da17c238de41d34585df061a7d5ba2f6",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1|^2",
+                "composer/composer": "*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "fenetikm\\DrupalAutoloadPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "fenetikm\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Welford",
+                    "email": "mail@michaelwelford.com"
+                }
+            ],
+            "description": "Autoload Drupal modules into composer autoloader",
+            "support": {
+                "issues": "https://github.com/fenetikm/autoload-drupal/issues",
+                "source": "https://github.com/fenetikm/autoload-drupal/tree/1.0.0"
+            },
+            "time": "2023-01-23T21:06:34+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -13033,6 +13080,55 @@
             "time": "2022-06-03T18:03:27+00:00"
         },
         {
+            "name": "webmozart/glob",
+            "version": "4.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/glob.git",
+                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/glob/zipball/3c17f7dec3d9d0e87b575026011f2e75a56ed655",
+                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "symfony/filesystem": "^5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "support": {
+                "issues": "https://github.com/webmozarts/glob/issues",
+                "source": "https://github.com/webmozarts/glob/tree/4.6.0"
+            },
+            "time": "2022-05-24T19:45:58+00:00"
+        },
+        {
             "name": "webonyx/graphql-php",
             "version": "v14.11.9",
             "source": {
@@ -13099,52 +13195,7 @@
             "time": "2023-01-06T12:12:50+00:00"
         }
     ],
-    "packages-dev": [
-        {
-            "name": "fenetikm/autoload-drupal",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fenetikm/autoload-drupal.git",
-                "reference": "14c9f1c6da17c238de41d34585df061a7d5ba2f6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fenetikm/autoload-drupal/zipball/14c9f1c6da17c238de41d34585df061a7d5ba2f6",
-                "reference": "14c9f1c6da17c238de41d34585df061a7d5ba2f6",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1|^2",
-                "composer/composer": "*"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "fenetikm\\DrupalAutoloadPlugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "fenetikm\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Welford",
-                    "email": "mail@michaelwelford.com"
-                }
-            ],
-            "description": "Autoload Drupal modules into composer autoloader",
-            "support": {
-                "issues": "https://github.com/fenetikm/autoload-drupal/issues",
-                "source": "https://github.com/fenetikm/autoload-drupal/tree/1.0.0"
-            },
-            "time": "2023-01-23T21:06:34+00:00"
-        }
-    ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {

--- a/apps/silverback-drupal/config/sync/graphql.graphql_servers.silverback_gatsby.yml
+++ b/apps/silverback-drupal/config/sync/graphql.graphql_servers.silverback_gatsby.yml
@@ -17,7 +17,7 @@ schema_configuration:
     extensions:
       silverback_campaign_urls: silverback_campaign_urls
       silverback_gatsby: silverback_gatsby
-    schema_definition: modules/custom/silverback_gatsby_test/graphql/silverback_gatsby_test.graphqls
+    schema_definition: ../graphqlrc.yml
     build_trigger_on_save: 1
     build_url: ''
     build_webhook: 'http://localhost:9001/__rebuild'

--- a/apps/silverback-drupal/config/sync/graphql.graphql_servers.silverback_gatsby_preview.yml
+++ b/apps/silverback-drupal/config/sync/graphql.graphql_servers.silverback_gatsby_preview.yml
@@ -16,12 +16,13 @@ schema_configuration:
   silverback_gatsby_test:
     extensions:
       silverback_gatsby: silverback_gatsby
+      silverback_campaign_urls: 0
+    schema_definition: ../graphqlrc.yml
     build_trigger_on_save: 1
     build_webhook: 'http://localhost:8000/__refresh'
     build_url: ''
     update_webhook: ''
     user: e6bbb44c-6dcf-44aa-8d41-67b920e233b9
-    schema_definition: modules/custom/silverback_gatsby_test/graphql/silverback_gatsby_test.graphqls
 persisted_queries_settings:
   silverback_graphql_persisted:
     weight: 0

--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -376,6 +376,268 @@ type FirstLevelMainMenu @menu(menu_id: "main", max_level: 1) {
 
 type GatsbyStringTranslation @stringTranslation(contextPrefix: "gatsby")
 
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Arg".
+"""
+directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
+"""
+directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
+"""
+directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
+"""
+directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemId".
+"""
+directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemLabel".
+"""
+directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemParentId".
+"""
+directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemUrl".
+"""
+directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
+"""
+directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Apply all directives on the right to output on the left.
+"""
+directive @map repeatable on FIELD_DEFINITION
+
+"""
+Load a given entity by it's path or type and id or uuid
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLoad".
+"""
+directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Mark a type as member of a generic.
+The id argument contains a string that has to match the generics resolution.
+"""
+directive @type(id: String!) repeatable on OBJECT
+
+"""
+Provide a default value for a given type.
+"""
+directive @default repeatable on UNION | ENUM | SCALAR | OBJECT | INTERFACE
+
+"""
+Provide a static value as JSON string.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
+"""
+directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Pull a specific typed-data property from an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityProperty".
+"""
+directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Resolve a path to an Url object.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Route".
+"""
+directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve a specific translation of an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslation".
+"""
+directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve all translations of an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslations".
+"""
+directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities bundle.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityBundle".
+"""
+directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities id.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityId".
+"""
+directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities label.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLabel".
+"""
+directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities type id.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityType".
+"""
+directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities url path.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityPath".
+"""
+directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities uuid.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityUuid".
+"""
+directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an images public url.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\ImageUrl".
+"""
+directive @imageUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an object or map property.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop".
+"""
+directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve the language of an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLanguage".
+"""
+directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Seek a specific element in a list.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Seek".
+"""
+directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Directive for the responsive_image data producer.
+
+Provided by the "silverback_cloudinary" module.
+Implemented in "Drupal\silverback_cloudinary\Plugin\GraphQL\Directive\ResponsiveImage".
+"""
+directive @responsiveImage(width: String, height: String, sizes: String, transform: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Fetch an entity or entity revision based on id, rid or route
+
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\EntityFetch".
+"""
+directive @fetchEntity(type: String, id: String, rid: String, language: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve the properties of an image.
+
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\ImageProps".
+"""
+directive @imageProps repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
+"""
+directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMarkup".
+"""
+directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMedia".
+"""
+directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockType".
+"""
+directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Parse a gutenberg document into block data.
+
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlocks".
+"""
+directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an editor block attribute.
+
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockAttribute".
+"""
+directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
 type CampaignUrl @entity(type: "campaign_url", bundle: "campaign_url") {
   source: String! @resolveProperty(path: "campaign_url_source.value")
   destination: String! @resolveProperty(path: "campaign_url_destination.value")

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -376,6 +376,268 @@ type FirstLevelMainMenu @menu(menu_id: "main", max_level: 1) {
 
 type GatsbyStringTranslation @stringTranslation(contextPrefix: "gatsby")
 
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Arg".
+"""
+directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
+"""
+directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
+"""
+directive @resolveEntityReferenceRevisions(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
+"""
+directive @lang(code: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemId".
+"""
+directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemLabel".
+"""
+directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemParentId".
+"""
+directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemUrl".
+"""
+directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
+"""
+directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Apply all directives on the right to output on the left.
+"""
+directive @map repeatable on FIELD_DEFINITION
+
+"""
+Load a given entity by it's path or type and id or uuid
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLoad".
+"""
+directive @loadEntity(route: String, type: String, uuid: String, id: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Mark a type as member of a generic.
+The id argument contains a string that has to match the generics resolution.
+"""
+directive @type(id: String!) repeatable on OBJECT
+
+"""
+Provide a default value for a given type.
+"""
+directive @default repeatable on UNION | ENUM | SCALAR | OBJECT | INTERFACE
+
+"""
+Provide a static value as JSON string.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
+"""
+directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Pull a specific typed-data property from an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityProperty".
+"""
+directive @resolveProperty(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Resolve a path to an Url object.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Route".
+"""
+directive @route(path: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve a specific translation of an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslation".
+"""
+directive @resolveEntityTranslation(lang: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve all translations of an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslations".
+"""
+directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities bundle.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityBundle".
+"""
+directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities id.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityId".
+"""
+directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities label.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLabel".
+"""
+directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities type id.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityType".
+"""
+directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities url path.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityPath".
+"""
+directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities uuid.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityUuid".
+"""
+directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an images public url.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\ImageUrl".
+"""
+directive @imageUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an object or map property.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop".
+"""
+directive @prop(key: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve the language of an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLanguage".
+"""
+directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Seek a specific element in a list.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Seek".
+"""
+directive @seek(pos: Int!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Directive for the responsive_image data producer.
+
+Provided by the "silverback_cloudinary" module.
+Implemented in "Drupal\silverback_cloudinary\Plugin\GraphQL\Directive\ResponsiveImage".
+"""
+directive @responsiveImage(width: String, height: String, sizes: String, transform: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Fetch an entity or entity revision based on id, rid or route
+
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\EntityFetch".
+"""
+directive @fetchEntity(type: String, id: String, rid: String, language: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve the properties of an image.
+
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\ImageProps".
+"""
+directive @imageProps repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
+"""
+directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMarkup".
+"""
+directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMedia".
+"""
+directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockType".
+"""
+directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Parse a gutenberg document into block data.
+
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlocks".
+"""
+directive @resolveEditorBlocks(path: String!, ignored: [String!], aggregated: [String!]) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an editor block attribute.
+
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockAttribute".
+"""
+directive @resolveEditorBlockAttribute(key: String!, plainText: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
 type CampaignUrl @entity(type: "campaign_url", bundle: "campaign_url") {
   source: String! @resolveProperty(path: "campaign_url_source.value")
   destination: String! @resolveProperty(path: "campaign_url_destination.value")

--- a/apps/silverback-drupal/graphqlrc.yml
+++ b/apps/silverback-drupal/graphqlrc.yml
@@ -1,0 +1,3 @@
+schema:
+  - web/modules/custom/silverback_gatsby_test/graphql/silverback_gatsby_test.graphqls
+  - web/modules/contrib/*/directives.graphql

--- a/packages/composer/amazeelabs/graphql_directives/composer.json
+++ b/packages/composer/amazeelabs/graphql_directives/composer.json
@@ -5,6 +5,9 @@
   "description": "Directive based GraphQL schemas for Drupal.",
   "homepage": "https://silverback.netlify.app",
   "license": "GPL-2.0+",
+  "require": {
+    "webmozart/glob": "^4.6.0"
+  },
   "extra": {
     "drush": {
       "services": {

--- a/packages/composer/amazeelabs/graphql_directives/directives.graphql
+++ b/packages/composer/amazeelabs/graphql_directives/directives.graphql
@@ -1,0 +1,225 @@
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Arg".
+"""
+directive @arg(
+  name: String!
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
+"""
+directive @resolveEntityReference(
+  field: String!
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReferenceRevisions".
+"""
+directive @resolveEntityReferenceRevisions(
+  field: String!
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Lang".
+"""
+directive @lang(
+  code: String
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemId".
+"""
+directive @resolveMenuItemId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemLabel".
+"""
+directive @resolveMenuItemLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemParentId".
+"""
+directive @resolveMenuItemParentId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItemUrl".
+"""
+directive @resolveMenuItemUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
+"""
+directive @resolveMenuItems(
+  max_level: Int
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Apply all directives on the right to output on the left.
+"""
+directive @map repeatable on FIELD_DEFINITION
+
+"""
+Load a given entity by it's path or type and id or uuid
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLoad".
+"""
+directive @loadEntity(
+  route: String
+  type: String
+  uuid: String
+  id: String
+  operation: String
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Mark a type as member of a generic.
+The id argument contains a string that has to match the generics resolution.
+"""
+directive @type(id: String!) repeatable on OBJECT
+
+"""
+Provide a default value for a given type.
+"""
+directive @default repeatable on UNION | ENUM | SCALAR | OBJECT | INTERFACE
+
+"""
+Provide a static value as JSON string.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
+"""
+directive @value(
+  json: String!
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Pull a specific typed-data property from an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityProperty".
+"""
+directive @resolveProperty(
+  path: String!
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Resolve a path to an Url object.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Route".
+"""
+directive @route(
+  path: String!
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve a specific translation of an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslation".
+"""
+directive @resolveEntityTranslation(
+  lang: String!
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve all translations of an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityTranslations".
+"""
+directive @resolveEntityTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities bundle.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityBundle".
+"""
+directive @resolveEntityBundle repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities id.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityId".
+"""
+directive @resolveEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities label.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLabel".
+"""
+directive @resolveEntityLabel repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities type id.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityType".
+"""
+directive @resolveEntityType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities url path.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityPath".
+"""
+directive @resolveEntityPath repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an entities uuid.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityUuid".
+"""
+directive @resolveEntityUuid repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an images public url.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\ImageUrl".
+"""
+directive @imageUrl repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an object or map property.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Prop".
+"""
+directive @prop(
+  key: String!
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve the language of an entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityLanguage".
+"""
+directive @resolveEntityLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Seek a specific element in a list.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Seek".
+"""
+directive @seek(
+  pos: Int!
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT

--- a/packages/composer/amazeelabs/graphql_directives/src/ConfigLoader.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/ConfigLoader.php
@@ -1,0 +1,28 @@
+<?php
+namespace Drupal\graphql_directives;
+
+use Symfony\Component\Yaml\Yaml;
+use Webmozart\Glob\Glob;
+
+
+/**
+ * Load a graphql schema from a graphql-config file.
+ * https://the-guild.dev/graphql/config/docs/user/schema#multiple-files
+ *
+ * Only supports local files.
+ */
+class ConfigLoader {
+  public static function loadSchema($configFile) {
+    $configDir = dirname($configFile);
+    $config = Yaml::parseFile($configFile);
+    $configFiles = is_array($config['schema']) ? $config['schema'] : [$config['schema']];
+    $result = [];
+    foreach ($configFiles as $glob) {
+      $files = Glob::glob($configDir . '/' . $glob);
+      foreach ($files as $file) {
+        $result[$file] = file_get_contents($file);
+      }
+    }
+    return implode("\n", $result);
+  }
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Schema/DirectableSchema.php
@@ -11,6 +11,7 @@ use Drupal\graphql\GraphQL\ResolverBuilder;
 use Drupal\graphql\GraphQL\ResolverRegistry;
 use Drupal\graphql\Plugin\GraphQL\Schema\ComposableSchema;
 use Drupal\graphql\Plugin\SchemaExtensionPluginManager;
+use Drupal\graphql_directives\ConfigLoader;
 use Drupal\graphql_directives\DirectableSchemaExtensionPluginBase;
 use Drupal\graphql_directives\DirectiveInterpreter;
 use Drupal\graphql_directives\DirectivePrinter;
@@ -89,9 +90,16 @@ class DirectableSchema extends ComposableSchema {
    */
   public function getSchemaDefinition() {
     $file = $this->configuration['schema_definition'];
+    $rawSchema = false;
+    if (preg_match("/\.yml$/", $file)) {
+      $rawSchema = ConfigLoader::loadSchema(DRUPAL_ROOT.'/'.$file);
+    }
+    else if (file_exists($file)) {
+      $rawSchema = file_get_contents($file);
+    }
     return implode("\n", [
       $this->directivePrinter->printDirectives(),
-      file_exists($file) ? file_get_contents($file) : parent::getSchemaDefinition(),
+      $rawSchema ? $rawSchema : parent::getSchemaDefinition(),
     ]);
   }
 

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/config/directives/test.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/config/directives/test.graphqls
@@ -1,0 +1,1 @@
+directive @test on FIELD_DEFINITION

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/config/graphqlrc-multi.yml
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/config/graphqlrc-multi.yml
@@ -1,0 +1,3 @@
+schema:
+  - '*/*.graphqls'
+  - 'schema.graphqls'

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/config/graphqlrc-single.yml
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/config/graphqlrc-single.yml
@@ -1,0 +1,1 @@
+schema: 'schema.graphqls'

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/config/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/config/schema.graphqls
@@ -1,0 +1,3 @@
+type Query {
+  test: String @test
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/ConfigLoaderTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Unit/ConfigLoaderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\graphql_directives\ConfigLoader;
+
+class ConfigLoaderTest extends UnitTestCase {
+  public function testSingleFile(): void {
+    $configFile = __DIR__ . '/../../assets/config/graphqlrc-single.yml';
+    $this->assertEquals(implode("\n", [
+      'type Query {',
+      '  test: String @test',
+      '}',
+      '',
+    ]), ConfigLoader::loadSchema($configFile));
+  }
+
+  public function testMultipleFiles(): void {
+    $configFile = __DIR__ . '/../../assets/config/graphqlrc-multi.yml';
+    $this->assertEquals(implode("\n", [
+      'directive @test on FIELD_DEFINITION',
+      '',
+      'type Query {',
+      '  test: String @test',
+      '}',
+      '',
+    ]), ConfigLoader::loadSchema($configFile));
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_cloudinary/directives.graphql
+++ b/packages/composer/amazeelabs/silverback_cloudinary/directives.graphql
@@ -1,0 +1,12 @@
+"""
+Directive for the responsive_image data producer.
+
+Provided by the "silverback_cloudinary" module.
+Implemented in "Drupal\silverback_cloudinary\Plugin\GraphQL\Directive\ResponsiveImage".
+"""
+directive @responsiveImage(
+  width: String
+  height: String
+  sizes: String
+  transform: String
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT

--- a/packages/composer/amazeelabs/silverback_gatsby/directives.graphql
+++ b/packages/composer/amazeelabs/silverback_gatsby/directives.graphql
@@ -1,0 +1,21 @@
+"""
+Fetch an entity or entity revision based on id, rid or route
+
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\EntityFetch".
+"""
+directive @fetchEntity(
+  type: String
+  id: String
+  rid: String
+  language: String
+  operation: String
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve the properties of an image.
+
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\ImageProps".
+"""
+directive @imageProps repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT

--- a/packages/composer/amazeelabs/silverback_gutenberg/directives.graphql
+++ b/packages/composer/amazeelabs/silverback_gutenberg/directives.graphql
@@ -1,0 +1,46 @@
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
+"""
+directive @resolveEditorBlockChildren repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMarkup".
+"""
+directive @resolveEditorBlockMarkup repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockMedia".
+"""
+directive @resolveEditorBlockMedia repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockType".
+"""
+directive @resolveEditorBlockType repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Parse a gutenberg document into block data.
+
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlocks".
+"""
+directive @resolveEditorBlocks(
+  path: String!
+  ignored: [String!]
+  aggregated: [String!]
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieve an editor block attribute.
+
+Provided by the "silverback_gutenberg" module.
+Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockAttribute".
+"""
+directive @resolveEditorBlockAttribute(
+  key: String!
+  plainText: Boolean
+) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/graphql-directives`

## Description of changes

Add an option to load and aggregate the graphql schema from a `graphql-config` configuration file.
https://the-guild.dev/graphql/config

## Motivation and context

* Unify schema aggregation across systems (Gatsby, Decap, Drupal ...)
* Remove necessity of "export schema" step.

## How has this been tested?

- [x] Manually
- [x] Unit tests
- [x] Integration tests