### PR TITLE
feat(graphql-directives): pass through source value if appropriate

### DIFF
--- a/packages/npm/@amazeelabs/graphql-directives/src/resolvers.test.ts
+++ b/packages/npm/@amazeelabs/graphql-directives/src/resolvers.test.ts
@@ -57,6 +57,14 @@ describe('executeResolver', () => {
       } as any),
     ).toEqual('parent value');
   });
+  it('passes through the the parent value if it does not have the property', async () => {
+    const resolver = buildResolver([['echo', { msg: '$' }]], { echo });
+    expect(
+      await resolver({ prop: 'parent value' }, {}, undefined, {
+        fieldName: 'p',
+      } as any),
+    ).toEqual({ prop: 'parent value' });
+  });
   it('passes through arguments', async () => {
     const resolver = buildResolver([['echo', { msg: '$msg' }]], { echo });
     expect(

--- a/packages/npm/@amazeelabs/graphql-directives/src/resolvers.ts
+++ b/packages/npm/@amazeelabs/graphql-directives/src/resolvers.ts
@@ -76,7 +76,12 @@ export function buildResolver(
   return async (source, args, context, info) => {
     const fns = [
       (parent: any) => {
-        return parent?.[info?.fieldName];
+        if (parent && info) {
+          if (Object.hasOwn(parent, info.fieldName)) {
+            return parent?.[info?.fieldName];
+          }
+        }
+        return parent;
       },
       ...config.map(([name, spec]) => {
         return async (parent: any) => {


### PR DESCRIPTION

## Package(s) involved

`@amazeelabs/directives`

## Description of changes

If the source value has a property that matches the field name, use that, otherwise pass in the source value itself.

## Motivation and context

In some cases we want to post-process values of fields (e.g. image sources), in others we need to work with the source object.

## How has this been tested?

- Unit tests
