### PR TITLE
SLB-202: inline fragments in operations

### DIFF
--- a/packages/npm/@amazeelabs/codegen-operation-ids/src/index.test.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/src/index.test.ts
@@ -135,8 +135,8 @@ describe('mode: map', () => {
     ]);
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
-        "Home:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
-        loadPage(path: \\"/\\") {
+        "Home:37b18153e5d5ac538e6f4b371203b73e0b273d9ea2cd26c8b8eeed655c229db6": "query Home {
+        loadPage(path: "/") {
           title
         }
       }",
@@ -162,8 +162,8 @@ describe('mode: map', () => {
     ]);
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
-        "Home:c620d8758f07daaf2feb128e0c3528520075759288d46dee708d324a6aa44ca7": "query Home {
-        loadPage(path: \\"/\\") {
+        "Home:126fe24c4e0358d329a4f1699ece318fbe6c2a6c7f771f240402ccac2dcde676": "query Home {
+        loadPage(path: "/") {
           title
           related {
             title
@@ -190,8 +190,8 @@ describe('mode: map', () => {
     ]);
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
-        "Home:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
-        loadPage(path: \\"/\\") {
+        "Home:126fe24c4e0358d329a4f1699ece318fbe6c2a6c7f771f240402ccac2dcde676": "query Home {
+        loadPage(path: "/") {
           title
           related {
             title
@@ -223,8 +223,8 @@ describe('mode: map', () => {
     ]);
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
-        "Home:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
-        loadPage(path: \\"/\\") {
+        "Home:37b18153e5d5ac538e6f4b371203b73e0b273d9ea2cd26c8b8eeed655c229db6": "query Home {
+        loadPage(path: "/") {
           title
         }
       }",
@@ -259,8 +259,8 @@ describe('mode: map', () => {
     ]);
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
-        "Home:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
-        loadPage(path: \\"/\\") {
+        "Home:126fe24c4e0358d329a4f1699ece318fbe6c2a6c7f771f240402ccac2dcde676": "query Home {
+        loadPage(path: "/") {
           title
           related {
             title
@@ -330,7 +330,7 @@ describe('mode: ids', () => {
 
       export type OperationVariables<TQueryID extends OperationId<any, any>> =
         TQueryID['___query_variables'];
-      export const HomeQuery = "Home:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d" as OperationId<HomeQuery,HomeQueryVariables | undefined>;"
+      export const HomeQuery = "Home:37b18153e5d5ac538e6f4b371203b73e0b273d9ea2cd26c8b8eeed655c229db6" as OperationId<HomeQuery,HomeQueryVariables | undefined>;"
     `);
   });
 

--- a/packages/npm/@amazeelabs/codegen-operation-ids/src/index.test.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/src/index.test.ts
@@ -136,17 +136,14 @@ describe('mode: map', () => {
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
         "Home:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
-        loadPage(path: "/") {
-          ...Page
+        loadPage(path: \\"/\\") {
+          title
         }
-      }
-      fragment Page on Page {
-        title
       }",
       }
     `);
   });
-  it('de-duplicates fragments', async () => {
+  it('inlines multiple invocations', async () => {
     const result = await runPlugin([
       {
         location: 'a.gql',
@@ -166,15 +163,12 @@ describe('mode: map', () => {
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
         "Home:c620d8758f07daaf2feb128e0c3528520075759288d46dee708d324a6aa44ca7": "query Home {
-        loadPage(path: "/") {
-          ...Page
+        loadPage(path: \\"/\\") {
+          title
           related {
-            ...Page
+            title
           }
         }
-      }
-      fragment Page on Page {
-        title
       }",
       }
     `);
@@ -197,18 +191,12 @@ describe('mode: map', () => {
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
         "Home:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
-        loadPage(path: "/") {
-          ...Page
+        loadPage(path: \\"/\\") {
+          title
+          related {
+            title
+          }
         }
-      }
-      fragment Page on Page {
-        title
-        related {
-          ...RelatedPage
-        }
-      }
-      fragment RelatedPage on Page {
-        title
       }",
       }
     `);
@@ -236,12 +224,9 @@ describe('mode: map', () => {
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
         "Home:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
-        loadPage(path: "/") {
-          ...Page
+        loadPage(path: \\"/\\") {
+          title
         }
-      }
-      fragment Page on Page {
-        title
       }",
       }
     `);
@@ -275,18 +260,12 @@ describe('mode: map', () => {
     expect(JSON.parse(result)).toMatchInlineSnapshot(`
       {
         "Home:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
-        loadPage(path: "/") {
-          ...Page
+        loadPage(path: \\"/\\") {
+          title
+          related {
+            title
+          }
         }
-      }
-      fragment Page on Page {
-        title
-        related {
-          ...RelatedPage
-        }
-      }
-      fragment RelatedPage on Page {
-        title
       }",
       }
     `);

--- a/packages/npm/@amazeelabs/codegen-operation-ids/src/inline.test.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/src/inline.test.ts
@@ -1,0 +1,93 @@
+import {
+  DefinitionNode,
+  FragmentDefinitionNode,
+  Kind,
+  OperationDefinitionNode,
+  parse,
+  print,
+} from 'graphql';
+import { describe, expect, it } from 'vitest';
+
+import { inlineFragments } from './inline';
+
+function isFragmentDefinitionNode(
+  def: DefinitionNode,
+): def is FragmentDefinitionNode {
+  return def.kind === Kind.FRAGMENT_DEFINITION;
+}
+
+function isOperationDefinitionNode(
+  def: DefinitionNode,
+): def is OperationDefinitionNode {
+  return def.kind === Kind.OPERATION_DEFINITION;
+}
+
+describe('inlineFragments', () => {
+  it('inlines a fragment into a query', () => {
+    const doc = parse(`
+  query {
+      ...A
+  }
+  fragment A on Query {
+    myprop
+  }
+  `);
+    const [query] = doc.definitions.filter(isOperationDefinitionNode);
+    const [A] = doc.definitions.filter(isFragmentDefinitionNode);
+    const inlined = inlineFragments(query, new Map(Object.entries({ A })));
+    expect(print(inlined)).toEqual(`{
+  myprop
+}`);
+  });
+
+  it('inlines a fragment into a field', () => {
+    const doc = parse(`
+  query {
+    a {
+      ...A
+    }
+  }
+  fragment A on A {
+    myprop
+  }
+  `);
+    const [query] = doc.definitions.filter(isOperationDefinitionNode);
+    const [A] = doc.definitions.filter(isFragmentDefinitionNode);
+    const inlined = inlineFragments(query, new Map(Object.entries({ A })));
+    expect(print(inlined)).toEqual(`{
+  a {
+    myprop
+  }
+}`);
+  });
+
+  it('inlines nested fragments', () => {
+    const doc = parse(`query {
+  a {
+    propA
+    ...A
+  }
+}
+fragment A on A {
+  propA
+  propB {
+    ...B
+  }
+}
+fragment B on B {
+  propC
+}`);
+    const [query] = doc.definitions.filter(isOperationDefinitionNode);
+    const [A, B] = doc.definitions.filter(isFragmentDefinitionNode);
+    const inlined = inlineFragments(query, new Map(Object.entries({ A, B })));
+    expect(print(inlined)).toEqual(`{
+  a {
+    propA
+    propA
+    propB {
+      propC
+    }
+  }
+}`);
+  });
+});

--- a/packages/npm/@amazeelabs/codegen-operation-ids/src/inline.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/src/inline.ts
@@ -1,0 +1,33 @@
+import {
+  ExecutableDefinitionNode,
+  FieldNode,
+  FragmentDefinitionNode,
+  Kind,
+  SelectionNode,
+} from 'graphql';
+
+export function inlineFragments<
+  TNode extends ExecutableDefinitionNode | FieldNode,
+>(target: TNode, fragments: Map<string, FragmentDefinitionNode>): TNode {
+  const selections = [] as Array<SelectionNode>;
+  target.selectionSet?.selections.forEach((sel) => {
+    if (sel.kind === Kind.FRAGMENT_SPREAD) {
+      const fragment = fragments.get(sel.name.value);
+      if (fragment) {
+        inlineFragments(fragment, fragments).selectionSet.selections.forEach(
+          (sel) => {
+            selections.push(sel);
+          },
+        );
+      }
+    } else if (sel.kind === Kind.FIELD && sel.selectionSet) {
+      selections.push(inlineFragments(sel, fragments));
+    } else {
+      selections.push(sel);
+    }
+  });
+  if (target.selectionSet) {
+    target.selectionSet.selections = selections;
+  }
+  return target;
+}


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/codegen-operation-ids`

## Description of changes

Instead of appending fragments to each operation, they are inlined now.

Before:
```graphql
query {
  ...MyFragment
}

fragment MyFragment on Query {
  myProp
}
```

After:
```graphql
query {
  myProp
}
```

## Motivation and context

Gatsby breaks if it encounters multiple fragments. This change allows us to use the same queries in Gatsby directly, without having duplicate them there.

## Related Issue(s)

[SLB-202](https://amazeelabs.atlassian.net/browse/SLB-202)

## How has this been tested?

- [x] unit tests


[SLB-202]: https://amazeelabs.atlassian.net/browse/SLB-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ