### PR TITLE
Fix Gatsby's `translation` field

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-translation-query-field.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/create-translation-query-field.ts
@@ -27,8 +27,7 @@ export const createTranslationQueryField = async (
               },
               resolve: async (
                 source: {
-                  drupalId: string;
-                  translations: Array<{ langcode: string }>;
+                  _drupalId: string;
                   internal: { type: string };
                 },
                 args: { langcode: string },
@@ -38,8 +37,8 @@ export const createTranslationQueryField = async (
                   (await context.nodeModel.findOne({
                     query: {
                       filter: {
-                        langcode: { eq: args.langcode },
-                        drupalId: { eq: source.drupalId },
+                        _langcode: { eq: args.langcode },
+                        _drupalId: { eq: source._drupalId },
                       },
                     },
                     type: source.internal.type,
@@ -47,8 +46,8 @@ export const createTranslationQueryField = async (
                   (await context.nodeModel.findOne({
                     query: {
                       filter: {
-                        defaultTranslation: { eq: true },
-                        drupalId: { eq: source.drupalId },
+                        _defaultTranslation: { eq: true },
+                        _drupalId: { eq: source._drupalId },
                       },
                     },
                     type: source.internal.type,


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/gatsby-source-silverback`

## Motivation and context

Some bits of code were not updated in https://github.com/AmazeeLabs/silverback-mono/pull/1432

## How has this been tested?

Manually on a project using `translation` field.
