### PR TITLE
feat(SLB-255): allow primitive values in @value directive

### DIFF
--- a/apps/silverback-drupal/generated/extra.composed.graphqls
+++ b/apps/silverback-drupal/generated/extra.composed.graphqls
@@ -130,7 +130,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+directive @value(json: String, int: Int, float: Float, string: String, boolean: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.

--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -130,7 +130,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+directive @value(json: String, int: Int, float: Float, string: String, boolean: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.
@@ -468,7 +468,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+directive @value(json: String, int: Int, float: Float, string: String, boolean: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -130,7 +130,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+directive @value(json: String, int: Int, float: Float, string: String, boolean: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.
@@ -468,7 +468,7 @@ Provide a static value as JSON string.
 Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
-directive @value(json: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+directive @value(json: String, int: Int, float: Float, string: String, boolean: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Pull a specific typed-data property from an entity.

--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -10,7 +10,7 @@ Create a GraphQL schema definition file, and annotate it with directives.
 
 ```graphql
 type Query {
-  hello: String @value(json: "\"Hello world!\"")
+  hello: String @value(string: "Hello world!")
 }
 ```
 
@@ -67,17 +67,17 @@ For custom types, interface, unions or scalars, the `@default` directive can be
 used to start a directive chain that generates a default value.
 
 ```graphql
-scalar MyScalar @default @value(json: "\"bar\"")
+scalar MyScalar @default @value(string: "bar")
 
 type Query {
   # This will emit `''`.
-  string: String! @value(json: "null")
+  string: String! @value
   # This will emit `0`.
-  int: Int! @value(json: "null")
+  int: Int! @value
   # This will emit `[]`.
-  list: [String!]! @value(json: "null")
+  list: [String!]! @value
   # This will emit `bar`
-  manual: MyScalar! @value(json: "null")
+  manual: MyScalar! @value
 }
 ```
 
@@ -117,7 +117,7 @@ Arguments that implement this behaviour are marked to be (dynamic).
 ```graphql
 type Query {
   static: Post @loadEntity(type: "node", id: "1")
-  parent: Post @value(json: "1") @loadEntity(type: "node", id: "$")
+  parent: Post @value(int: 1) @loadEntity(type: "node", id: "$")
   argument(id: String!): Post @loadEntity(type: "node", id: "$id")
 }
 ```
@@ -126,12 +126,17 @@ type Query {
 
 ### `@value`
 
-The `@value` directive allows you to define a static value for a field as a JSON
-encoded string.
+The `@value` directive allows you to define a static value for a field as primitive
+or a JSON encoded string. Without any arguments, it will emit `null`.
 
 ```graphql
 type Query {
-  hello: String @value(json: "\"Hello world!\"")
+  null: String @value
+  hello: String! @value(string: "Hello world!")
+  theAnswer: Int! @value(int: 42)
+  pi: Float! @value(float: 3.14)
+  true: Boolean! @value(float: true)
+  object: MyType! @value(json: "{\"foo\":\"bar\"}")
 }
 ```
 

--- a/packages/composer/amazeelabs/graphql_directives/directives.graphql
+++ b/packages/composer/amazeelabs/graphql_directives/directives.graphql
@@ -99,7 +99,11 @@ Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\Value".
 """
 directive @value(
-  json: String!
+  json: String
+  int: Int
+  float: Float
+  string: String
+  boolean: Boolean
 ) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Value.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/Value.php
@@ -12,7 +12,11 @@ use Drupal\graphql_directives\DirectiveInterface;
  *   id = "value",
  *   description = "Provide a static value as JSON string.",
  *   arguments = {
- *     "json" = "String!",
+ *     "json" = "String",
+ *     "int" = "Int",
+ *     "float" = "Float",
+ *     "string" = "String",
+ *     "boolean" = "Boolean"
  *   }
  * )
  */
@@ -25,6 +29,14 @@ class Value extends PluginBase implements DirectiveInterface {
     ResolverBuilder $builder,
     array $arguments
   ) : ResolverInterface {
-    return $builder->fromValue(json_decode($arguments['json']));
+    if (array_key_exists('json', $arguments)) {
+      return $builder->fromValue(json_decode($arguments['json']));
+    }
+    foreach(['string', 'int', 'float', 'boolean'] as $key) {
+      if (array_key_exists($key, $arguments)) {
+        return $builder->fromValue($arguments[$key]);
+      }
+    }
+    return $builder->fromValue(NULL);
   }
 }

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/utilities/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/utilities/schema.graphqls
@@ -1,6 +1,10 @@
 directive @unknown on FIELD_DEFINITION
 
 type Query {
+  primitiveString: String! @value(string: "foo")
+  primitiveInt: Int! @value(int: 42)
+  primitiveFloat: Float! @value(float: 3.14)
+  primitiveBoolean: Boolean! @value(boolean: true)
   foo: String! @value(json: "\"bar\"")
   bar: String @unknown
   seek: String! @value(json: "[\"one\", \"two\"]") @seek(pos: 1)

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/UtilitiesTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/UtilitiesTest.php
@@ -24,6 +24,13 @@ class UtilitiesTest extends GraphQLTestBase {
     $this->assertResults('{ foo }', [], ['foo' => 'bar']);
   }
 
+  function testValuePrimitives() {
+    $this->assertResults('{ primitiveString }', [], ['primitiveString' => 'foo']);
+    $this->assertResults('{ primitiveInt }', [], ['primitiveInt' => 42]);
+    $this->assertResults('{ primitiveFloat }', [], ['primitiveFloat' => 3.14]);
+    $this->assertResults('{ primitiveBoolean }', [], ['primitiveBoolean' => true]);
+  }
+
   function testSeekDirective() {
     $this->assertResults('{ seek }', [], ['seek' => 'two']);
   }


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/graphql_directives`

## Description of changes

Add additional `int`, `float`, `string` and `boolean` parameters to the `@value` directive.

## Motivation and context

A little nicer GraphQL code when we don't have to encode objects.

## Related Issue(s)

SLB-255

## How has this been tested?

* Unit tests
