### PR TITLE
chore: format the error message as one line

### DIFF
--- a/packages/npm/@amazeelabs/executors/src/lib.test.ts
+++ b/packages/npm/@amazeelabs/executors/src/lib.test.ts
@@ -50,7 +50,9 @@ test('structural argument matching', () => {
   registerExecutor(id, { y: 1 }, a);
   registerExecutor(id, { y: 2 }, b);
   registerExecutor(id, { y: 1, z: 1 }, c);
-  expect(() => createExecutor(id, { y: 3 })()).toThrow();
+  expect(() => createExecutor(id, { y: 3 })()).toThrow(
+    'No executor found for: x:{"y":3} Candidates: x:{"y":1} x:{"y":2} x:{"y":1,"z":1}',
+  );
   expect(() => createExecutor(id, { y: 1, z: 1 })()).not.toThrow();
   expect(() => createExecutor(id, { y: 1 })()).not.toThrow();
   expect(() => createExecutor(id, { y: 2 })()).not.toThrow();

--- a/packages/npm/@amazeelabs/executors/src/lib.ts
+++ b/packages/npm/@amazeelabs/executors/src/lib.ts
@@ -55,7 +55,7 @@ function getCandidates(id: string) {
 }
 
 function formatEntry(id: string | undefined, variables?: Record<string, any>) {
-  return `  ${id ? id : '*'}:${variables ? JSON.stringify(variables) : '*'}`;
+  return `${id ? id : '*'}:${variables ? JSON.stringify(variables) : '*'}`;
 }
 
 class ExecutorRegistryError extends Error {
@@ -75,7 +75,7 @@ class ExecutorRegistryError extends Error {
         'No executor found for:',
         formatEntry(id, variables),
         ...candidatesMessage,
-      ].join('\n'),
+      ].join(' '),
     );
     this.name = 'ExecutorRegistryError';
   }


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/executors`

## Motivation and context

Webpack prints only the first line of the error message.

![Screenshot 2024-03-11 at 21 06 24](https://github.com/AmazeeLabs/silverback-mono/assets/989015/3260ed6e-0b2a-4abf-9968-7e38ac8c0856)

## How has this been tested?

Unit test, manually.
