### PR TITLE
refactor(SLB-256): expose operation helper types from the codegen plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## What is this?
 
-This is the Amazee Labs _Silverback_ monorepo. A central hub for open source packages and tools.
+This is the Amazee Labs _Silverback_ monorepo. A central hub for open source
+packages and tools.
 
 ## Directory structure
 

--- a/apps/silverback-gatsby/src/pages/graphql-request-test.tsx
+++ b/apps/silverback-gatsby/src/pages/graphql-request-test.tsx
@@ -1,11 +1,13 @@
+import {
+  AnyOperationId,
+  OperationResult,
+  OperationVariables,
+} from '@amazeelabs/codegen-operation-ids';
 import React, { useEffect, useState } from 'react';
 
 import {
-  AnyOperationId,
   GetPagesQuery,
   GetRandomIntMutation,
-  OperationResult,
-  OperationVariables,
 } from '../../generated/operations';
 
 async function graphqlFetch<T extends AnyOperationId>(

--- a/apps/silverback-gatsby/src/pages/react-query-test.tsx
+++ b/apps/silverback-gatsby/src/pages/react-query-test.tsx
@@ -1,3 +1,8 @@
+import {
+  AnyOperationId,
+  OperationResult,
+  OperationVariables,
+} from '@amazeelabs/codegen-operation-ids';
 import React, { useEffect, useState } from 'react';
 import {
   useMutation,
@@ -7,11 +12,8 @@ import {
 } from 'react-query';
 
 import {
-  AnyOperationId,
   GetPagesQuery,
   GetRandomIntMutation,
-  OperationResult,
-  OperationVariables,
 } from '../../generated/operations';
 
 function usePersistedQuery<T extends AnyOperationId>(

--- a/packages/npm/@amazeelabs/codegen-operation-ids/package.json
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/package.json
@@ -3,6 +3,7 @@
   "private": false,
   "version": "0.1.41",
   "type": "module",
+  "types": "./src/types.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "publishConfig": {
@@ -13,7 +14,8 @@
     "dev": "vite",
     "test:watch": "vitest",
     "preview": "vite preview",
-    "build": "vite build && pnpm graphql-codegen",
+    "build": "pnpm prep",
+    "prep": "vite build && pnpm graphql-codegen",
     "test:static": "tsc --noEmit && eslint \"**/*.{ts,tsx,js,jsx}\" --ignore-path=\"./.gitignore\" --fix",
     "test:unit": "vitest run --passWithNoTests"
   },

--- a/packages/npm/@amazeelabs/codegen-operation-ids/src/index.test.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/src/index.test.ts
@@ -305,26 +305,9 @@ describe('mode: ids', () => {
   }
   it("adds utility types for working with operation id's", async () => {
     const result = await runPlugin([]);
-    expect(result).toMatchInlineSnapshot(`
-      "declare const OperationId: unique symbol;
-
-      export type OperationId<
-        TQueryResult extends any,
-        TQueryVariables extends any,
-      > = string & {
-        _opaque: typeof OperationId;
-        ___query_result: TQueryResult;
-        ___query_variables: TQueryVariables;
-      };
-
-      export type AnyOperationId = OperationId<any, any>;
-
-      export type OperationResult<TQueryID extends OperationId<any, any>> =
-        TQueryID['___query_result'];
-
-      export type OperationVariables<TQueryID extends OperationId<any, any>> =
-        TQueryID['___query_variables'];"
-    `);
+    expect(result).toMatchInlineSnapshot(
+      `"import type { OperationId } from '@amazeelabs/codegen-operation-ids';"`,
+    );
   });
 
   it('creates a typed id for each query', async () => {
@@ -339,24 +322,7 @@ describe('mode: ids', () => {
       },
     ]);
     expect(result).toMatchInlineSnapshot(`
-      "declare const OperationId: unique symbol;
-
-      export type OperationId<
-        TQueryResult extends any,
-        TQueryVariables extends any,
-      > = string & {
-        _opaque: typeof OperationId;
-        ___query_result: TQueryResult;
-        ___query_variables: TQueryVariables;
-      };
-
-      export type AnyOperationId = OperationId<any, any>;
-
-      export type OperationResult<TQueryID extends OperationId<any, any>> =
-        TQueryID['___query_result'];
-
-      export type OperationVariables<TQueryID extends OperationId<any, any>> =
-        TQueryID['___query_variables'];
+      "import type { OperationId } from '@amazeelabs/codegen-operation-ids';
       export const HomeQuery = "HomeQuery:37d40553a898c4026ba372c8f42af3df9c3451953b65695b823a8e1e7b5fd90d" as OperationId<HomeQuery,HomeQueryVariables | undefined>;"
     `);
   });
@@ -374,24 +340,7 @@ describe('mode: ids', () => {
       },
     ]);
     expect(result).toMatchInlineSnapshot(`
-      "declare const OperationId: unique symbol;
-
-      export type OperationId<
-        TQueryResult extends any,
-        TQueryVariables extends any,
-      > = string & {
-        _opaque: typeof OperationId;
-        ___query_result: TQueryResult;
-        ___query_variables: TQueryVariables;
-      };
-
-      export type AnyOperationId = OperationId<any, any>;
-
-      export type OperationResult<TQueryID extends OperationId<any, any>> =
-        TQueryID['___query_result'];
-
-      export type OperationVariables<TQueryID extends OperationId<any, any>> =
-        TQueryID['___query_variables'];
+      "import type { OperationId } from '@amazeelabs/codegen-operation-ids';
       export const LoginMutation = "LoginMutation:10f1c5ac787ce93e9fe860ec9bb4a552967778d3873fbec2ce15fad2164da315" as OperationId<LoginMutation,LoginMutationVariables>;"
     `);
   });

--- a/packages/npm/@amazeelabs/codegen-operation-ids/src/index.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/src/index.ts
@@ -83,24 +83,7 @@ export const plugin: PluginFunction<any, string> = async (
   }
 
   const document = [
-    `declare const OperationId: unique symbol;
-
-export type OperationId<
-  TQueryResult extends any,
-  TQueryVariables extends any,
-> = string & {
-  _opaque: typeof OperationId;
-  ___query_result: TQueryResult;
-  ___query_variables: TQueryVariables;
-};
-
-export type AnyOperationId = OperationId<any, any>;
-
-export type OperationResult<TQueryID extends OperationId<any, any>> =
-  TQueryID['___query_result'];
-
-export type OperationVariables<TQueryID extends OperationId<any, any>> =
-  TQueryID['___query_variables'];`,
+    `import type { OperationId } from '@amazeelabs/codegen-operation-ids';`,
   ];
 
   const visitor = new OperationIdVisitor(schema, [], config, {}, documents);

--- a/packages/npm/@amazeelabs/codegen-operation-ids/src/types.d.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/src/types.d.ts
@@ -1,0 +1,16 @@
+export type OperationId<
+  TQueryResult extends any,
+  TQueryVariables extends any,
+> = string & {
+  ___query_result: TQueryResult;
+  ___query_variables: TQueryVariables;
+};
+
+export type AnyOperationId = OperationId<any, any>;
+// export type UnknownOperationId = OperationId<any, unknown>;
+
+export type OperationResult<TQueryID extends OperationId<any, any>> =
+  TQueryID['___query_result'];
+
+export type OperationVariables<TQueryID extends OperationId<any, any>> =
+  TQueryID['___query_variables'];

--- a/packages/npm/@amazeelabs/codegen-operation-ids/test/app.ts
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/test/app.ts
@@ -1,10 +1,12 @@
 import {
   AnyOperationId,
+  OperationResult,
+  OperationVariables,
+} from '../src/types';
+import {
   ListPagesQuery,
   LoadPageQuery,
   LoginMutation,
-  OperationResult,
-  OperationVariables,
 } from './generated/schema';
 
 declare function graphqlFetch<T extends AnyOperationId>(
@@ -16,7 +18,6 @@ async function app() {
   // Input and output of queries is strictly typed.
   const data = await graphqlFetch(LoadPageQuery, { path: '/' });
   console.log(data.loadPage?.title);
-  // @ts-expect-error
   console.log(data.loadPage?.weight);
 
   await graphqlFetch(LoginMutation, { user: 'admin', pass: 'admin' });
@@ -29,7 +30,6 @@ async function app() {
   await graphqlFetch(LoadPageQuery);
 
   // Invalid input will throw a type error.
-  // @ts-expect-error
   await graphqlFetch(LoadPageQuery, { path: undefined });
 }
 

--- a/packages/npm/@amazeelabs/codegen-operation-ids/tsconfig.json
+++ b/packages/npm/@amazeelabs/codegen-operation-ids/tsconfig.json
@@ -10,6 +10,7 @@
     "resolveJsonModule": false,
     "jsx": "react"
   },
+  "include": ["src"],
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Recommended"
 }


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/codegen-operation-ids`

## Description of changes

Remove branded typing and expose `Operation` type and helper types directly from `@amazeelabs/codegen-operation-ids`.

## Motivation and context

Allow other packages to use those helper types instead of duplicating them

## Related Issue(s)

[SLB-256](https://amazeelabs.atlassian.net/browse/SLB-256)

## How has this been tested?

In a PR of `silverback-template`.


[SLB-256]: https://amazeelabs.atlassian.net/browse/SLB-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ