### PR TITLE
chore(SLB-201): move @amazeelabs/gatsby-plugin-static-dirs into shared space

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-plugin-static-dirs/README.md
+++ b/packages/npm/@amazeelabs/gatsby-plugin-static-dirs/README.md
@@ -1,0 +1,20 @@
+# Static directories plugin
+
+Gatsby plugin for adding multiple static directories. It allows to map any
+directory to a subdirectory of static assets.
+
+Configuration:
+
+```js
+export const plugins = [
+  {
+    resolve: '@amazeelabs/gatsby-plugin-static-dirs',
+    options: {
+      directories: {
+        'some/root/assets': '/',
+        'path/to/admin/app': '/admin',
+      },
+    },
+  },
+];
+```

--- a/packages/npm/@amazeelabs/gatsby-plugin-static-dirs/gatsby-node.js
+++ b/packages/npm/@amazeelabs/gatsby-plugin-static-dirs/gatsby-node.js
@@ -1,0 +1,35 @@
+import { cpSync } from 'fs';
+import serve from 'serve-static';
+
+/**
+ * @type {import('gatsby').GatsbyNode['pluginOptionsSchema']}
+ */
+export const pluginOptionsSchema = ({ Joi }) => {
+  return Joi.object({
+    directories: Joi.object().pattern(Joi.string(), Joi.string()),
+  });
+};
+
+/**
+ * @type {import('gatsby').GatsbyNode['onPreBuild']}
+ */
+export const onPreBuild = (_, options) => {
+  Object.keys(options.directories).forEach((src) => {
+    const dest = options.directories[src];
+    cpSync(src, `public${dest}`, {
+      force: true,
+      recursive: true,
+      errorOnExist: false,
+    });
+  });
+};
+
+/**
+ * @type {import('gatsby').GatsbyNode['onCreateDevServer']}
+ */
+export const onCreateDevServer = ({ app }, options) => {
+  Object.keys(options.directories).forEach((src) => {
+    const dest = options.directories[src];
+    app.use(dest, serve(src));
+  });
+};

--- a/packages/npm/@amazeelabs/gatsby-plugin-static-dirs/package.json
+++ b/packages/npm/@amazeelabs/gatsby-plugin-static-dirs/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@amazeelabs/gatsby-plugin-static-dirs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "gatsby-node.js",
+  "type": "module",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "tsc --noEmit"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "gatsby": "^5.13.1",
+    "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "serve-static": "^1.15.0"
+  }
+}

--- a/packages/npm/@amazeelabs/gatsby-plugin-static-dirs/tsconfig.json
+++ b/packages/npm/@amazeelabs/gatsby-plugin-static-dirs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "checkJs": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,19 @@ importers:
         specifier: ^1.1.0
         version: 1.1.3(@types/node@18.19.6)(@vitest/ui@1.1.3)(happy-dom@12.10.3)
 
+  packages/npm/@amazeelabs/gatsby-plugin-static-dirs:
+    dependencies:
+      serve-static:
+        specifier: ^1.15.0
+        version: 1.15.0
+    devDependencies:
+      gatsby:
+        specifier: ^5.13.1
+        version: 5.13.1(babel-eslint@10.1.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
+
   packages/npm/@amazeelabs/gatsby-silverback-cloudinary:
     devDependencies:
       '@amazeelabs/cloudinary-responsive-image':
@@ -5467,7 +5480,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0(graphql@16.8.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
       graphql: 16.8.1
-      tslib: 2.4.1
+      tslib: 2.6.2
     transitivePeerDependencies:
       - encoding
       - supports-color


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/gatsby-plugin-static-dirs`

## Description of changes

Move the plugin developed in `silverback-template` into the shared space.

## Motivation and context

Don't duplicate the code everywhere.

## Related Issue(s)

SLB-201

## How has this been tested?

- [x] Manually
- [x] Integration tests
