### PR TITLE
SLB-426: GraphQL Build entity update

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/src/GraphQL/Build.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GraphQL/Build.php
@@ -195,7 +195,7 @@ class Build extends EntityForm {
    */
   public function buildEntity(array $form, FormStateInterface $form_state) {
     $entity = clone $this->entity;
-    $entity->schema_configuration[$entity->schema] += $form_state->getValue('schema_configuration')[$entity->schema];
+    $entity->schema_configuration[$entity->schema] = array_merge($entity->schema_configuration[$entity->schema], $form_state->getValue('schema_configuration')[$entity->schema]);
     return $entity;
   }
 


### PR DESCRIPTION
## Package(s) involved
silverback_gatsby

## Description of changes
Once the GraphQL Build entity is saved at /admin/config/graphql/servers/build/silverback_gatsby for example (let's say the Notification user gets updated), a second update operation is not possible because the buildEntity() method of the Build entity class uses "+" to append data into the configuration entity. But the "+" operation would not overwrite existing data. One solution (which has been implemented) is to use array_merge. Another one would be to use the "+", but in a different way, something like:
`$entity->schema_configuration[$entity->schema] = $form_state->getValue('schema_configuration')[$entity->schema] + $entity->schema_configuration[$entity->schema]`

## Related Issue(s)
[GraphQL Server Build entities cannot be updated](https://amazeelabs.atlassian.net/browse/SLB-426)

## How has this been tested?
Locally, manually.
