### PR TITLE
chore: add legacy directives for easy v2-to-v3 migrations

### DIFF
--- a/apps/silverback-drupal/generated/extra.composed.graphqls
+++ b/apps/silverback-drupal/generated/extra.composed.graphqls
@@ -53,6 +53,30 @@ Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
 directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\EntityTranslationsWithDefault".
+"""
+directive @entityTranslationsWithDefault repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\MenuLangcode".
+"""
+directive @menuLangcode repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\MenuTranslations".
+"""
+directive @menuTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\SilverbackGatsbyEntityId".
+"""
+directive @silverbackGatsbyEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
 """

--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -53,6 +53,30 @@ Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
 directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\EntityTranslationsWithDefault".
+"""
+directive @entityTranslationsWithDefault repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\MenuLangcode".
+"""
+directive @menuLangcode repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\MenuTranslations".
+"""
+directive @menuTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\SilverbackGatsbyEntityId".
+"""
+directive @silverbackGatsbyEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
 """

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -53,6 +53,30 @@ Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\MenuItems".
 directive @resolveMenuItems(max_level: Int) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\EntityTranslationsWithDefault".
+"""
+directive @entityTranslationsWithDefault repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\MenuLangcode".
+"""
+directive @menuLangcode repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\MenuTranslations".
+"""
+directive @menuTranslations repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "silverback_gatsby" module.
+Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\SilverbackGatsbyEntityId".
+"""
+directive @silverbackGatsbyEntityId repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
 Provided by the "silverback_gutenberg" module.
 Implemented in "Drupal\silverback_gutenberg\Plugin\GraphQL\Directive\EditorBlockChildren".
 """

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/EntityTranslationsWithDefault.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/EntityTranslationsWithDefault.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\GraphQL\Directive;
+
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+
+/**
+ * @deprecated
+ *
+ * Duplicates EntityFeed::resolveTranslations().
+ *
+ * @Directive(
+ *   id = "entityTranslationsWithDefault"
+ * )
+ */
+class EntityTranslationsWithDefault implements  DirectiveInterface {
+
+  public function buildResolver(ResolverBuilder $builder, $arguments): ResolverInterface {
+    return $builder->defaultValue(
+      $builder->compose(
+        $builder->produce('entity_translations')->map('entity', $builder->fromParent()),
+        $builder->callback(fn ($entities) => $entities ? array_filter($entities) : NULL)
+      ),
+      $builder->callback(fn ($value) => [$value])
+    );
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/MenuLangcode.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/MenuLangcode.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\GraphQL\Directive;
+
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+use Drupal\system\Entity\Menu;
+
+/**
+ * @deprecated
+ *
+ * Duplicates MenuFeed::resolveLangcode().
+ *
+ * @Directive(
+ *   id = "menuLangcode"
+ * )
+ */
+class MenuLangcode implements  DirectiveInterface {
+
+  public function buildResolver(ResolverBuilder $builder, $arguments): ResolverInterface {
+    return $builder->callback(
+      fn (Menu $value) => $value->language()->getId()
+    );
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/MenuTranslations.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/MenuTranslations.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\GraphQL\Directive;
+
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+use Drupal\system\Entity\Menu;
+
+/**
+ *
+ * @deprecated
+ *
+ * Duplicates MenuFeed::resolveTranslations().
+ *
+ * @Directive(
+ *   id = "menuTranslations"
+ * )
+ */
+class MenuTranslations implements DirectiveInterface {
+
+  public function buildResolver(ResolverBuilder $builder, $arguments): ResolverInterface {
+    return $builder->compose($builder->callback(function(Menu $menu) {
+      return array_map(
+        function(LanguageInterface $lang) use ($menu) {
+          $clone = clone $menu;
+          $clone->set('langcode', $lang->getId());
+          return $clone;
+        },
+        \Drupal::languageManager()->getLanguages()
+      );
+    }));
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/SilverbackGatsbyEntityId.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/SilverbackGatsbyEntityId.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\GraphQL\Directive;
+
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+
+/**
+ * @deprecated
+ *
+ * Duplicates a part of SilverbackGatsbySchemaExtension::addFieldResolvers().
+ *
+ * @Directive(
+ *   id = "silverbackGatsbyEntityId"
+ * )
+ */
+class SilverbackGatsbyEntityId implements  DirectiveInterface {
+
+  public function buildResolver(ResolverBuilder $builder, $arguments): ResolverInterface {
+    $idResolver = $builder->produce('entity_uuid')
+      ->map('entity', $builder->fromParent());
+    $langcodeResolver = $builder->callback(
+      fn (TranslatableInterface $value) => $value->language()->getId()
+    );
+    return $builder->produce('gatsby_build_id')
+      ->map('id', $idResolver)
+      ->map('langcode', $langcodeResolver);
+  }
+
+}


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

Directives for easy silverback_gatsby v3 migrations

## Related Issue(s)

SLB-244

## How has this been tested?

It was not
