### PR TITLE
SLB-220: autoload @sourceFrom directive functions

### DIFF
--- a/packages/npm/@amazeelabs/codegen-autoloader/README.md
+++ b/packages/npm/@amazeelabs/codegen-autoloader/README.md
@@ -101,6 +101,19 @@ generates:
     mode: 'js'
 ```
 
+## `@sourceFrom` support
+
+The `@sourceFrom` from the `@amazeelabs/gatsby-source-silverback` directive
+allows to specify Javascript functions that should be used to source data into
+the Gatsby data store. This package will include these functions in the
+autoloader output.
+
+```graphql
+type Page @sourceFrom(fn: "@my/package#pages") {
+  title: String!
+}
+```
+
 ## Output modes
 
 The `mode` configuration parameter allows to select the output mode. `js`

--- a/packages/npm/@amazeelabs/codegen-autoloader/src/lib.test.ts
+++ b/packages/npm/@amazeelabs/codegen-autoloader/src/lib.test.ts
@@ -341,4 +341,28 @@ describe('generateAutoloader', () => {
       ].join('\n'),
     );
   });
+  it('generates autoloader entries for @sourceFrom directives', () => {
+    expect(
+      generateAutoloader(
+        buildSchema(
+          [
+            'directive @sourceFrom(fn: String) on OBJECT',
+            'type A @sourceFrom(fn: "@my/package#function") { id: ID! }',
+            'type B @sourceFrom(fn: "./file.js#function") { id: ID! }',
+          ].join('\n'),
+        ),
+        ['gatsby', 'cloudinary'],
+        printJsAutoload,
+      ),
+    ).toEqual(
+      [
+        'import { function as al0 } from "@my/package";',
+        'import { function as al1 } from "./file.js";',
+        'export default {',
+        "  '@my/package#function': al0,",
+        "  './file.js#function': al1,",
+        '};',
+      ].join('\n'),
+    );
+  });
 });

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
@@ -198,19 +198,19 @@ The
 [`@amazeelabs/codegen-autoloader`](https://github.com/AmazeeLabs/silverback-mono/blob/development/packages/npm/@amazeelabs/codegen-autoloader/README.md)
 package provides a more convenient way to inject new directives the schema. It's
 a [`graphql-codegen`](https://the-guild.dev/graphql/codegen) that produces a
-file with a single default export that can be passed into the `directives`
+file with a single default export that can be passed into the `autoload`
 configuration property.
 
 ```javascript
 // gatsby-config.mjs
-import directives from './generated/directives.mjs';
+import autoload from './generated/autoload.mjs';
 
 export const plugins = [
   {
     resolve: '@amazeelabs/gatsby-source-silverback',
     options: {
       schema_configuration: './',
-      directives,
+      autoload,
     },
   },
 ];

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -49,6 +49,7 @@ export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
     schema_configuration: Joi.string().optional(),
     directives: Joi.object().pattern(Joi.string(), Joi.function()).optional(),
     sources: Joi.object().pattern(Joi.string(), Joi.function()).optional(),
+    autoload: Joi.object().pattern(Joi.string(), Joi.function()).optional(),
   });
 
 const getForwardedHeaders = (url: URL) => ({
@@ -162,7 +163,10 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
 
       const sources = extractSourceMapping(schema);
       for (const type in sources) {
-        const resolver = options.sources?.[sources[type]];
+        const resolver =
+          options.autoload?.[sources[type]] ||
+          options.directives?.[sources[type]] ||
+          options.sources?.[sources[type]];
         if (!resolver) {
           gatsbyApi.reporter.error(
             `"${sources[type]}" on "${type}" is not a registered source function. Check the "sources" property of the "@amazeelabs/gatsby-source-silverback" plugin.`,
@@ -308,6 +312,7 @@ export const createResolvers: GatsbyNode['createResolvers'] = async (
   if (options.schema_configuration) {
     const availableDirectives = {
       ...(options.directives || {}),
+      ...(options.autoload || {}),
       gatsbyNode,
       gatsbyNodes,
     };

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
@@ -23,6 +23,8 @@ export type Options = {
   directives?: Record<string, Function>;
   // A list of functions that will be available as data source.
   sources?: Record<string, Function>;
+  // A list of functions that will be available as data source or directive.
+  autoload?: Record<string, Function>;
 };
 
 export const validOptions = (options: {


### PR DESCRIPTION
## Package(s) involved

* `@amazeelabs/codegen-autoloader`
* `@amazeelabs/gatsby-source-silverback`

## Description of changes

Extract autoloaders for `@sourceFrom` directives so we don't have to manually configure them.

## Related Issue(s)

SLB-220

## How has this been tested?

* Unit tests
