### PR TITLE
fix: wrap fragments while inlining, or unions will break

### DIFF
--- a/packages/npm/@amazeelabs/codegen-operation-ids/src/index.test.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/src/index.test.ts
@@ -137,7 +137,9 @@ describe('mode: map', () => {
       {
         "HomeQuery:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
         loadPage(path: "/") {
-          title
+          ... on Page {
+            title
+          }
         }
       }",
       }
@@ -166,16 +168,22 @@ describe('mode: map', () => {
       {
         "HomeQuery:e8b5953fe0f339244ebb14102eddc5d0e23259606de6f697574f69bfe468ac53": "query Home {
         loadPage(path: "/") {
-          title
-          related {
-            path
-          }
-          related {
+          ... on Page {
             title
             related {
               path
             }
-            path
+          }
+          related {
+            ... on Page {
+              title
+              related {
+                path
+              }
+            }
+            ... on Page {
+              path
+            }
           }
         }
       }",
@@ -201,9 +209,13 @@ describe('mode: map', () => {
       {
         "HomeQuery:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
         loadPage(path: "/") {
-          title
-          related {
+          ... on Page {
             title
+            related {
+              ... on Page {
+                title
+              }
+            }
           }
         }
       }",
@@ -234,7 +246,9 @@ describe('mode: map', () => {
       {
         "HomeQuery:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
         loadPage(path: "/") {
-          title
+          ... on Page {
+            title
+          }
         }
       }",
       }
@@ -270,9 +284,13 @@ describe('mode: map', () => {
       {
         "HomeQuery:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d": "query Home {
         loadPage(path: "/") {
-          title
-          related {
+          ... on Page {
             title
+            related {
+              ... on Page {
+                title
+              }
+            }
           }
         }
       }",

--- a/packages/npm/@amazeelabs/codegen-operation-ids/src/inline.test.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/src/inline.test.ts
@@ -36,7 +36,9 @@ describe('inlineFragments', () => {
     const [A] = doc.definitions.filter(isFragmentDefinitionNode);
     const inlined = inlineFragments(query, new Map(Object.entries({ A })));
     expect(print(inlined)).toEqual(`{
-  myprop
+  ... on Query {
+    myprop
+  }
 }`);
   });
 
@@ -56,7 +58,9 @@ describe('inlineFragments', () => {
     const inlined = inlineFragments(query, new Map(Object.entries({ A })));
     expect(print(inlined)).toEqual(`{
   a {
-    myprop
+    ... on A {
+      myprop
+    }
   }
 }`);
   });
@@ -83,9 +87,13 @@ fragment B on B {
     expect(print(inlined)).toEqual(`{
   a {
     propA
-    propA
-    propB {
-      propC
+    ... on A {
+      propA
+      propB {
+        ... on B {
+          propC
+        }
+      }
     }
   }
 }`);


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/codegen-operation-ids`

## Description of changes

Wrap fragment selections in inline fragments while while inlining.

## Motivation and context

Unions break without a type condtion.

## Related Issue(s)

SLB-202

## How has this been tested?

- [x] unit tests

