### PR TITLE
refactor: remove oauth scope for publisher auth code

### DIFF
--- a/packages/npm/@amazeelabs/publisher/publisher.config.ts
+++ b/packages/npm/@amazeelabs/publisher/publisher.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   oAuth2: {
     clientId: process.env.OAUTH2_CLIENT_ID || 'publisher',
     clientSecret: process.env.OAUTH2_CLIENT_ID || 'publisher',
+    // Applies for ResourceOwnerPassword only.
     scope: process.env.OAUTH2_SCOPE || 'publisher',
     tokenHost: process.env.OAUTH2_TOKEN_HOST || 'http://127.0.0.1:8888',
     tokenPath: process.env.OAUTH2_TOKEN_PATH || '/oauth/token',

--- a/packages/npm/@amazeelabs/publisher/src/core/tools/oAuth2.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tools/oAuth2.ts
@@ -284,7 +284,6 @@ export const getOAuth2AuthorizeUrl = (
   return client.authorizeURL({
     // Set on the OAuth2 provider.
     //redirect_uri: callbackUrl,
-    scope: oAuth2Config.scope,
     // https://auth0.com/docs/secure/attack-protection/state-parameters
     state: encodedState,
   });
@@ -320,11 +319,7 @@ export const isAuthenticated = async (req: Request): Promise<boolean> => {
       result = true;
     } else {
       try {
-        const refreshParams = {
-          grant_type: 'refresh_token',
-          scope: oAuth2Config.scope,
-        };
-        accessToken = await accessToken.refresh(refreshParams);
+        accessToken = await accessToken.refresh();
         persistAccessToken(accessToken, req);
         result = true;
       } catch (error) {


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

Removed default publisher scope for `AuthorizationCode` grant type as we are removing the default Publisher role in https://github.com/AmazeeLabs/silverback-template/pull/86

It's still set in the Publisher configuration if we want to use `ResourceOwnerPassword` grant type.

## Motivation and context

Make OAuth work without the scope being set in the Consumer.
Access is checked based on the current user permission.

## How has this been tested?

Manually.