### PR TITLE
fix(SLB-146): hide gutenberg preview button and disable fullscreen mode

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/css/gutenberg-tweaks.css
+++ b/packages/composer/amazeelabs/silverback_gutenberg/css/gutenberg-tweaks.css
@@ -37,3 +37,8 @@ with cypress tests.*/
   filter: drop-shadow(2px 2px 5px #cc1818);
   background: white;
 }
+
+/* Hide the preview button. */
+.block-editor-post-preview__dropdown {
+  display: none;
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/js/gutenberg-tweaks.js
+++ b/packages/composer/amazeelabs/silverback_gutenberg/js/gutenberg-tweaks.js
@@ -31,7 +31,16 @@
         coreColumnsBlock.example.innerBlocks[0].innerBlocks.splice(1, 1);
       }
     },
+    // Disable fullscreen mode.
+    function () {
+      const isFullscreenMode = wp.data
+        .select('core/edit-post')
+        .isFeatureActive('fullscreenMode');
 
+      if (isFullscreenMode) {
+        wp.data.dispatch('core/edit-post').toggleFeature('fullscreenMode');
+      }
+    },
     // Remove most of the columns options.
     function () {
       var coreColumnsBlock = wp.blocks.getBlockType('core/columns');


### PR DESCRIPTION

## Package(s) involved

<!-- type the name of the package(s) involved in this pull request -->
`amazeelabs/silverback_gutenberg`

## Description of changes

<!-- a brief summary of your code changes -->
* Hide the Gutenberg "Preview" button.
* Disable Gutenberg Fullscreen mode by default.

## Motivation and context

Make sure the toolbar "preview" button is always visible and the only one on screen, to reduce confusions.

## Related Issue(s)

SLB-146

## How has this been tested?

* Manually
