### PR TITLE
refactor(graphql): abort js directive chain on null

### DIFF
--- a/packages/npm/@amazeelabs/graphql-directives/src/resolvers.test.ts
+++ b/packages/npm/@amazeelabs/graphql-directives/src/resolvers.test.ts
@@ -17,6 +17,14 @@ const echo: GraphQLFieldResolver<unknown, any, { msg: string }> = (
   { msg },
 ) => new Promise((resolve) => resolve(msg));
 
+const resolveToNull: GraphQLFieldResolver<unknown, any, {}> = () =>
+  new Promise((resolve) => resolve(null));
+
+const throwIfCalled: GraphQLFieldResolver<unknown, any, {}> = () =>
+  new Promise(() => {
+    throw 'parent is undefined';
+  });
+
 describe('extractResolverMapping', () => {
   it('extracts fields with attached directives', () => {
     expect(extractResolverMapping(schema, { echo })).toEqual({
@@ -71,6 +79,17 @@ describe('executeResolver', () => {
     expect(await resolver(undefined, {}, undefined, null as any)).toEqual(
       'my value',
     );
+  });
+
+  it('aborts a chain on null', async () => {
+    const resolver = buildResolver(
+      [
+        ['resolveToNull', {}],
+        ['throwIfCalled', {}],
+      ],
+      { resolveToNull, throwIfCalled },
+    );
+    expect(await resolver(undefined, {}, undefined, null as any)).toEqual(null);
   });
 });
 

--- a/packages/npm/@amazeelabs/graphql-directives/src/resolvers.ts
+++ b/packages/npm/@amazeelabs/graphql-directives/src/resolvers.ts
@@ -5,7 +5,7 @@ import { flow, isString } from 'lodash-es';
 export function createResolveConfig(
   schema: GraphQLSchema,
   directives: Record<string, GraphQLFieldResolver<any, any>>,
-  api?: any
+  api?: any,
 ): Record<string, Record<string, GraphQLFieldResolver<any, any>>> {
   const mapping = extractResolverMapping(schema, directives);
   const config: Record<
@@ -17,7 +17,11 @@ export function createResolveConfig(
       config[type] = {};
     }
     Object.keys(mapping[type]).forEach((field) => {
-      config[type][field] = buildResolver(mapping[type][field], directives, api);
+      config[type][field] = buildResolver(
+        mapping[type][field],
+        directives,
+        api,
+      );
     });
   });
   return config;
@@ -67,7 +71,7 @@ export function extractResolverMapping(
 export function buildResolver(
   config: Array<[string, Record<string, unknown>]>,
   directives: Record<string, Function>,
-  api?: any
+  api?: any,
 ): GraphQLFieldResolver<any, any> {
   return async (source, args, context, info) => {
     const fns = [
@@ -77,6 +81,9 @@ export function buildResolver(
       ...config.map(([name, spec]) => {
         return async (parent: any) => {
           const value = await parent;
+          if (value === null) {
+            return null;
+          }
           return directives[name](
             value,
             processDirectiveArguments(value, args, spec),


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/graphql-directives`

## Description of changes

Directive chains abort if one directive returns null.

## Motivation and context

Align behaviour with GraphQL resolvers in Drupal.

## How has this been tested?

- [x] Unit tests
