### PR TITLE
feat: allow @responsiveImageSharp to handle local images

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/directives.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/directives.ts
@@ -1,5 +1,9 @@
-import {fluid} from 'gatsby-plugin-sharp';
-import {createRemoteFileNode} from 'gatsby-source-filesystem';
+import { readFileSync } from 'fs';
+import { fluid } from 'gatsby-plugin-sharp';
+import {
+  createFileNodeFromBuffer,
+  createRemoteFileNode,
+} from 'gatsby-source-filesystem';
 
 import { SilverbackResolver } from './types';
 
@@ -32,67 +36,79 @@ export const gatsbyNodes: SilverbackResolver = async (
   ).entries;
 };
 
-export const responsiveImageSharp: SilverbackResolver = async (originalImage: any, args: any, context: any) => {
-    const responsiveImage = JSON.parse(originalImage);
-    const { cache, createNode, createNodeId, reporter } = context.api;
-    try {
-      const responsiveImageResult: {
-        originalSrc: string;
-        src: string;
-        srcset?: string;
-        sizes?: string;
-        width?: number;
-        height?: number;
-      } = {
-        ...responsiveImage,
-        originalSrc: responsiveImage.src
-      };
+export const responsiveImageSharp: SilverbackResolver = async (
+  originalImage: any,
+  args: any,
+  context: any,
+) => {
+  const responsiveImage = JSON.parse(originalImage);
+  const { cache, createNode, createNodeId, reporter } = context.api;
+  try {
+    const responsiveImageResult: {
+      originalSrc: string;
+      src: string;
+      srcset?: string;
+      sizes?: string;
+      width?: number;
+      height?: number;
+    } = {
+      ...responsiveImage,
+      originalSrc: responsiveImage.src,
+    };
 
-      // If no config object is given, or no width is specified, we just return
-      // the original image url.
-      if (typeof args === 'undefined' || typeof args.width === 'undefined') {
-        return JSON.stringify(responsiveImageResult);
-      }
-
-      const file = await createRemoteFileNode({
-        url: responsiveImage.src,
-        cache: cache,
-        createNode: createNode,
-        createNodeId: createNodeId,
-      })
-      const width = args.width;
-      const height = args.height || undefined;
-      const breakpoints = args.sizes && args.sizes.length > 0 ?
-        args.sizes.map((item: Array<number> | number) => {
-          // If the sizes array contains tuples, then just return the first item
-          // to be added to the breakpoints elements.
-          if (Array.isArray(item)) {
-            return item[0];
-          }
-          return item;
-        }) :
-        undefined
-      const fluidFileResult = await fluid({
-          file,
-          args: {
-            maxWidth: width,
-            maxHeight: height,
-            quality: 90,
-            srcSetBreakpoints: breakpoints,
-            cropFocus: 'entropy'
-          },
-          reporter: reporter,
-          cache: cache
-      });
-      responsiveImageResult.src = fluidFileResult.src;
-      responsiveImageResult.width = fluidFileResult.presentationWidth;
-      responsiveImageResult.height = fluidFileResult.presentationHeight;
-      responsiveImageResult.sizes = fluidFileResult.sizes;
-      responsiveImageResult.srcset = fluidFileResult.srcSet;
-
+    // If no config object is given, or no width is specified, we just return
+    // the original image url.
+    if (typeof args === 'undefined' || typeof args.width === 'undefined') {
       return JSON.stringify(responsiveImageResult);
-    } catch (err) {
-      console.error(`Error loading image ${responsiveImage.src}`, err)
-      return JSON.stringify(responsiveImage);
     }
+
+    const file = responsiveImage.src.startsWith('http')
+      ? await createRemoteFileNode({
+          url: responsiveImage.src,
+          cache: cache,
+          createNode: createNode,
+          createNodeId: createNodeId,
+        })
+      : await createFileNodeFromBuffer({
+          buffer: readFileSync(responsiveImage.src),
+          cache: cache,
+          createNode: createNode,
+          createNodeId: createNodeId,
+        });
+    const width = args.width;
+    const height = args.height || undefined;
+    const breakpoints =
+      args.sizes && args.sizes.length > 0
+        ? args.sizes.map((item: Array<number> | number) => {
+            // If the sizes array contains tuples, then just return the first item
+            // to be added to the breakpoints elements.
+            if (Array.isArray(item)) {
+              return item[0];
+            }
+            return item;
+          })
+        : undefined;
+    const fluidFileResult = await fluid({
+      file,
+      args: {
+        maxWidth: width,
+        maxHeight: height,
+        quality: 90,
+        srcSetBreakpoints: breakpoints,
+        cropFocus: 'entropy',
+      },
+      reporter: reporter,
+      cache: cache,
+    });
+    responsiveImageResult.src = fluidFileResult.src;
+    responsiveImageResult.width = fluidFileResult.presentationWidth;
+    responsiveImageResult.height = fluidFileResult.presentationHeight;
+    responsiveImageResult.sizes = fluidFileResult.sizes;
+    responsiveImageResult.srcset = fluidFileResult.srcSet;
+
+    return JSON.stringify(responsiveImageResult);
+  } catch (err) {
+    console.error(`Error loading image ${responsiveImage.src}`, err);
+    return JSON.stringify(responsiveImage);
+  }
 };


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/gatsby-source-silverback`

## Description of changes

Extend the `@responsiveImageSharp` directive to also handle local file.

## Motivation and context

Use Gatsby image processing with images from Decap.

