### PR TITLE
fix(bridge-gatsby): trigger a render on search params load

### DIFF
--- a/packages/npm/@amazeelabs/bridge-gatsby/src/index.tsx
+++ b/packages/npm/@amazeelabs/bridge-gatsby/src/index.tsx
@@ -5,7 +5,7 @@ import type {
 } from '@amazeelabs/bridge';
 import { useLocation as gatsbyUseLocation } from '@reach/router';
 import { Link as GatsbyLink, navigate as gatsbyNavigate } from 'gatsby';
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, useEffect } from 'react';
 
 export const Link: LinkType &
   Pick<ComponentProps<typeof GatsbyLink>, 'ref'> = ({ href, ...props }) => {
@@ -14,8 +14,17 @@ export const Link: LinkType &
 
 export const useLocation: useLocationType = () => {
   const location = gatsbyUseLocation();
+  const [updatedSearch, setUpdatedSearch] = React.useState('');
+  useEffect(() => {
+    if (location.search) setUpdatedSearch(location.search);
+  }, [location.search]);
+
   return [
-    new URL(location.href || location.pathname, 'relative:/'),
+    {
+      ...location,
+      search: updatedSearch,
+      searchParams: new URLSearchParams(updatedSearch),
+    },
     gatsbyNavigate,
   ];
 };


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/bridge-gatsby`

## Description of changes

- Added a state that get updated whenever the search params are defined, in order to trigger a render on the client 

## Motivation and context

A common bug on `PAR` that got partially fixed when using `react-hook-form` but wasn't completely solved expect by doing a Two pass render similar to the one implemented here. The issue is also reproducible in a new project using SLB. [More on PAR issue](https://github.com/AmazeeLabs/paraplegie_ch/blob/895034f4a91f159e53ca929777b14acc2fe9e0bd/apps/website/README.md#known-issues)

Some resources:
- [Ongoing discussion about `hydration` in Gatsby](https://github.com/gatsbyjs/gatsby/discussions/17914/)
- [A similar stackoverflow issue](https://stackoverflow.com/questions/56398811/unable-to-update-jsx-attribute-based-on-url-parameter-in-a-gatsby-app-running-in/56403717#56403717)

## Related Issue(s)

<!-- make sure you link with either an `#issue-number` or directly with `[link-text](url)` -->

- [PAR-1973](https://amazeelabs.atlassian.net/browse/PAR-1973)
- [PAR-1702](https://amazeelabs.atlassian.net/browse/PAR-1702)

## How has this been tested?

Manually with a new frontend project with SLB as a starter
- Before -> [https://splendorous-kataifi-fda428.netlify.app/?id=2](https://splendorous-kataifi-fda428.netlify.app/?id=2)
  - First form is using `useLocation` directly
  - Second form is using `react-hook-form`. First and third field using `register`, second field using `watch` (not updated, same with `getValues`)

- After -> [https://celebrated-sunflower-c2587c.netlify.app/?id=2](https://celebrated-sunflower-c2587c.netlify.app/?id=2)

[PAR-1973]: https://amazeelabs.atlassian.net/browse/PAR-1973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ