### PR TITLE
feat(silverback_gatsby): default entity fetch operation

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -15,3 +15,5 @@
 /markdown.xml
 /misc.xml
 /inspectionProfiles/profiles_settings.xml
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/EntityFetch.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/EntityFetch.php
@@ -29,12 +29,17 @@ class EntityFetch extends PluginBase implements DirectiveInterface {
    * @throws \Exception
    */
   public function buildResolver(ResolverBuilder $builder, array $arguments): ResolverInterface {
-    return $builder->produce('fetch_entity')
+    $resolver = $builder->produce('fetch_entity')
       ->map('type', $this->argumentResolver($arguments['type'], $builder))
       ->map('id', $this->argumentResolver($arguments['id'], $builder))
       ->map('revision_id', $this->argumentResolver($arguments['rid'], $builder))
-      ->map('language', $this->argumentResolver($arguments['language'], $builder))
-      ->map('operation', $this->argumentResolver($arguments['operation'], $builder));
+      ->map('language', $this->argumentResolver($arguments['language'], $builder));
+    // If empty, delegate to access_operation default value
+    // from the fetch_entity data producer.
+    if (!empty($arguments['operation'])) {
+      $resolver->map('access_operation', $this->argumentResolver($arguments['operation'], $builder));
+    }
+    return $resolver;
   }
 
 }


### PR DESCRIPTION
## Package(s) involved

`silverback_gatsby`

## Description of changes

Delegate to the `fetch_entity` data producer default `access_operation` value if `operation` is not set.

## Motivation and context

Directives can be simplified as

```graphql
previewPage(id: ID!, rid: ID, locale: String!): Page
    @fetchEntity(type: "node", id: "$id", rid: "$rid", language: "$locale")
```

instead of

```graphql
previewPage(id: ID!, rid: ID, locale: String!): Page
    @fetchEntity(type: "node", id: "$id", rid: "$rid", language: "$locale", operation: "view")
```

## How has this been tested?

Manually, on a project.