### PR TITLE
chore: fix translation resolver

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-translation-query-field.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-translation-query-field.ts
@@ -35,7 +35,7 @@ export const createTranslationQueryField = async (
                 context,
               ) => {
                 return (
-                  (await context.nodeModel.runQuery({
+                  (await context.nodeModel.findOne({
                     query: {
                       filter: {
                         langcode: { eq: args.langcode },
@@ -43,9 +43,8 @@ export const createTranslationQueryField = async (
                       },
                     },
                     type: source.internal.type,
-                    firstOnly: true,
                   })) ||
-                  (await context.nodeModel.runQuery({
+                  (await context.nodeModel.findOne({
                     query: {
                       filter: {
                         defaultTranslation: { eq: true },
@@ -53,7 +52,6 @@ export const createTranslationQueryField = async (
                       },
                     },
                     type: source.internal.type,
-                    firstOnly: true,
                   }))
                 );
               },


### PR DESCRIPTION
`nodeModel.runQuery` was deprecated in Gatsby 4 and removed in Gatsby 5

https://github.com/gatsbyjs/gatsby/blob/4f8c065ae710ac3d80187436d4fcb3b249bbabf3/docs/docs/reference/release-notes/migrating-from-v3-to-v4.md#nodemodelrunquery-is-deprecated