### PR TITLE
SLB-269: translatable strings in full-directive schemas

### DIFF
--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -685,6 +685,8 @@ directive @menu(menu_id: String, menu_ids: [String!], item_type: String, max_lev
 
 directive @stringTranslation(contextPrefix: String) on OBJECT
 
+directive @translatableString(contextPrefix: String) on OBJECT
+
 type _Feed {
   typeName: String!
   translatable: Boolean!

--- a/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby_preview.composed.graphqls
@@ -685,6 +685,8 @@ directive @menu(menu_id: String, menu_ids: [String!], item_type: String, max_lev
 
 directive @stringTranslation(contextPrefix: String) on OBJECT
 
+directive @translatableString(contextPrefix: String) on OBJECT
+
 type _Feed {
   typeName: String!
   translatable: Boolean!

--- a/packages/composer/amazeelabs/silverback_gatsby/graphql/stringTranslation.directive.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/graphql/stringTranslation.directive.graphqls
@@ -1,4 +1,4 @@
 # Directive for the "StringTranslationFeed" plugin.
-directive @stringTranslation(
-  contextPrefix: String
-) on OBJECT
+# DEPRECATED: Use @translatableString instead, when working with a directive
+# based schema.
+directive @stringTranslation(contextPrefix: String) on OBJECT

--- a/packages/composer/amazeelabs/silverback_gatsby/graphql/translatableString.directive.graphqls
+++ b/packages/composer/amazeelabs/silverback_gatsby/graphql/translatableString.directive.graphqls
@@ -1,0 +1,2 @@
+# Directive for the "StringTranslationFeed" plugin.
+directive @translatableString(contextPrefix: String) on OBJECT

--- a/packages/composer/amazeelabs/silverback_gatsby/src/LocaleStorageDecorator.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/LocaleStorageDecorator.php
@@ -5,6 +5,7 @@ namespace Drupal\silverback_gatsby;
 use Drupal\locale\StringContextInterface;
 use Drupal\locale\StringStorageInterface;
 use Drupal\silverback_gatsby\Plugin\Gatsby\Feed\StringTranslationFeed;
+use Drupal\silverback_gatsby\Plugin\Gatsby\Feed\TranslatableStringFeed;
 
 class LocaleStorageDecorator implements StringStorageInterface, StringContextInterface {
 
@@ -85,6 +86,7 @@ class LocaleStorageDecorator implements StringStorageInterface, StringContextInt
     // reasons.
     if (!empty($string->context)) {
       $this->getGatsbyUpdateHandler()->handle(StringTranslationFeed::class, $string);
+      $this->getGatsbyUpdateHandler()->handle(TranslatableStringFeed::class, $string);
     }
     return $this;
   }

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/StringTranslationFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/StringTranslationFeed.php
@@ -15,6 +15,9 @@ use GraphQL\Language\AST\DocumentNode;
 /**
  * Feed plugin that creates Gatsby feeds based on Drupal string translations.
  *
+ * DEPRECATED: Use @translatableString instead, when working with a directive
+ * based schema.
+ *
  * @GatsbyFeed(
  *   id = "stringTranslation"
  * )

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/TranslatableStringFeed.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/Gatsby/Feed/TranslatableStringFeed.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\Gatsby\Feed;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\locale\StringInterface;
+use Drupal\locale\TranslationString;
+use Drupal\silverback_gatsby\Plugin\FeedBase;
+
+/**
+ * Feed plugin that sources string translations into Gatsby.
+ *
+ * @GatsbyFeed(
+ *   id = "translatableString"
+ * )
+ */
+class TranslatableStringFeed extends FeedBase {
+
+  /**
+   * The context prefix, matching the drupal translation context.
+   */
+  protected string $contextPrefix;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(
+    $config,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    $this->contextPrefix = $config['contextPrefix'];
+    parent::__construct($config, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getUpdateIds($context, ?AccountInterface $account): array {
+    if (!$context instanceof StringInterface) {
+      return [];
+    }
+
+    // If the string has the 'context' property, we only return its id if it has
+    // the context prefix match. If there's no context property, then we return
+    // its id in any case.
+    if (!isset($context->context) || empty($this->contextPrefix)) {
+      return [$context->getId()];
+    }
+    if (strpos($context->context, $this->contextPrefix) === 0) {
+      return [$context->getId()];
+    }
+    return [];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function isTranslatable(): bool {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function resolveId(): ResolverInterface {
+    return $this->builder->produce('string_id')
+      ->map('string', $this->builder->fromParent());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function resolveLangcode(): ResolverInterface {
+    return $this->builder->callback(
+      fn(StringInterface $value) => $value instanceof TranslationString ? $value->language : 'en'
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function resolveDefaultTranslation(): ResolverInterface {
+    return $this->builder->callback(
+      fn(StringInterface $value) => FALSE
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function resolveTranslations(): ResolverInterface {
+    return $this->builder->produce('string_translations')
+      ->map('sourceString', $this->builder->fromParent());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function resolveItems(ResolverInterface $limit, ResolverInterface $offset): ResolverInterface {
+    return $this->builder->produce('list_strings')
+      ->map('offset', $this->builder->defaultValue(
+        $this->builder->fromArgument('offset'),
+        $this->builder->fromValue(0)
+      ))
+      ->map('limit', $this->builder->defaultValue(
+        $this->builder->fromArgument('limit'),
+        $this->builder->fromValue(10),
+      ))
+      // For now, the schema extension does not allow array arguments. However,
+      // the list strings resolver can do that, so we just convert the context
+      // prefix to an array here. By doing that, when we add support for array
+      // arguments in directives, we don't have to change this code.
+      ->map('translationContext', $this->builder->fromValue(is_array($this->contextPrefix) ? $this->contextPrefix : [$this->contextPrefix]));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function resolveItem(ResolverInterface $id, ?ResolverInterface $langcode = NULL): ResolverInterface {
+    $resolver = $this->builder->produce('fetch_translatable_string')
+      ->map('id', $id)
+      ->map('language', $langcode);
+    return $resolver;
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchTranslatableString.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchTranslatableString.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\locale\StringStorageInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ *
+ * Loads a single string or translated string.
+ *
+ * @DataProducer(
+ *   id = "fetch_translatable_string",
+ *   name = @Translation("Fetch translatable string"),
+ *   description = @Translation("Loads a single translatable string."),
+ *   produces = @ContextDefinition("any",
+ *     label = @Translation("String")
+ *   ),
+ *   consumes = {
+ *     "id" = @ContextDefinition("string",
+ *       label = @Translation("Identifier"),
+ *       required = FALSE
+ *     ),
+ *     "language" = @ContextDefinition("string",
+ *       label = @Translation("Language"),
+ *       required = FALSE
+ *     )
+ *   }
+ * )
+ */
+class FetchTranslatableString extends DataProducerPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The locale storage service.
+   *
+   * @var \Drupal\locale\StringStorageInterface
+   */
+  protected $localeStorage;
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    StringStorageInterface $locale_storage
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->localeStorage = $locale_storage;
+  }
+
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('locale.storage')
+    );
+  }
+
+  public function resolve($id, $language, FieldContext $context) {
+    $strings = $this->localeStorage->getTranslations([
+      'lid' => $id,
+      'language' => $language,
+    ]);
+    // Make sure the result clears when new translations are added.
+    $context->addCacheTags(['locale']);
+    if (!empty($strings)) {
+      return reset($strings);
+    }
+    return NULL;
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/schema/translatable-strings.graphql
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/schema/translatable-strings.graphql
@@ -1,0 +1,7 @@
+type Query
+
+type TranslatableString @translatableString(contextPrefix: "gatsby") {
+  source: String!
+  language: String!
+  translation: String
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/TranslatableStringFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/TranslatableStringFeedTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Drupal\Tests\silverback_gatsby\Kernel;
+
+use Drupal\locale\StringStorageInterface;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+
+/**
+ * Test case for translatable strings in GraphQL.
+ */
+class TranslatableStringFeedTest extends GraphQLTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $strictConfigSchema = FALSE;
+
+  public static $modules = [
+    'locale',
+    'graphql_directives',
+    'silverback_gatsby',
+    'silverback_gatsby_example',
+  ];
+
+  /**
+   * The string storage.
+   *
+   * @var \Drupal\locale\StringStorageInterface
+   */
+  protected StringStorageInterface $storage;
+
+  /**
+   * The GraphQL query for listing operations.
+   *
+   * @var string
+   */
+  protected string $query = <<<'GQL'
+    query {
+      _queryTranslatableStrings {
+        _id
+        source
+        _translations {
+          _id
+          language
+          translation
+        }
+      }
+    }
+    GQL;
+
+  /**
+   * The GraphQL query for loading a single operation.
+   *
+   * @var string
+   */
+  protected string $load = <<<'GQL'
+    query load($id: String!) {
+      _loadTranslatableString(id: $id) {
+        _id
+        source
+        _translations {
+          _id
+          language
+          translation
+        }
+      }
+    }
+    GQL;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->storage = $this->container->get('locale.storage');
+    $this->installSchema('silverback_gatsby', ['gatsby_update_log']);
+    $this->installSchema('locale', ['locales_source', 'locales_target', 'locales_location', 'locale_file']);
+    $schema = __DIR__ . '/../../schema/translatable-strings.graphql';
+    $this->createTestServer(
+      'directable',
+      '/gatsby',
+      [
+        'schema_configuration' => [
+          'directable' => [
+            'extensions' => [
+              'silverback_gatsby' => 'silverback_gatsby',
+            ],
+            'schema_definition' => $schema,
+            'build_webhook' => 'http://127.0.0.1:8888/__refresh',
+          ],
+        ],
+      ]
+    );
+  }
+
+  /**
+   * Verify that it just generates an empty result if there are no strings.
+   */
+  public function testQueryWithoutStrings(): void {
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheTags(['locale']);
+    $this->assertResults($this->query, [], [
+      '_queryTranslatableStrings' => [],
+    ], $metadata);
+  }
+
+  /**
+   * Test querying an untranslated string.
+   */
+  public function testQueryWithUntranslatedString(): void {
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheTags(['locale']);
+    $this->storage->createString([
+      'source' => 'test source',
+      'context' => 'gatsby',
+    ])->save();
+    $this->assertResults($this->query, [], [
+      '_queryTranslatableStrings' => [
+        [
+          '_id' => '1:en',
+          'source' => 'test source',
+          '_translations' => [],
+        ],
+      ],
+    ], $metadata);
+  }
+
+  /**
+   * List results with a translated string.
+   */
+  public function testQueryWithTranslatedString(): void {
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheTags(['locale']);
+    $string = $this->storage->createString([
+      'source' => 'test source',
+      'context' => 'gatsby',
+    ]);
+    $string->save();
+    $this->storage->createTranslation([
+      'lid' => $string->lid,
+      'language' => 'de',
+      'translation' => 'test german',
+    ])->save();
+
+    $this->assertResults($this->query, [], [
+      '_queryTranslatableStrings' => [
+      [
+        '_id' => '1:en',
+        'source' => 'test source',
+        '_translations' => [
+          [
+            '_id' => '1:de',
+            'language' => 'de',
+            'translation' => 'test german',
+          ],
+        ],
+      ],
+      ],
+    ], $metadata);
+  }
+
+  /**
+   * Test loading a translated string that does not exist.
+   */
+  public function testLoadNoneExistingString(): void {
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheTags(['locale']);
+    $this->assertResults($this->load, ['id' => '1:en'], [
+      '_loadTranslatableString' => NULL,
+    ], $metadata);
+  }
+
+  public function testLoadTranslatedString(): void {
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheTags(['locale']);
+    $string = $this->storage->createString([
+      'source' => 'test source',
+      'context' => 'gatsby',
+    ]);
+    $string->save();
+    $this->storage->createTranslation([
+      'lid' => $string->lid,
+      'language' => 'de',
+      'translation' => 'test german',
+    ])->save();
+
+    $this->assertResults($this->load, ['id' => '1:de'], [
+      '_loadTranslatableString' => [
+        '_id' => '1:de',
+        'source' => 'test source',
+        '_translations' => [
+          [
+            '_id' => '1:de',
+            'language' => 'de',
+            'translation' => 'test german',
+          ],
+        ],
+      ],
+    ], $metadata);
+  }
+}

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/TranslatableStringFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/TranslatableStringFeedTest.php
@@ -15,7 +15,10 @@ class TranslatableStringFeedTest extends GraphQLTestBase {
    */
   protected $strictConfigSchema = FALSE;
 
-  public static $modules = [
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
     'locale',
     'graphql_directives',
     'silverback_gatsby',
@@ -24,15 +27,11 @@ class TranslatableStringFeedTest extends GraphQLTestBase {
 
   /**
    * The string storage.
-   *
-   * @var \Drupal\locale\StringStorageInterface
    */
   protected StringStorageInterface $storage;
 
   /**
    * The GraphQL query for listing operations.
-   *
-   * @var string
    */
   protected string $query = <<<'GQL'
     query {
@@ -50,8 +49,6 @@ class TranslatableStringFeedTest extends GraphQLTestBase {
 
   /**
    * The GraphQL query for loading a single operation.
-   *
-   * @var string
    */
   protected string $load = <<<'GQL'
     query load($id: String!) {
@@ -74,7 +71,12 @@ class TranslatableStringFeedTest extends GraphQLTestBase {
     parent::setUp();
     $this->storage = $this->container->get('locale.storage');
     $this->installSchema('silverback_gatsby', ['gatsby_update_log']);
-    $this->installSchema('locale', ['locales_source', 'locales_target', 'locales_location', 'locale_file']);
+    $this->installSchema('locale', [
+      'locales_source',
+      'locales_target',
+      'locales_location',
+      'locale_file',
+    ]);
     $schema = __DIR__ . '/../../schema/translatable-strings.graphql';
     $this->createTestServer(
       'directable',
@@ -144,17 +146,17 @@ class TranslatableStringFeedTest extends GraphQLTestBase {
 
     $this->assertResults($this->query, [], [
       '_queryTranslatableStrings' => [
-      [
-        '_id' => '1:en',
-        'source' => 'test source',
-        '_translations' => [
-          [
-            '_id' => '1:de',
-            'language' => 'de',
-            'translation' => 'test german',
+        [
+          '_id' => '1:en',
+          'source' => 'test source',
+          '_translations' => [
+            [
+              '_id' => '1:de',
+              'language' => 'de',
+              'translation' => 'test german',
+            ],
           ],
         ],
-      ],
       ],
     ], $metadata);
   }
@@ -170,6 +172,9 @@ class TranslatableStringFeedTest extends GraphQLTestBase {
     ], $metadata);
   }
 
+  /**
+   * Test loading a translated string.
+   */
   public function testLoadTranslatedString(): void {
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheTags(['locale']);
@@ -198,4 +203,5 @@ class TranslatableStringFeedTest extends GraphQLTestBase {
       ],
     ], $metadata);
   }
+
 }


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gatsby`

## Description of changes

Introduce a new `@translatableString` directive (and Feed), and deprecate the existing `@stringTranslation` directive.

## Motivation and context

`@stringTranslation` was missed in https://github.com/AmazeeLabs/silverback-mono/pull/1432, and is not compatible to the schema-first approach, since it writes automatic fields and also does translations in a custom way.

I added a new directive to avoid breaking changes.

## Related Issue(s)

[SLB-269](https://amazeelabs.atlassian.net/browse/SLB-269)

## How has this been tested?

* Drupal Kernel Test


[SLB-269]: https://amazeelabs.atlassian.net/browse/SLB-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ