### PR TITLE
fix: make executors accept arguments directly

### DIFF
--- a/packages/npm/@amazeelabs/executors/src/lib.test.tsx
+++ b/packages/npm/@amazeelabs/executors/src/lib.test.tsx
@@ -15,7 +15,9 @@ function Consumer({
   variables?: Record<string, any>;
 }) {
   const executor = useExecutor(id, variables);
-  return <p>{typeof executor === 'function' ? executor() : executor}</p>;
+  return (
+    <p>{typeof executor === 'function' ? executor(variables) : executor}</p>
+  );
 }
 
 test('no operator', () => {

--- a/packages/npm/@amazeelabs/executors/src/lib.tsx
+++ b/packages/npm/@amazeelabs/executors/src/lib.tsx
@@ -37,7 +37,7 @@ export function useExecutor(id: string, variables?: Record<string, any>) {
 
   if (op) {
     if (typeof op.executor === 'function') {
-      return () => op.executor(id, variables);
+      return (vars?: Record<string, any>) => op.executor(id, vars);
     }
     return op.executor;
   }


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/executors`

## Description of changes

Executors accept argumetns directly instead of inheriting them from `useExecutor`. Those are only used for executor matching now.

## Motivation and context

Required to properly work with mutations, specifically `useSWRMutation`.


## How has this been tested?

Unit tests
