### PR TITLE
Gatsby references

### DIFF
--- a/apps/silverback-drupal/config/sync/entity_usage.settings.yml
+++ b/apps/silverback-drupal/config/sync/entity_usage.settings.yml
@@ -3,6 +3,7 @@ _core:
 local_task_enabled_entity_types:
   - media
   - node
+  - taxonomy_term
 track_enabled_source_entity_types:
   - node
   - block_content

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
@@ -6,7 +6,22 @@ use Drupal\user\UserInterface;
 
 
 function _silverback_gatsby_entity_event(EntityInterface $entity) {
-  \Drupal::service('silverback_gatsby.update_handler')->handle(EntityFeed::class, $entity);
+  /** @var \Drupal\silverback_gatsby\GatsbyUpdateHandler $updateHandler */
+  $updateHandler = \Drupal::service('silverback_gatsby.update_handler');
+  $updateHandler->handle(EntityFeed::class, $entity);
+
+  if (\Drupal::hasService('entity_usage.usage')) {
+    /** @var \Drupal\entity_usage\EntityUsage $entityUsage */
+    $entityUsage = \Drupal::service('entity_usage.usage');
+    foreach ($entityUsage->listSources($entity) as $sourceEntityType => $sources) {
+      $entities = \Drupal::entityTypeManager()
+        ->getStorage($sourceEntityType)
+        ->loadMultiple(array_keys($sources));
+      foreach ($entities as $source) {
+        $updateHandler->handle(EntityFeed::class, $source);
+      }
+    }
+  }
 }
 
 /**
@@ -40,6 +55,18 @@ function silverback_gatsby_entity_update(EntityInterface $entity) {
  */
 function silverback_gatsby_entity_predelete(EntityInterface $entity) {
   _silverback_gatsby_entity_event($entity);
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function silverback_gatsby_module_implements_alter(&$implementations, $hook) {
+  // Act before entity_usage module.
+  if (in_array($hook, ['entity_insert', 'entity_update', 'entity_predelete'], TRUE)) {
+    $implementations = [
+      'silverback_gatsby' => $implementations['silverback_gatsby'],
+    ] + $implementations;
+  }
 }
 
 /**

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
@@ -36,9 +36,9 @@ function silverback_gatsby_entity_update(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_entity_delete().
+ * Implements hook_entity_predelete().
  */
-function silverback_gatsby_entity_delete(EntityInterface $entity) {
+function silverback_gatsby_entity_predelete(EntityInterface $entity) {
   _silverback_gatsby_entity_event($entity);
 }
 

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.module
@@ -10,7 +10,7 @@ function _silverback_gatsby_entity_event(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_entity_create().
+ * Implements hook_entity_insert().
  */
 function silverback_gatsby_entity_insert(EntityInterface $entity) {
   _silverback_gatsby_entity_event($entity);

--- a/packages/tests/silverback-gatsby/playwright-tests/references.spec.ts
+++ b/packages/tests/silverback-gatsby/playwright-tests/references.spec.ts
@@ -1,0 +1,37 @@
+import {
+  drupal,
+  drupalLogin,
+  gatsby,
+  resetState,
+  waitForGatsby,
+} from '@amazeelabs/silverback-playwright';
+import { expect, test } from '@playwright/test';
+
+test.beforeAll(async () => {
+  await resetState();
+});
+
+test('@gatsby-build references', async ({ page }) => {
+  // Check the tag present on the page.
+  await page.goto(gatsby.baseUrl);
+  await page.click('a:text-is("With everything")');
+  await expect(page.locator(':text("Tag 1")')).toHaveCount(1);
+
+  // Remove the tag.
+  await drupalLogin(page);
+  await page.goto(
+    `${drupal.baseUrl}/admin/structure/taxonomy/manage/tag/overview`,
+  );
+  await page.click(
+    '.dropbutton-wrapper :text-is("Edit"):right-of(:text-is("Tag 1"))',
+  );
+  await page.click('.tabs--primary :text-is("Delete")');
+  await page.click('.button--primary');
+  await page.waitForSelector(':text("Deleted term")');
+  await waitForGatsby();
+
+  // Check the tag has gone.
+  await page.goto(gatsby.baseUrl);
+  await page.click('a:text-is("With everything")');
+  await expect(page.locator(':text("Tag 1")')).toHaveCount(0);
+});


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

Whenever we track an update on an entity, get all its usages and track the source entities as well.

## Motivation and context

`gatsby-graphql-toolkit` creates node references in Gatsby data layer. Yet it does not clean them up when a target node is removed.

```
    if (node) {
      context.gatsbyApi.actions.deleteNode(node)
    }
    // TODO: find all nodes referencing deleted nodes and update/refetch all of them?
```
https://github.com/gatsbyjs/gatsby-graphql-toolkit/blob/cec93fe2457aa0de64dbdeb759626010d9fe270a/src/source-nodes/node-actions/delete-nodes.ts#L17-L20

## Related Issue(s)

https://github.com/AmazeeLabs/silverback-mono/issues/1274

## How has this been tested?

Manually. Added an integration test case.
