### PR TITLE
fix(SLB-278): improve gatsby node type detection

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -27,6 +27,7 @@ import { fetchNodeChanges } from './helpers/fetch-node-changes.js';
 import {
   cleanSchema,
   extractInterfaces,
+  extractNodeTypes,
   extractSourceMapping,
   extractUnions,
 } from './helpers/schema.js';
@@ -247,7 +248,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
               },
             }),
           ),
-          ...Object.keys(extractSourceMapping(schema)).map((name) =>
+          ...extractNodeTypes(schema).map((name) =>
             args.schema.buildObjectType({
               name,
               interfaces: ['Node'],

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.test.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   cleanSchema,
   extractInterfaces,
+  extractNodeTypes,
   extractSourceMapping,
   extractUnions,
 } from './schema.js';
@@ -23,6 +24,17 @@ describe('extractSourceMapping', () => {
       Customer: 'sourceCustomers',
       Employee: 'sourceEmployees',
     });
+  });
+});
+
+describe('extractNodeTypes', () => {
+  it('extracts types custom directives that suggest its sourced from somewhere', () => {
+    expect(extractNodeTypes(schema)).toEqual([
+      'Customer',
+      'Employee',
+      'WithDirective',
+      'WithCustomAndDefaultDirective',
+    ]);
   });
 });
 
@@ -61,6 +73,24 @@ describe('cleanSchema', () => {
         role: String!
         name: String!
         email: Email!
+      }
+      type WithoutDirective {
+        id: ID!
+      }
+      type WithDirective {
+        id: ID!
+      }
+      type WithTypeDirective {
+        id: ID!
+      }
+      type WithDefaultDirective {
+        id: ID!
+      }
+      type WithTypeAndDefaultDirective {
+        id: ID!
+      }
+      type WithCustomAndDefaultDirective {
+        id: ID!
       }"
     `);
   });

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.ts
@@ -37,6 +37,29 @@ export function extractSourceMapping(schema: GraphQLSchema) {
 }
 
 /**
+ * Extract a list of all object types that are queryable in Gatsby.
+ * @param schema
+ */
+export function extractNodeTypes(schema: GraphQLSchema) {
+  const sources = [] as string[];
+
+  for (const type of Object.values(schema.getTypeMap())) {
+    if (isObjectType(type)) {
+      const directives = (type.astNode?.directives || [])
+        .map((dir) => dir.name.value)
+        .filter((dir) => dir !== 'type');
+      const firstDefault = directives.indexOf('default');
+      const relevantDirectives =
+        firstDefault === -1 ? directives : directives.slice(0, firstDefault);
+      if (relevantDirectives.length > 0) {
+        sources.push(type.name);
+      }
+    }
+  }
+  return sources;
+}
+
+/**
  * Extract a list of all union types.
  */
 export function extractUnions(schema: GraphQLSchema) {

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/test/schema/schema.graphql
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/test/schema/schema.graphql
@@ -24,3 +24,47 @@ type Employee implements Contact @sourceFrom(fn: "sourceEmployees") {
   name: String!
   email: Email!
 }
+
+# Arbitrary directive that produces values.
+directive @value repeatable on OBJECT
+# @type directive used by the Drupal module.
+directive @type on OBJECT
+# @default directive used by the Drupal module.
+directive @default on OBJECT
+
+# Should not show up in `extractNodeTypes`.
+# Regular types are not Nodes in Gatsby.
+type WithoutDirective {
+  id: ID!
+}
+
+# Should show up in `extractNodeTypes`
+# An unknown directive suggests that this type is sourced from somewhere.
+# e.g. @entity, @sourceFrom etc.
+type WithDirective @value {
+  id: ID!
+}
+
+# Should not show up in `extractNodeTypes`
+# @type is used by Drupal to resolve interfaces. This alone does not mean
+# the type is sourced from somewhere.
+type WithTypeDirective @type {
+  id: ID!
+}
+
+# Should not show up in `extractNodeTypes`
+# @default is used by Drupal to provide default values. Any directives
+# after this have to be ignored.
+type WithDefaultDirective @default @value {
+  id: ID!
+}
+
+# Should not show up in `extractNodeTypes`
+type WithTypeAndDefaultDirective @type @default @value {
+  id: ID!
+}
+
+# Should show up in `extractNodeTypes`
+type WithCustomAndDefaultDirective @value @default @value {
+  id: ID!
+}


### PR DESCRIPTION

## Package(s) involved

* `@amazeelabs/gatsby-source-silverback`

## Description of changes

Detect Gatsby Node types based on custom directives that are attached to
them instead of "sourceFrom" only.

## Motivation and context

If Drupal is not available, types with `@entity` directives are not queryable in Gatsby any more and break the schema.

## Related Issue(s)

SLB-278

## How has this been tested?

- [x] Unit tests
