### PR TITLE
fix: support fragments in Link component

### DIFF
--- a/packages/npm/@amazeelabs/scalars/src/index.tsx
+++ b/packages/npm/@amazeelabs/scalars/src/index.tsx
@@ -44,14 +44,15 @@ export function overrideUrlParameters(
   hash?: string,
 ): Url {
   if (isUrl(url)) {
-    if (url[0] === '/') {
+    if (['/','#','?','javascript:'].includes(url[0])) {
       return overrideUrlParameters(
         `relative://${url}` as Url,
         search,
         hash,
       ).replace('relative://', '') as Url;
     }
-    const parsed = qs.parseUrl(url);
+    const parsed = qs.parseUrl(url, {parseFragmentIdentifier: true});
+
     return qs.stringifyUrl(
       {
         url: parsed.url,

--- a/packages/npm/@amazeelabs/scalars/src/link.test.ts
+++ b/packages/npm/@amazeelabs/scalars/src/link.test.ts
@@ -37,6 +37,36 @@ describe('overrideUrlParameters', () => {
     );
   });
 
+  it('works with just a search parameter', () => {
+    expect(overrideUrlParameters('?foo=bar' as Url)).toBe(
+        '?foo=bar',
+    );
+  });
+
+  it('works with just javascript', () => {
+    expect(overrideUrlParameters('javascript:void(0);' as Url)).toBe(
+        'javascript:void(0);',
+    );
+  });
+
+  it('works with mailto:', () => {
+    expect(overrideUrlParameters('mailto:foo@bar.com' as Url)).toBe(
+        'mailto:foo@bar.com',
+    );
+  });
+
+  it('works with a relative url and hash', () => {
+    expect(overrideUrlParameters('/foo#bar' as Url )).toBe(
+        '/foo#bar',
+    );
+  });
+
+  it('works with just a hash', () => {
+    expect(overrideUrlParameters('#bar' as Url)).toBe(
+        '#bar',
+    );
+  });
+
   it('allows to add a hash', () => {
     expect(overrideUrlParameters('/foo' as Url, {}, 'bar')).toBe('/foo#bar');
   });


### PR DESCRIPTION
## Package(s) involved

- @amazeelabs/scalars

## Description of changes

Support fragments in links

## Motivation and context

fragments were stripped from URLs when using query-string parseUrl, as parseFragmentIdentifier needs to be set to tru in the function options.

## How has this been tested?

Locally and with vitest 
