### PR TITLE
refactor(SLB-353)!: new RSC compatible operations API

### DIFF
--- a/packages/npm/@amazeelabs/executors/.eslintrc
+++ b/packages/npm/@amazeelabs/executors/.eslintrc
@@ -1,4 +1,57 @@
 {
-  "extends": ["@amazeelabs/eslint-config"],
-  "root": true
+  "$schema": "https://json.schemastore.org/eslintrc.json",
+  "root": true,
+  "settings": {
+    "react": {
+      "version": "18"
+    }
+  },
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:promise/recommended",
+    "plugin:react/recommended",
+    "prettier"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "plugins": [
+    "@typescript-eslint",
+    "promise",
+    "simple-import-sort",
+    "import",
+    "no-only-tests",
+    "react",
+    "react-hooks"
+  ],
+  "rules": {
+    "no-unused-vars": ["off"],
+    "@typescript-eslint/no-unused-vars": ["error"],
+    "simple-import-sort/imports": "error",
+    "sort-imports": "off",
+    "import/first": "error",
+    "import/newline-after-import": "error",
+    "import/no-duplicates": "error",
+    "no-only-tests/no-only-tests": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+    "react/prop-types": ["off"],
+    "react/prefer-stateless-function": ["error"],
+    "react/react-in-jsx-scope": ["off"]
+  }
 }

--- a/packages/npm/@amazeelabs/executors/.gitignore
+++ b/packages/npm/@amazeelabs/executors/.gitignore
@@ -1,1 +1,7 @@
 build
+dist
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/packages/npm/@amazeelabs/executors/.prettierrc
+++ b/packages/npm/@amazeelabs/executors/.prettierrc
@@ -1,0 +1,1 @@
+"@amazeelabs/prettier-config"

--- a/packages/npm/@amazeelabs/executors/.turbo/turbo-prep.log
+++ b/packages/npm/@amazeelabs/executors/.turbo/turbo-prep.log
@@ -1,4 +1,0 @@
-
-> @amazeelabs/executors@1.0.0 prep /Users/pmelab/Code/silverback-template/packages/executors
-> tsc
-

--- a/packages/npm/@amazeelabs/executors/.turbo/turbo-test:static.log
+++ b/packages/npm/@amazeelabs/executors/.turbo/turbo-test:static.log
@@ -1,4 +1,0 @@
-
-> @amazeelabs/executors@1.0.0 test:static /Users/pmelab/Code/silverback-template/packages/executors
-> tsc --noEmit && eslint "**/*.{ts,tsx,js,jsx}" --ignore-path="./.gitignore" --fix
-

--- a/packages/npm/@amazeelabs/executors/package.json
+++ b/packages/npm/@amazeelabs/executors/package.json
@@ -2,8 +2,7 @@
   "name": "@amazeelabs/executors",
   "version": "2.0.7",
   "description": "",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "types": "build/client.d.ts",
   "private": false,
   "sideEffects": false,
   "publishConfig": {
@@ -11,31 +10,55 @@
   },
   "type": "module",
   "scripts": {
-    "prep": "tsc && rollup -c",
+    "prep": "tsup src/client.tsx src/server.tsx --dts --format esm --out-dir build",
+    "watch": "pnpm prep --watch",
     "build": "pnpm prep",
     "test:unit": "vitest run",
-    "test:static": "tsc --noEmit && eslint \"**/*.{ts,tsx,js,jsx}\" --ignore-path=\"./.gitignore\" --fix"
+    "test:static": "tsc --noEmit && eslint \"**/*.{ts,tsx,js,jsx}\" --ignore-path=\"./.gitignore\" --fix",
+    "test:integration": "playwright test",
+    "test:cmd": "cd test && ../node_modules/waku/cli.js",
+    "test:dev": "pnpm test:cmd dev",
+    "test:start": "pnpm test:cmd build && pnpm test:cmd start",
+    "test:all": "pnpm test:unit && pnpm test:static && pnpm test:integration"
+  },
+  "exports": {
+    ".": {
+      "react-server": "./build/server.js",
+      "default": "./build/client.js"
+    }
   },
   "keywords": [],
   "author": "Amazee Labs <development@amazeelabs.com>",
   "license": "ISC",
   "dependencies": {
-    "lodash-es": "^4.17.21"
+    "@amazeelabs/codegen-operation-ids": "workspace:*",
+    "lodash-es": "^4.17.21",
+    "react-server-dom-webpack": "19.0.0-rc.0",
+    "server-only-context": "^0.1.0"
   },
   "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "*",
+    "react-dom": "*"
   },
   "devDependencies": {
     "@amazeelabs/eslint-config": "1.4.43",
+    "@amazeelabs/prettier-config": "1.1.3",
+    "@playwright/test": "^1.44.1",
     "@testing-library/react": "14.3.1",
     "@types/lodash-es": "4.17.12",
-    "@types/react": "18.3.1",
+    "@types/node": "^20.14.5",
+    "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "eslint": "8.57.0",
-    "rollup": "4.17.2",
-    "rollup-plugin-dts": "6.1.0",
+    "jsdom": "^24.1.0",
+    "playwright": "^1.44.1",
+    "prettier": "3.2.5",
+    "react": "^19.0.0-rc.0",
+    "react-dom": "^19.0.0-rc.0",
+    "ts-expect": "^1.3.0",
     "typescript": "5.4.5",
-    "vitest": "1.6.0"
+    "vitest": "1.5.0",
+    "tsup": "^8.0.1",
+    "waku": "0.21.0-alpha.2"
   }
 }

--- a/packages/npm/@amazeelabs/executors/playwright.config.ts
+++ b/packages/npm/@amazeelabs/executors/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './test',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'list',
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm test:start',
+    url: 'http://127.0.0.1:8080/static',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/packages/npm/@amazeelabs/executors/rollup.config.js
+++ b/packages/npm/@amazeelabs/executors/rollup.config.js
@@ -1,8 +1,0 @@
-import { defineConfig } from 'rollup';
-import dts from 'rollup-plugin-dts';
-
-export default defineConfig({
-  input: 'build/dts/index.d.ts',
-  output: [{ file: 'build/index.d.ts', format: 'es' }],
-  plugins: [dts()],
-});

--- a/packages/npm/@amazeelabs/executors/src/client.tsx
+++ b/packages/npm/@amazeelabs/executors/src/client.tsx
@@ -1,0 +1,114 @@
+'use client';
+import {
+  AnyOperationId,
+  OperationResult,
+  OperationVariables,
+} from '@amazeelabs/codegen-operation-ids';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+import type {
+  Operation as ComponentType,
+  OperationExecutorsProvider as ProviderType,
+  useOperationExecutor as HookType,
+} from './interface.js';
+import { findExecutor, mergeExecutors } from './lib.js';
+import type {
+  ExecutorFunction,
+  OperationProps,
+  RegistryEntry,
+} from './types.js';
+
+const ExecutorsContext = createContext<{
+  executors: RegistryEntry[];
+}>({
+  executors: [],
+});
+
+export const OperationExecutorsProvider: ProviderType = ({
+  children,
+  executors,
+}) => {
+  const upstream = useContext(ExecutorsContext).executors;
+  const merged = mergeExecutors(upstream, executors);
+  return (
+    <ExecutorsContext.Provider
+      value={{
+        executors: merged,
+      }}
+    >
+      {children}
+    </ExecutorsContext.Provider>
+  );
+};
+
+export const useOperationExecutor: HookType = <
+  TOperation extends AnyOperationId,
+>(
+  id: TOperation,
+  variables?: OperationVariables<TOperation>,
+) => {
+  const { executors } = useContext(ExecutorsContext);
+  const op = findExecutor(executors, id, variables);
+  if (typeof op.executor === 'function') {
+    return (vars?: OperationVariables<TOperation>) => op.executor(id, vars);
+  }
+  return op.executor;
+};
+
+function StaticOperation<TOperation extends AnyOperationId>({
+  children,
+  result,
+}: Pick<OperationProps<TOperation>, 'children'> & {
+  result: OperationResult<TOperation>;
+}) {
+  return children({ state: 'success', data: result });
+}
+
+function DelayedOperation<TOperation extends AnyOperationId>({
+  variables,
+  children,
+  executor,
+}: OperationProps<TOperation> & {
+  executor: ExecutorFunction<TOperation>;
+}) {
+  const [state, setState] =
+    useState<Parameters<OperationProps<TOperation>['children']>[0]['state']>(
+      'loading',
+    );
+
+  const [data, setData] = useState<OperationResult<TOperation> | undefined>(
+    undefined,
+  );
+
+  const [error, setError] = useState<unknown>();
+
+  useEffect(() => {
+    executor(variables)
+      .then((result) => {
+        setData(result);
+        setState('success');
+        return;
+      })
+      .catch((error) => {
+        setError(error);
+        setState('error');
+      });
+  }, [executor, variables]);
+
+  return children({ state, error, data });
+}
+
+export const Operation: ComponentType = <TOperation extends AnyOperationId>({
+  id,
+  variables,
+  children,
+}: OperationProps<TOperation>) => {
+  const executor = useOperationExecutor(id, variables);
+  return executor instanceof Function ? (
+    <DelayedOperation id={id} variables={variables} executor={executor}>
+      {children}
+    </DelayedOperation>
+  ) : (
+    <StaticOperation result={executor}>{children}</StaticOperation>
+  );
+};

--- a/packages/npm/@amazeelabs/executors/src/index.ts
+++ b/packages/npm/@amazeelabs/executors/src/index.ts
@@ -1,1 +1,0 @@
-export { OperationExecutor, useExecutor } from './lib.js';

--- a/packages/npm/@amazeelabs/executors/src/interface.ts
+++ b/packages/npm/@amazeelabs/executors/src/interface.ts
@@ -1,0 +1,24 @@
+import type {
+  AnyOperationId,
+  OperationVariables,
+} from '@amazeelabs/codegen-operation-ids';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import type { ExecutorFunction, OperationProps, RegistryEntry } from './types';
+
+export type Operation = <TOperation extends AnyOperationId>(
+  props: undefined extends OperationVariables<TOperation>
+    ? Omit<OperationProps<TOperation>, 'variables'>
+    : OperationProps<TOperation> & {
+        variables: OperationVariables<TOperation>;
+      },
+) => ReactNode;
+
+export type useOperationExecutor = <TOperation extends AnyOperationId>(
+  id: TOperation,
+  variables?: OperationVariables<TOperation>,
+) => ExecutorFunction<TOperation>;
+
+export type OperationExecutorsProvider = (
+  props: PropsWithChildren<{ executors: Array<RegistryEntry<AnyOperationId>> }>,
+) => ReactNode;

--- a/packages/npm/@amazeelabs/executors/src/lib.tsx
+++ b/packages/npm/@amazeelabs/executors/src/lib.tsx
@@ -1,74 +1,36 @@
 import { isMatch } from 'lodash-es';
-import React, { createContext, PropsWithChildren, useContext } from 'react';
 
-type Executor =
-  | any
-  | ((id: string, variables: Record<string, any>) => any | Promise<any>);
+import { RegistryEntry } from './types.js';
 
 type VariablesMatcher =
   | Record<string, any>
   | ((vars: Record<string, any>) => boolean);
 
-type RegistryEntry = {
-  executor: Executor;
-  id?: string;
-  variables?: VariablesMatcher;
-};
-
-const ExecutorsContext = createContext<{
-  executors: RegistryEntry[];
-}>({
-  executors: [],
-});
-
-export function useExecutor(id: string, variables?: Record<string, any>) {
-  const { executors } = useContext(ExecutorsContext);
-  const op = getCandidates(id, executors)
-    .filter((entry) => matchVariables(entry.variables, variables))
-    .pop();
-
-  if (op) {
-    if (typeof op.executor === 'function') {
-      return (vars?: Record<string, any>) => op.executor(id, vars);
-    }
-    return op.executor;
-  }
-  throw new ExecutorRegistryError(executors, id, variables);
-}
-
-export function OperationExecutor({
-  children,
-  ...entry
-}: PropsWithChildren<RegistryEntry>) {
-  const upstream = useContext(ExecutorsContext).executors;
-  const merged = mergeExecutors(upstream, [entry]);
-  return (
-    <ExecutorsContext.Provider
-      value={{
-        executors: merged,
-      }}
-    >
-      {children}
-    </ExecutorsContext.Provider>
-  );
-}
-
-function executorMap(executors: RegistryEntry[]) {
-  return Object.fromEntries(
-    executors.map((ex) => [`${ex.id}:${JSON.stringify(ex.variables)}`, ex]),
-  );
-}
-
-function mergeExecutors(
+export function mergeExecutors(
   oldExecutors: RegistryEntry[],
   newExecutors: RegistryEntry[],
 ): RegistryEntry[] {
-  return Object.values(
-    Object.assign({}, executorMap(oldExecutors), executorMap(newExecutors)),
-  );
+  return [...oldExecutors, ...newExecutors];
 }
 
-function matchVariables(matcher: VariablesMatcher | undefined, variables: any) {
+export function findExecutor(
+  executors: RegistryEntry[],
+  id: string,
+  variables: any,
+) {
+  const op = getCandidates(id, executors)
+    .filter((entry) => matchVariables(entry.variables, variables))
+    .pop();
+  if (!op) {
+    throw new ExecutorRegistryError(executors, id, variables);
+  }
+  return op;
+}
+
+export function matchVariables(
+  matcher: VariablesMatcher | undefined,
+  variables: any,
+) {
   if (typeof matcher === 'undefined') {
     return true;
   }
@@ -78,22 +40,18 @@ function matchVariables(matcher: VariablesMatcher | undefined, variables: any) {
   return isMatch(variables, matcher);
 }
 
-function getCandidates(id: string, registry: RegistryEntry[]) {
+export function getCandidates(id: string, registry: RegistryEntry[]) {
   return (registry as Array<RegistryEntry>).filter(
     (entry) => id === entry.id || entry.id === undefined,
   );
 }
 
-function formatEntry(id: string | undefined, variables?: Record<string, any>) {
+function formatEntry(id: string | undefined, variables?: unknown) {
   return `${id ? id : '*'}:${variables ? JSON.stringify(variables) : '*'}`;
 }
 
-class ExecutorRegistryError extends Error {
-  constructor(
-    registry: RegistryEntry[],
-    id: string,
-    variables?: Record<string, any>,
-  ) {
+export class ExecutorRegistryError extends Error {
+  constructor(registry: RegistryEntry[], id: string, variables?: unknown) {
     const candidates = getCandidates(id, registry);
     const candidatesMessage =
       candidates.length > 0

--- a/packages/npm/@amazeelabs/executors/src/server.tsx
+++ b/packages/npm/@amazeelabs/executors/src/server.tsx
@@ -1,0 +1,83 @@
+import {
+  AnyOperationId,
+  OperationVariables,
+} from '@amazeelabs/codegen-operation-ids';
+import { cache } from 'react';
+
+import type {
+  Operation as ComponentType,
+  OperationExecutorsProvider as ProviderType,
+  useOperationExecutor as HookType,
+} from './interface.js';
+import { ExecutorRegistryError, findExecutor, mergeExecutors } from './lib.js';
+import type { OperationProps, RegistryEntry } from './types.js';
+
+function serverContext<T>(defaultValue: T): [() => T, (v: T) => void] {
+  const getRef = cache(() => ({ current: defaultValue }));
+
+  const getValue = (): T => getRef().current;
+
+  const setValue = (value: T) => {
+    getRef().current = value;
+  };
+
+  return [getValue, setValue];
+}
+
+const [getRegistry, setRegistry] = serverContext<
+  RegistryEntry<AnyOperationId>[]
+>([]);
+
+export const OperationExecutorsProvider: ProviderType = ({
+  children,
+  executors,
+}) => {
+  const registry = getRegistry();
+  if (registry.length) {
+    throw new Error(
+      'OperationExecutor can only be used once in a server context.',
+    );
+  }
+  setRegistry(mergeExecutors(registry, executors));
+  return children;
+};
+
+export const useOperationExecutor: HookType = <
+  TOperation extends AnyOperationId,
+>(
+  id: TOperation,
+  variables: OperationVariables<TOperation>,
+) => {
+  const op = findExecutor(getRegistry(), id, variables);
+  if (op) {
+    if (typeof op.executor === 'function') {
+      return (vars) => op.executor(id, vars);
+    }
+    return op.executor;
+  }
+  throw new ExecutorRegistryError(getRegistry(), id, variables);
+};
+
+type Promisify<T extends (...args: any) => any> = (
+  ...args: Parameters<T>
+) => Promise<ReturnType<T>>;
+
+type ServerComponentType = Promisify<ComponentType>;
+
+export const Operation: ComponentType = (async <
+  TOperation extends AnyOperationId,
+>({
+  id,
+  variables,
+  children,
+}: OperationProps<TOperation>) => {
+  try {
+    const executor = useOperationExecutor(id, variables);
+    if (executor instanceof Function) {
+      return children({ state: 'success', data: await executor(variables) });
+    }
+    return children({ state: 'success', data: executor });
+  } catch (error) {
+    return children({ state: 'error', error });
+  }
+}) satisfies ServerComponentType as unknown as ComponentType;

--- a/packages/npm/@amazeelabs/executors/src/types.ts
+++ b/packages/npm/@amazeelabs/executors/src/types.ts
@@ -1,0 +1,94 @@
+import type {
+  AnyOperationId,
+  OperationId,
+  OperationResult,
+  OperationVariables,
+} from '@amazeelabs/codegen-operation-ids';
+import type { ReactNode } from 'react';
+import { expectType } from 'ts-expect';
+
+type TestWithVariables = OperationId<{ hasVariables: true }, { a: string }>;
+type TestWithoutVariables = OperationId<
+  { hasVariables: false },
+  { [key: string]: never } | undefined
+>;
+
+export type ExecutorFunction<TOperation extends AnyOperationId> = (
+  variables: OperationVariables<TOperation>,
+) => Promise<OperationResult<TOperation>>;
+
+export type Executor<TOperation extends AnyOperationId> =
+  | OperationResult<TOperation>
+  | ((
+      id: TOperation,
+      variables: OperationVariables<TOperation>,
+    ) => Promise<OperationResult<TOperation>>);
+
+type ExecutorWithVariables = Executor<TestWithVariables>;
+type ExecutorWithoutVariables = Executor<TestWithoutVariables>;
+
+expectType<ExecutorWithVariables>({ hasVariables: true });
+expectType<ExecutorWithVariables>(
+  (id: TestWithVariables, variables: { a: string }) =>
+    new Promise(() => ({ hasVariables: true, id, variables })),
+);
+
+expectType<ExecutorWithoutVariables>({ hasVariables: false });
+expectType<ExecutorWithoutVariables>(
+  (id: TestWithoutVariables) =>
+    new Promise(() => ({ hasVariables: false, id })),
+);
+
+type VariablesMatcher<TOperation extends AnyOperationId> =
+  | OperationVariables<TOperation>
+  | ((vars: OperationVariables<TOperation>) => boolean);
+
+expectType<VariablesMatcher<TestWithVariables>>({ a: 'string' });
+expectType<VariablesMatcher<TestWithVariables>>(
+  (vars: { a: string }) => !!vars,
+);
+
+expectType<VariablesMatcher<TestWithoutVariables>>({});
+
+export type RegistryEntry<TOperation extends AnyOperationId = AnyOperationId> =
+  {
+    executor: Executor<TOperation>;
+    id?: TOperation;
+    variables?: VariablesMatcher<TOperation>;
+  };
+
+type RegistryEntryWithVariables = RegistryEntry<TestWithVariables>;
+type RegistryEntryWithoutVariables = RegistryEntry<TestWithoutVariables>;
+expectType<RegistryEntryWithVariables>({
+  id: '' as TestWithVariables,
+  executor: { hasVariables: true },
+  variables: { a: 'string' },
+});
+
+expectType<RegistryEntryWithoutVariables>({
+  id: '' as TestWithoutVariables,
+  executor: { hasVariables: false },
+});
+
+type OperationChildProps<TOperation extends AnyOperationId> =
+  | {
+      state: 'loading';
+    }
+  | {
+      state: 'error';
+      error: unknown;
+    }
+  | {
+      state: 'updating';
+      data: OperationResult<TOperation>;
+    }
+  | {
+      state: 'success';
+      data: OperationResult<TOperation>;
+    };
+
+export type OperationProps<TOperation extends AnyOperationId> = {
+  id: TOperation;
+  children: (props: OperationChildProps<TOperation>) => ReactNode;
+  variables?: OperationVariables<TOperation>;
+};

--- a/packages/npm/@amazeelabs/executors/test/executors.spec.ts
+++ b/packages/npm/@amazeelabs/executors/test/executors.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+['static', 'dynamic', 'client'].forEach((render) => {
+  const cases = {
+    Hardcoded: 'Hardcoded: 1 + 2 = 3',
+    Delayed: 'Delayed: 2 + 3 = 5',
+    Error: 'Error: I dont like 6es!',
+    DelayedError: 'Error: I dont like 7s!',
+  };
+  Object.entries(cases).forEach(([label, expected]) => {
+    test(`${render}: ${label}`, async ({ page }) => {
+      await page.goto(`http://localhost:8080/${render}`);
+      await expect(page.getByTestId(label)).toHaveText(expected);
+    });
+  });
+});

--- a/packages/npm/@amazeelabs/executors/test/src/add-client.tsx
+++ b/packages/npm/@amazeelabs/executors/test/src/add-client.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { Operation, OperationExecutorsProvider } from '../../src/client.js';
+import { TestComponent } from './add.js';
+
+export const Add = () => (
+  <TestComponent
+    label={'Client'}
+    OperationExecutorsProvider={OperationExecutorsProvider}
+    Operation={Operation}
+  />
+);

--- a/packages/npm/@amazeelabs/executors/test/src/add-server.tsx
+++ b/packages/npm/@amazeelabs/executors/test/src/add-server.tsx
@@ -1,0 +1,10 @@
+import { Operation, OperationExecutorsProvider } from '../../src/server.js';
+import { TestComponent } from './add.js';
+
+export const Add = ({ label }: { label: string }) => (
+  <TestComponent
+    OperationExecutorsProvider={OperationExecutorsProvider}
+    Operation={Operation}
+    label={label}
+  />
+);

--- a/packages/npm/@amazeelabs/executors/test/src/add.tsx
+++ b/packages/npm/@amazeelabs/executors/test/src/add.tsx
@@ -1,0 +1,102 @@
+import type { OperationId } from '@amazeelabs/codegen-operation-ids';
+
+import type {
+  Operation as ComponentType,
+  OperationExecutorsProvider as ProviderType,
+} from '../../src/interface.js';
+import type { RegistryEntry } from '../../src/types.js';
+
+export const AddOperation = 'add_two_numbers' as OperationId<
+  { result: number },
+  { a: number; b: number }
+>;
+
+async function sleep(milliseconds: number) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export const HardcodedAdd: RegistryEntry<typeof AddOperation> = {
+  id: AddOperation,
+  executor: { result: 3 },
+  variables: { a: 1, b: 2 },
+};
+
+export const ErrorAdd: RegistryEntry<typeof AddOperation> = {
+  id: AddOperation,
+  executor: async () => {
+    throw 'I dont like 6es!';
+  },
+  variables: function Sixes({ a, b }) {
+    return a === 6 && b === 6;
+  },
+};
+
+export const DelayedErrorAdd: RegistryEntry<typeof AddOperation> = {
+  id: AddOperation,
+  executor: async () => {
+    await sleep(1000);
+    throw 'I dont like 7s!';
+  },
+  variables: function Sevens({ a, b }) {
+    return a === 7 && b === 7;
+  },
+};
+
+export const DelayedAdd: RegistryEntry<typeof AddOperation> = {
+  executor: async (_, { a, b }) => {
+    await sleep(1000);
+    return { result: a + b };
+  },
+};
+
+export function Calc({
+  label,
+  a,
+  b,
+  Operation,
+}: {
+  label: string;
+  a: number;
+  b: number;
+  Operation: ComponentType;
+}) {
+  return (
+    <Operation id={AddOperation} variables={{ a, b }}>
+      {(props) => {
+        if (props.state === 'loading') {
+          return <p data-testid={label}>Loading...</p>;
+        }
+        if (props.state === 'error') {
+          return <p data-testid={label}>Error: {`${props.error}`}</p>;
+        }
+        return (
+          <p data-testid={label}>
+            {label}: {a} + {b} = {props.data.result}
+          </p>
+        );
+      }}
+    </Operation>
+  );
+}
+
+export function TestComponent({
+  label,
+  OperationExecutorsProvider,
+  Operation,
+}: {
+  label: string;
+  OperationExecutorsProvider: ProviderType;
+  Operation: ComponentType;
+}) {
+  return (
+    <OperationExecutorsProvider
+      executors={[DelayedAdd, HardcodedAdd, ErrorAdd, DelayedErrorAdd]}
+    >
+      <h1>{label}</h1>
+      <Calc label="Hardcoded" a={1} b={2} Operation={Operation} />
+      <Calc label="Delayed" a={2} b={3} Operation={Operation} />
+      <Calc label="Error" a={6} b={6} Operation={Operation} />
+      <Calc label="DelayedError" a={7} b={7} Operation={Operation} />
+    </OperationExecutorsProvider>
+  );
+}

--- a/packages/npm/@amazeelabs/executors/test/src/pages/client.tsx
+++ b/packages/npm/@amazeelabs/executors/test/src/pages/client.tsx
@@ -1,0 +1,11 @@
+import { Add } from '../add-client.js';
+
+export default function Static() {
+  return <Add />;
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'static',
+  };
+};

--- a/packages/npm/@amazeelabs/executors/test/src/pages/dynamic.tsx
+++ b/packages/npm/@amazeelabs/executors/test/src/pages/dynamic.tsx
@@ -1,0 +1,5 @@
+import { Add } from '../add-server.js';
+
+export default function Dynamic() {
+  return <Add label="Dynamic" />;
+}

--- a/packages/npm/@amazeelabs/executors/test/src/pages/static.tsx
+++ b/packages/npm/@amazeelabs/executors/test/src/pages/static.tsx
@@ -1,0 +1,11 @@
+import { Add } from '../add-server.js';
+
+export default function Static() {
+  return <Add label="Static" />;
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'static',
+  };
+};

--- a/packages/npm/@amazeelabs/executors/tsconfig.json
+++ b/packages/npm/@amazeelabs/executors/tsconfig.json
@@ -12,9 +12,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "declaration": true,
-    "declarationDir": "build/dts",
+    "declarationDir": "build",
     "outDir": "build",
+    "types": ["react/experimental"],
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/npm/@amazeelabs/executors/vitest.config.ts
+++ b/packages/npm/@amazeelabs/executors/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.tsx'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,13 +14,13 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: 19.3.0
-        version: 19.3.0(@types/node@20.12.11)(typescript@5.4.5)
+        version: 19.3.0(@types/node@20.14.9)(typescript@5.4.5)
       '@commitlint/config-conventional':
         specifier: 19.2.2
         version: 19.2.2
       commitizen:
         specifier: 4.3.0
-        version: 4.3.0(@types/node@20.12.11)(typescript@5.4.5)
+        version: 4.3.0(@types/node@20.14.9)(typescript@5.4.5)
       husky:
         specifier: 9.0.11
         version: 9.0.11
@@ -56,10 +56,10 @@ importers:
         version: 2.6.3(@opentelemetry/api@1.8.0)
       decap-cms-app:
         specifier: 3.1.10
-        version: 3.1.10(@types/node@20.12.11)(@types/react@18.3.1)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)
+        version: 3.1.10(@types/node@20.14.9)(@types/react@18.3.1)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)
       netlify-cli:
         specifier: 17.23.2
-        version: 17.23.2(@types/node@20.12.11)
+        version: 17.23.2(@types/node@20.14.9)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -96,7 +96,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.11
-        version: 5.2.11(@types/node@20.12.11)
+        version: 5.2.11(@types/node@20.14.9)
 
   apps/silverback-drupal:
     dependencies:
@@ -478,7 +478,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
     devDependencies:
       '@amazeelabs/eslint-config':
         specifier: 1.4.43
@@ -507,7 +507,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
     devDependencies:
       '@amazeelabs/bridge':
         specifier: workspace:*
@@ -551,7 +551,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.12.11)
 
   packages/npm/@amazeelabs/codegen-autoloader:
     dependencies:
@@ -570,7 +570,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
 
   packages/npm/@amazeelabs/codegen-gatsby-fragments:
     dependencies:
@@ -586,7 +586,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
     devDependencies:
       '@amazeelabs/eslint-config':
         specifier: 1.4.43
@@ -615,7 +615,7 @@ importers:
         version: 1.4.43(eslint@8.57.0)(tailwindcss@3.4.3)(typescript@5.4.5)
       '@graphql-codegen/cli':
         specifier: 5.0.2
-        version: 5.0.2(@types/node@20.12.11)(graphql@16.8.1)(typescript@5.4.5)
+        version: 5.0.2(@types/node@20.14.9)(graphql@16.8.1)(typescript@5.4.5)
       '@graphql-codegen/typescript':
         specifier: 4.0.6
         version: 4.0.6(graphql@16.8.1)
@@ -636,10 +636,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.11
-        version: 5.2.11(@types/node@20.12.11)
+        version: 5.2.11(@types/node@20.14.9)
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
 
   packages/npm/@amazeelabs/decap-cms-backend-token-auth:
     dependencies:
@@ -770,50 +770,80 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
 
   packages/npm/@amazeelabs/executors:
     dependencies:
+      '@amazeelabs/codegen-operation-ids':
+        specifier: workspace:*
+        version: link:../codegen-operation-ids
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+      react-server-dom-webpack:
+        specifier: 19.0.0-rc.0
+        version: 19.0.0-rc.0(react-dom@19.0.0-rc.0)(react@19.0.0-rc.0)(webpack@5.91.0)
+      server-only-context:
+        specifier: ^0.1.0
+        version: 0.1.0(react@19.0.0-rc.0)
     devDependencies:
       '@amazeelabs/eslint-config':
         specifier: 1.4.43
         version: 1.4.43(eslint@8.57.0)(tailwindcss@3.4.3)(typescript@5.4.5)
+      '@amazeelabs/prettier-config':
+        specifier: 1.1.3
+        version: 1.1.3(prettier@3.2.5)
+      '@playwright/test':
+        specifier: ^1.44.1
+        version: 1.44.1
       '@testing-library/react':
         specifier: 14.3.1
-        version: 14.3.1(react-dom@18.3.1)(react@18.3.1)
+        version: 14.3.1(react-dom@19.0.0-rc.0)(react@19.0.0-rc.0)
       '@types/lodash-es':
         specifier: 4.17.12
         version: 4.17.12
+      '@types/node':
+        specifier: ^20.14.5
+        version: 20.14.5
       '@types/react':
-        specifier: 18.3.1
-        version: 18.3.1
+        specifier: 18.3.3
+        version: 18.3.3
       '@types/react-dom':
         specifier: 18.3.0
         version: 18.3.0
       eslint:
         specifier: 8.57.0
         version: 8.57.0
-      rollup:
-        specifier: 4.17.2
-        version: 4.17.2
-      rollup-plugin-dts:
-        specifier: 6.1.0
-        version: 6.1.0(rollup@4.17.2)(typescript@5.4.5)
+      jsdom:
+        specifier: ^24.1.0
+        version: 24.1.0
+      playwright:
+        specifier: ^1.44.1
+        version: 1.44.1
+      prettier:
+        specifier: 3.2.5
+        version: 3.2.5
+      react:
+        specifier: ^19.0.0-rc.0
+        version: 19.0.0-rc.0
+      react-dom:
+        specifier: ^19.0.0-rc.0
+        version: 19.0.0-rc.0(react@19.0.0-rc.0)
+      ts-expect:
+        specifier: ^1.3.0
+        version: 1.3.0
+      tsup:
+        specifier: ^8.0.1
+        version: 8.0.2(postcss@8.4.38)(typescript@5.4.5)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
       vitest:
-        specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        specifier: 1.5.0
+        version: 1.5.0(@types/node@20.14.5)(jsdom@24.1.0)
+      waku:
+        specifier: 0.21.0-alpha.2
+        version: 0.21.0-alpha.2(@types/node@20.14.5)(react-dom@19.0.0-rc.0)(react-server-dom-webpack@19.0.0-rc.0)(react@19.0.0-rc.0)
 
   packages/npm/@amazeelabs/gatsby-fragments:
     devDependencies:
@@ -852,7 +882,7 @@ importers:
         version: 10.3.14
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.12.11)
+        version: 29.7.0(@types/node@20.14.9)
       mock-fs:
         specifier: 5.2.0
         version: 5.2.0
@@ -956,7 +986,7 @@ importers:
         version: 16.8.1
       graphql-config:
         specifier: 5.0.3
-        version: 5.0.3(@types/node@20.12.11)(graphql@16.8.1)(typescript@5.4.5)
+        version: 5.0.3(@types/node@20.14.9)(graphql@16.8.1)(typescript@5.4.5)
       isomorphic-fetch:
         specifier: 3.0.0
         version: 3.0.0
@@ -1005,7 +1035,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
 
   packages/npm/@amazeelabs/graphql-directives:
     dependencies:
@@ -1027,7 +1057,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
 
   packages/npm/@amazeelabs/molecules:
     dependencies:
@@ -1142,7 +1172,7 @@ importers:
         version: 4.17.21
       netlify-cli:
         specifier: 17.23.2
-        version: 17.23.2(@types/node@20.12.11)
+        version: 17.23.2(@types/node@20.14.9)
       postcss:
         specifier: 8.4.38
         version: 8.4.38
@@ -1163,16 +1193,16 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.11
-        version: 5.2.11(@types/node@20.12.11)
+        version: 5.2.11(@types/node@20.14.9)
       vite-imagetools:
         specifier: 7.0.2
         version: 7.0.2
       vite-plugin-dts:
         specifier: 3.9.1
-        version: 3.9.1(@types/node@20.12.11)(typescript@5.4.5)(vite@5.2.11)
+        version: 3.9.1(@types/node@20.14.9)(typescript@5.4.5)(vite@5.2.11)
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
       zustand:
         specifier: 4.5.2
         version: 4.5.2(@types/react@18.3.1)(react@18.3.1)
@@ -1242,10 +1272,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.11
-        version: 5.2.11(@types/node@20.12.11)
+        version: 5.2.11(@types/node@20.14.9)
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
 
   packages/npm/@amazeelabs/publisher:
     dependencies:
@@ -1483,7 +1513,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.11
-        version: 5.2.11(@types/node@20.12.11)
+        version: 5.2.11(@types/node@20.14.9)
 
   packages/npm/@amazeelabs/react-intl-rsc:
     dependencies:
@@ -1577,7 +1607,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
     devDependencies:
       '@swc/cli':
         specifier: 0.3.12
@@ -1609,7 +1639,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.12.11)
+        version: 29.7.0(@types/node@20.14.9)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1697,7 +1727,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+        version: 1.6.0(@types/node@20.12.11)
 
   packages/npm/gatsby-plugin-schema-export:
     dependencies:
@@ -1954,7 +1984,7 @@ packages:
       '@tsconfig/recommended': 1.0.6
       '@types/jest': 29.5.12
       identity-obj-proxy: 3.0.0
-      jest: 29.7.0(@types/node@20.12.11)
+      jest: 29.7.0(@types/node@20.14.9)
       jest-environment-jsdom: 29.7.0
       jest-runner-eslint: 1.2.0(eslint@8.57.0)(jest@29.7.0)
       jest-watch-select-projects: 2.0.0
@@ -3540,14 +3570,14 @@ packages:
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
 
-  /@commitlint/cli@19.3.0(@types/node@20.12.11)(typescript@5.4.5):
+  /@commitlint/cli@19.3.0(@types/node@20.14.9)(typescript@5.4.5):
     resolution: {integrity: sha512-LgYWOwuDR7BSTQ9OLZ12m7F/qhNY+NpAyPBgo4YNMkACE7lGuUnuQq1yi9hz1KA4+3VqpOYl8H1rY/LYK43v7g==}
     engines: {node: '>=v18'}
     hasBin: true
     dependencies:
       '@commitlint/format': 19.3.0
       '@commitlint/lint': 19.2.2
-      '@commitlint/load': 19.2.0(@types/node@20.12.11)(typescript@5.4.5)
+      '@commitlint/load': 19.2.0(@types/node@20.14.9)(typescript@5.4.5)
       '@commitlint/read': 19.2.1
       '@commitlint/types': 19.0.3
       execa: 8.0.1
@@ -3616,7 +3646,7 @@ packages:
       '@commitlint/types': 19.0.3
     dev: true
 
-  /@commitlint/load@19.2.0(@types/node@20.12.11)(typescript@5.4.5):
+  /@commitlint/load@19.2.0(@types/node@20.14.9)(typescript@5.4.5):
     resolution: {integrity: sha512-XvxxLJTKqZojCxaBQ7u92qQLFMMZc4+p9qrIq/9kJDy8DOrEa7P1yx7Tjdc2u2JxIalqT4KOGraVgCE7eCYJyQ==}
     engines: {node: '>=v18'}
     dependencies:
@@ -3626,7 +3656,7 @@ packages:
       '@commitlint/types': 19.0.3
       chalk: 5.3.0
       cosmiconfig: 9.0.0(typescript@5.4.5)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.12.11)(cosmiconfig@9.0.0)(typescript@5.4.5)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.14.9)(cosmiconfig@9.0.0)(typescript@5.4.5)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -3865,7 +3895,7 @@ packages:
       vitest: ^1.4.0
     dependencies:
       effect: 3.1.4
-      vitest: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+      vitest: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
     dev: true
 
   /@emnapi/runtime@1.1.1:
@@ -4004,7 +4034,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/aix-ppc64@0.20.2:
@@ -4038,7 +4067,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.20.2:
@@ -4072,7 +4100,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.20.2:
@@ -4106,7 +4133,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.20.2:
@@ -4140,7 +4166,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.20.2:
@@ -4174,7 +4199,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.20.2:
@@ -4208,7 +4232,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.20.2:
@@ -4242,7 +4265,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.20.2:
@@ -4276,7 +4298,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.20.2:
@@ -4310,7 +4331,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.20.2:
@@ -4344,7 +4364,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.20.2:
@@ -4378,7 +4397,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.20.2:
@@ -4412,7 +4430,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.20.2:
@@ -4446,7 +4463,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.20.2:
@@ -4480,7 +4496,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.20.2:
@@ -4514,7 +4529,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.20.2:
@@ -4548,7 +4562,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.20.2:
@@ -4582,7 +4595,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.20.2:
@@ -4616,7 +4628,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.20.2:
@@ -4650,7 +4661,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.20.2:
@@ -4684,7 +4694,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.20.2:
@@ -4718,7 +4727,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.20.2:
@@ -4752,7 +4760,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.20.2:
@@ -5092,7 +5099,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@graphql-codegen/cli@5.0.2(@types/node@20.12.11)(graphql@16.8.1)(typescript@5.4.5):
+  /@graphql-codegen/cli@5.0.2(@types/node@20.14.9)(graphql@16.8.1)(typescript@5.4.5):
     resolution: {integrity: sha512-MBIaFqDiLKuO4ojN6xxG9/xL9wmfD3ZjZ7RsPjwQnSHBCUXnEkdKvX+JVpx87Pq29Ycn8wTJUguXnTZ7Di0Mlw==}
     hasBin: true
     peerDependencies:
@@ -5111,12 +5118,12 @@ packages:
       '@graphql-tools/apollo-engine-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/code-file-loader': 8.1.1(graphql@16.8.1)
       '@graphql-tools/git-loader': 8.0.5(graphql@16.8.1)
-      '@graphql-tools/github-loader': 8.0.1(@types/node@20.12.11)(graphql@16.8.1)
+      '@graphql-tools/github-loader': 8.0.1(@types/node@20.14.9)(graphql@16.8.1)
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/load': 8.0.2(graphql@16.8.1)
-      '@graphql-tools/prisma-loader': 8.0.4(@types/node@20.12.11)(graphql@16.8.1)
-      '@graphql-tools/url-loader': 8.0.2(@types/node@20.12.11)(graphql@16.8.1)
+      '@graphql-tools/prisma-loader': 8.0.4(@types/node@20.14.9)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@20.14.9)(graphql@16.8.1)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       '@whatwg-node/fetch': 0.8.8
       chalk: 4.1.2
@@ -5124,7 +5131,7 @@ packages:
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.8.1
-      graphql-config: 5.0.3(@types/node@20.12.11)(graphql@16.8.1)(typescript@5.4.5)
+      graphql-config: 5.0.3(@types/node@20.14.9)(graphql@16.8.1)(typescript@5.4.5)
       inquirer: 8.2.6
       is-glob: 4.0.3
       jiti: 1.21.0
@@ -5508,7 +5515,7 @@ packages:
       - '@types/node'
     dev: true
 
-  /@graphql-tools/executor-http@1.0.9(@types/node@20.12.11)(graphql@16.8.1):
+  /@graphql-tools/executor-http@1.0.9(@types/node@20.14.9)(graphql@16.8.1):
     resolution: {integrity: sha512-+NXaZd2MWbbrWHqU4EhXcrDbogeiCDmEbrAN+rMn4Nu2okDjn2MTFDbTIab87oEubQCH4Te1wDkWPKrzXup7+Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -5519,7 +5526,7 @@ packages:
       '@whatwg-node/fetch': 0.9.17
       extract-files: 11.0.0
       graphql: 16.8.1
-      meros: 1.3.0(@types/node@20.12.11)
+      meros: 1.3.0(@types/node@20.14.9)
       tslib: 2.6.2
       value-or-promise: 1.0.12
     transitivePeerDependencies:
@@ -5591,14 +5598,14 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-tools/github-loader@8.0.1(@types/node@20.12.11)(graphql@16.8.1):
+  /@graphql-tools/github-loader@8.0.1(@types/node@20.14.9)(graphql@16.8.1):
     resolution: {integrity: sha512-W4dFLQJ5GtKGltvh/u1apWRFKBQOsDzFxO9cJkOYZj1VzHCpRF43uLST4VbCfWve+AwBqOuKr7YgkHoxpRMkcg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/executor-http': 1.0.9(@types/node@20.12.11)(graphql@16.8.1)
+      '@graphql-tools/executor-http': 1.0.9(@types/node@20.14.9)(graphql@16.8.1)
       '@graphql-tools/graphql-tag-pluck': 8.3.1(graphql@16.8.1)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       '@whatwg-node/fetch': 0.9.17
@@ -5777,13 +5784,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@graphql-tools/prisma-loader@8.0.4(@types/node@20.12.11)(graphql@16.8.1):
+  /@graphql-tools/prisma-loader@8.0.4(@types/node@20.14.9)(graphql@16.8.1):
     resolution: {integrity: sha512-hqKPlw8bOu/GRqtYr0+dINAI13HinTVYBDqhwGAPIFmLr5s+qKskzgCiwbsckdrb5LWVFmVZc+UXn80OGiyBzg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/url-loader': 8.0.2(@types/node@20.12.11)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@20.14.9)(graphql@16.8.1)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       '@types/js-yaml': 4.0.9
       '@whatwg-node/fetch': 0.9.17
@@ -5885,7 +5892,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@graphql-tools/url-loader@8.0.2(@types/node@20.12.11)(graphql@16.8.1):
+  /@graphql-tools/url-loader@8.0.2(@types/node@20.14.9)(graphql@16.8.1):
     resolution: {integrity: sha512-1dKp2K8UuFn7DFo1qX5c1cyazQv2h2ICwA9esHblEqCYrgf69Nk8N7SODmsfWg94OEaI74IqMoM12t7eIGwFzQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -5894,7 +5901,7 @@ packages:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
       '@graphql-tools/executor-graphql-ws': 1.1.2(graphql@16.8.1)
-      '@graphql-tools/executor-http': 1.0.9(@types/node@20.12.11)(graphql@16.8.1)
+      '@graphql-tools/executor-http': 1.0.9(@types/node@20.14.9)(graphql@16.8.1)
       '@graphql-tools/executor-legacy-ws': 1.0.6(graphql@16.8.1)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       '@graphql-tools/wrap': 10.0.5(graphql@16.8.1)
@@ -6005,6 +6012,11 @@ packages:
       client-only: 0.0.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  /@hono/node-server@1.11.2:
+    resolution: {integrity: sha512-JhX0nUC66GeDxpIdMKWDRMEwtQBa64CY907iAF1sYqb4m2p2PdSU7zkbnNhAZLg/6IjSlTuj6CF307JlBXVvpg==}
+    engines: {node: '>=18.14.1'}
+    dev: true
 
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -6243,7 +6255,7 @@ packages:
       '@inquirer/figures': 1.0.3
       '@inquirer/type': 1.3.3
       '@types/mute-stream': 0.0.4
-      '@types/node': 20.14.2
+      '@types/node': 20.14.9
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -6297,7 +6309,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -6318,14 +6330,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.11)
+      jest-config: 29.7.0(@types/node@20.14.9)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6360,7 +6372,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       jest-mock: 29.7.0
     dev: true
 
@@ -6387,7 +6399,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -6420,7 +6432,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -6506,7 +6518,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
@@ -6517,7 +6529,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
@@ -6536,7 +6548,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.4.5)
       typescript: 5.4.5
-      vite: 5.2.11(@types/node@20.12.11)
+      vite: 5.2.11(@types/node@20.14.9)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.5:
@@ -6856,38 +6868,38 @@ packages:
       react: 18.3.1
     dev: true
 
-  /@mdx-js/react@3.0.1(@types/react@18.3.2)(react@18.3.1):
+  /@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-9ZrPIU4MGf6et1m1ov3zKf+q9+deetI51zprKB1D/z3NOb+rUxxtEl3mCjW5wTGh6VhRdwPueh1oRzi6ezkA8A==}
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       react: 18.3.1
     dev: true
 
-  /@microsoft/api-extractor-model@7.28.13(@types/node@20.12.11):
+  /@microsoft/api-extractor-model@7.28.13(@types/node@20.14.9):
     resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.12.11)
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.14.9)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.43.0(@types/node@20.12.11):
+  /@microsoft/api-extractor@7.43.0(@types/node@20.14.9):
     resolution: {integrity: sha512-GFhTcJpB+MI6FhvXEI9b2K0snulNLWHqC/BbcJtyNYcKUiw7l3Lgis5ApsYncJ0leALX7/of4XfmXk+maT111w==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.13(@types/node@20.12.11)
+      '@microsoft/api-extractor-model': 7.28.13(@types/node@20.14.9)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.12.11)
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.14.9)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.10.0(@types/node@20.12.11)
-      '@rushstack/ts-command-line': 4.19.1(@types/node@20.12.11)
+      '@rushstack/terminal': 0.10.0(@types/node@20.14.9)
+      '@rushstack/ts-command-line': 4.19.1(@types/node@20.14.9)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -7187,6 +7199,84 @@ packages:
       supports-color: 9.4.0
       terminal-link: 3.0.0
       ts-node: 10.9.2(@types/node@20.12.11)(typescript@5.4.5)
+      typescript: 5.4.5
+      uuid: 9.0.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - encoding
+      - picomatch
+    dev: true
+
+  /@netlify/build@29.41.2(@opentelemetry/api@1.8.0)(@types/node@20.14.9):
+    resolution: {integrity: sha512-txcYS00PXfmfw9hIxc4Q5c8p4DLkaGqgX3yjGUH2y/2NXxJQxpZiZBBVYeVW5q0rwb+17trE2gQJ/xnOXo3O5Q==}
+    engines: {node: ^14.16.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@netlify/opentelemetry-sdk-setup': ^1.1.0
+      '@opentelemetry/api': ~1.8.0
+    peerDependenciesMeta:
+      '@netlify/opentelemetry-sdk-setup':
+        optional: true
+    dependencies:
+      '@bugsnag/js': 7.22.7
+      '@netlify/blobs': 7.3.0
+      '@netlify/cache-utils': 5.1.5
+      '@netlify/config': 20.12.3
+      '@netlify/edge-bundler': 12.0.0(supports-color@9.4.0)
+      '@netlify/framework-info': 9.8.11
+      '@netlify/functions-utils': 5.2.56(@opentelemetry/api@1.8.0)(supports-color@9.4.0)
+      '@netlify/git-utils': 5.1.1
+      '@netlify/opentelemetry-utils': 1.2.0(@opentelemetry/api@1.8.0)
+      '@netlify/plugins-list': 6.78.0
+      '@netlify/run-utils': 5.1.1
+      '@netlify/zip-it-and-ship-it': 9.32.1(@opentelemetry/api@1.8.0)(supports-color@9.4.0)
+      '@opentelemetry/api': 1.8.0
+      '@sindresorhus/slugify': 2.2.1
+      ansi-escapes: 6.2.1
+      chalk: 5.3.0
+      clean-stack: 4.2.0
+      execa: 6.1.0
+      fdir: 6.1.1
+      figures: 5.0.0
+      filter-obj: 5.1.0
+      got: 12.6.1
+      hot-shots: 10.0.0
+      indent-string: 5.0.0
+      is-plain-obj: 4.1.0
+      js-yaml: 4.1.0
+      keep-func-props: 4.0.1
+      locate-path: 7.2.0
+      log-process-errors: 8.0.0
+      map-obj: 5.0.2
+      memoize-one: 6.0.0
+      minimatch: 9.0.4
+      node-fetch: 3.3.2
+      os-name: 5.1.0
+      p-event: 5.0.1
+      p-every: 2.0.0
+      p-filter: 3.0.0
+      p-locate: 6.0.0
+      p-map: 6.0.0
+      p-reduce: 3.0.0
+      path-exists: 5.0.0
+      path-type: 5.0.0
+      pkg-dir: 7.0.0
+      pretty-ms: 8.0.0
+      ps-list: 8.1.1
+      read-pkg-up: 9.1.0
+      readdirp: 3.6.0
+      resolve: 2.0.0-next.5
+      rfdc: 1.3.1
+      safe-json-stringify: 1.2.0
+      semver: 7.6.2
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+      supports-color: 9.4.0
+      terminal-link: 3.0.0
+      ts-node: 10.9.2(@types/node@20.14.9)(typescript@5.4.5)
       typescript: 5.4.5
       uuid: 9.0.1
       yargs: 17.7.2
@@ -8637,6 +8727,14 @@ packages:
       playwright: 1.44.0
     dev: true
 
+  /@playwright/test@1.44.1:
+    resolution: {integrity: sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright: 1.44.1
+    dev: true
+
   /@pmmmwh/react-refresh-webpack-plugin@0.5.13(react-refresh@0.14.2)(webpack@5.91.0):
     resolution: {integrity: sha512-odZVYXly+JwzYri9rKqqUAk0cY6zLpv4dxoKinhoJNShV36Gpxf+CyDIILJ4tYsJ1ZxIWs233Y39iVnynvDA/g==}
     engines: {node: '>= 10.13'}
@@ -8708,7 +8806,7 @@ packages:
       react: 18.3.1
     dev: true
 
-  /@radix-ui/react-compose-refs@1.0.1(@types/react@18.3.2)(react@18.3.1):
+  /@radix-ui/react-compose-refs@1.0.1(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
     peerDependencies:
       '@types/react': '*'
@@ -8718,7 +8816,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.5
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       react: 18.3.1
     dev: true
 
@@ -8737,7 +8835,7 @@ packages:
       react: 18.3.1
     dev: true
 
-  /@radix-ui/react-slot@1.0.2(@types/react@18.3.2)(react@18.3.1):
+  /@radix-ui/react-slot@1.0.2(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
     peerDependencies:
       '@types/react': '*'
@@ -8747,8 +8845,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.5
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.2)(react@18.3.1)
-      '@types/react': 18.3.2
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
       react: 18.3.1
     dev: true
 
@@ -8987,7 +9085,7 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rushstack/node-core-library@4.0.2(@types/node@20.12.11):
+  /@rushstack/node-core-library@4.0.2(@types/node@20.14.9):
     resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
     peerDependencies:
       '@types/node': '*'
@@ -8995,7 +9093,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -9011,7 +9109,7 @@ packages:
       strip-json-comments: 3.1.1
     dev: true
 
-  /@rushstack/terminal@0.10.0(@types/node@20.12.11):
+  /@rushstack/terminal@0.10.0(@types/node@20.14.9):
     resolution: {integrity: sha512-UbELbXnUdc7EKwfH2sb8ChqNgapUOdqcCIdQP4NGxBpTZV2sQyeekuK3zmfQSa/MN+/7b4kBogl2wq0vpkpYGw==}
     peerDependencies:
       '@types/node': '*'
@@ -9019,15 +9117,15 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.12.11)
-      '@types/node': 20.12.11
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.14.9)
+      '@types/node': 20.14.9
       supports-color: 8.1.1
     dev: true
 
-  /@rushstack/ts-command-line@4.19.1(@types/node@20.12.11):
+  /@rushstack/ts-command-line@4.19.1(@types/node@20.14.9):
     resolution: {integrity: sha512-J7H768dgcpG60d7skZ5uSSwyCZs/S2HrWP1Ds8d1qYAyaaeJmpmmLr9BVw97RjFzmQPOYnoXcKA4GkqDCkduQg==}
     dependencies:
-      '@rushstack/terminal': 0.10.0(@types/node@20.12.11)
+      '@rushstack/terminal': 0.10.0(@types/node@20.14.9)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -9211,7 +9309,7 @@ packages:
     engines: {node: '>= 18', npm: '>= 8.6.0'}
     dependencies:
       '@slack/types': 2.11.0
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       axios: 1.6.8(debug@4.3.4)
     transitivePeerDependencies:
       - debug
@@ -9256,10 +9354,10 @@ packages:
     resolution: {integrity: sha512-y+Agoez/hXZHKUMIZHU96T5V1v0cs4ArSNfjqDg9DPYcyQ88ihJNb6ZabIgzmEaJF/NncCW+LofWeUtkTwalkw==}
     dependencies:
       '@babel/core': 7.24.5
-      '@mdx-js/react': 3.0.1(@types/react@18.3.2)(react@18.3.1)
-      '@storybook/blocks': 8.0.10(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@mdx-js/react': 3.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@storybook/blocks': 8.0.10(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/client-logger': 8.0.10
-      '@storybook/components': 8.0.10(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/components': 8.0.10(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/csf-plugin': 8.0.10
       '@storybook/csf-tools': 8.0.10
       '@storybook/global': 5.0.0
@@ -9268,7 +9366,7 @@ packages:
       '@storybook/react-dom-shim': 8.0.10(react-dom@18.3.1)(react@18.3.1)
       '@storybook/theming': 8.0.10(react-dom@18.3.1)(react@18.3.1)
       '@storybook/types': 8.0.10
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -9478,7 +9576,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/blocks@8.0.10(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/blocks@8.0.10(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-LOaxvcO2d4dT4YoWlQ0bq/c8qA3aHoqtyuvBjwbVn+359bjMtgj/91YuP9Y2+ggZZ4p+ttgvk39PcmJlNXlJsw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -9491,7 +9589,7 @@ packages:
     dependencies:
       '@storybook/channels': 8.0.10
       '@storybook/client-logger': 8.0.10
-      '@storybook/components': 8.0.10(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/components': 8.0.10(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/core-events': 8.0.10
       '@storybook/csf': 0.1.7
       '@storybook/docs-tools': 8.0.10
@@ -9576,7 +9674,7 @@ packages:
       magic-string: 0.30.10
       ts-dedent: 2.2.0
       typescript: 5.4.5
-      vite: 5.2.11(@types/node@20.12.11)
+      vite: 5.2.11(@types/node@20.14.9)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9867,13 +9965,13 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/components@8.0.10(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/components@8.0.10(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-eo+oDDcm35YBB3dtDYDfcjJypNVPmRty85VWpAOBsJXpwp/fgU8csx0DM3KmhrQ4cWLf2WzcFowJwI1w+J88Sw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.3)(react@18.3.1)
       '@storybook/client-logger': 8.0.10
       '@storybook/csf': 0.1.7
       '@storybook/global': 5.0.0
@@ -10432,7 +10530,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       tsconfig-paths: 4.2.0
-      vite: 5.2.11(@types/node@20.12.11)
+      vite: 5.2.11(@types/node@20.14.9)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -10732,10 +10830,28 @@ packages:
       source-map: 0.7.4
     dev: true
 
+  /@swc/core-darwin-arm64@1.5.24:
+    resolution: {integrity: sha512-M7oLOcC0sw+UTyAuL/9uyB9GeO4ZpaBbH76JSH6g1m0/yg7LYJZGRmplhDmwVSDAR5Fq4Sjoi1CksmmGkgihGA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-darwin-arm64@1.5.5:
     resolution: {integrity: sha512-Ol5ZwZYdTOZsv2NwjcT/qVVALKzVFeh+IJ4GNarr3P99+38Dkwi81OqCI1o/WaDXQYKAQC/V+CzMbkEuJJfq9Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64@1.5.24:
+    resolution: {integrity: sha512-MfcFjGGYognpSBSos2pYUNYJSmqEhuw5ceGr6qAdME7ddbjGXliza4W6FggsM+JnWwpqa31+e7/R+GetW4WkaQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
@@ -10750,6 +10866,15 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-linux-arm-gnueabihf@1.5.24:
+    resolution: {integrity: sha512-amI2pwtcWV3E/m/nf+AQtn1LWDzKLZyjCmWd3ms7QjEueWYrY8cU1Y4Wp7wNNsxIoPOi8zek1Uj2wwFD/pttNQ==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-arm-gnueabihf@1.5.5:
     resolution: {integrity: sha512-vtoWNCWAe+CNSqtqIwFnIH48qgPPlUZKoQ4EVFeMM+7/kDi6SeNxoh5TierJs5bKAWxD49VkPvRoWFCk6V62mA==}
     engines: {node: '>=10'}
@@ -10759,8 +10884,26 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-linux-arm64-gnu@1.5.24:
+    resolution: {integrity: sha512-sTSvmqMmgT1ynH/nP75Pc51s+iT4crZagHBiDOf5cq+kudUYjda9lWMs7xkXB/TUKFHPCRK0HGunl8bkwiIbuw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-arm64-gnu@1.5.5:
     resolution: {integrity: sha512-L4l7M78U6h/rCAxId+y5Vu+1KfDRF6dJZtitFcaT293guiUQFwJv8gLxI4Jh5wFtZ0fYd0QaCuvh2Ip79CzGMg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-musl@1.5.24:
+    resolution: {integrity: sha512-vd2/hfOBGbrX21FxsFdXCUaffjkHvlZkeE2UMRajdXifwv79jqOHIJg3jXG1F3ZrhCghCzirFts4tAZgcG8XWg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -10777,8 +10920,26 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-linux-x64-gnu@1.5.24:
+    resolution: {integrity: sha512-Zrdzi7NqzQxm2BvAG5KyOSBEggQ7ayrxh599AqqevJmsUXJ8o2nMiWQOBvgCGp7ye+Biz3pvZn1EnRzAp+TpUg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-x64-gnu@1.5.5:
     resolution: {integrity: sha512-kj4ZwWJGeBEUzHrRQP2VudN+kkkYH7OI1dPVDc6kWQx5X4329JeKOas4qY0l7gDVjBbRwN9IbbPI6TIn2KfAug==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-musl@1.5.24:
+    resolution: {integrity: sha512-1F8z9NRi52jdZQCGc5sflwYSctL6omxiVmIFVp8TC9nngjQKc00TtX/JC2Eo2HwvgupkFVl5YQJidAck9YtmJw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -10795,10 +10956,28 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-win32-arm64-msvc@1.5.24:
+    resolution: {integrity: sha512-cKpP7KvS6Xr0jFSTBXY53HZX/YfomK5EMQYpCVDOvfsZeYHN20sQSKXfpVLvA/q2igVt1zzy1XJcOhpJcgiKLg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-win32-arm64-msvc@1.5.5:
     resolution: {integrity: sha512-o0/9pstmEjwZyrY/bA+mymF0zH7E+GT/XCVqdKeWW9Wn3gTTyWa5MZnrFgI2THQ+AXwdglMB/Zo76ARQPaz/+A==}
     engines: {node: '>=10'}
     cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-ia32-msvc@1.5.24:
+    resolution: {integrity: sha512-IoPWfi0iwqjZuf7gE223+B97/ZwkKbu7qL5KzGP7g3hJrGSKAvv7eC5Y9r2iKKtLKyv5R/T6Ho0kFR/usi7rHw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
@@ -10813,6 +10992,15 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-win32-x64-msvc@1.5.24:
+    resolution: {integrity: sha512-zHgF2k1uVJL8KIW+PnVz1To4a3Cz9THbh2z2lbehaF/gKHugH4c3djBozU4das1v35KOqf5jWIEviBLql2wDLQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-win32-x64-msvc@1.5.5:
     resolution: {integrity: sha512-ry83ki9ZX0Q+GWGnqc2J618Z+FvKE8Ajn42F8EYi8Wj0q6Jz3mj+pJzgzakk2INm2ldEZ+FaRPipn4ozsZDcBg==}
     engines: {node: '>=10'}
@@ -10821,6 +11009,31 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@swc/core@1.5.24:
+    resolution: {integrity: sha512-Eph9zvO4xvqWZGVzTdtdEJ0Vqf0VIML/o/e4Qd2RLOqtfgnlRi7avmMu5C0oqciJ0tk+hqdUKVUZ4JPoPaiGvQ==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': '*'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.9
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.5.24
+      '@swc/core-darwin-x64': 1.5.24
+      '@swc/core-linux-arm-gnueabihf': 1.5.24
+      '@swc/core-linux-arm64-gnu': 1.5.24
+      '@swc/core-linux-arm64-musl': 1.5.24
+      '@swc/core-linux-x64-gnu': 1.5.24
+      '@swc/core-linux-x64-musl': 1.5.24
+      '@swc/core-win32-arm64-msvc': 1.5.24
+      '@swc/core-win32-ia32-msvc': 1.5.24
+      '@swc/core-win32-x64-msvc': 1.5.24
+    dev: true
 
   /@swc/core@1.5.5:
     resolution: {integrity: sha512-M8O22EEgdSONLd+7KRrXj8pn+RdAZZ7ISnPjE9KCQQlI0kkFNEquWR+uFdlFxQfwlyCe/Zb6uGXGDvtcov4IMg==}
@@ -10876,6 +11089,12 @@ packages:
 
   /@swc/types@0.1.6:
     resolution: {integrity: sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==}
+    dependencies:
+      '@swc/counter': 0.1.3
+    dev: true
+
+  /@swc/types@0.1.9:
+    resolution: {integrity: sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==}
     dependencies:
       '@swc/counter': 0.1.3
     dev: true
@@ -10948,7 +11167,7 @@ packages:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
-      vitest: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+      vitest: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
     dev: true
 
   /@testing-library/react@14.3.1(react-dom@18.3.1)(react@18.3.1):
@@ -10963,6 +11182,20 @@ packages:
       '@types/react-dom': 18.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    dev: true
+
+  /@testing-library/react@14.3.1(react-dom@19.0.0-rc.0)(react@19.0.0-rc.0):
+    resolution: {integrity: sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@testing-library/dom': 9.3.4
+      '@types/react-dom': 18.3.0
+      react: 19.0.0-rc.0
+      react-dom: 19.0.0-rc.0(react@19.0.0-rc.0)
     dev: true
 
   /@testing-library/user-event@14.5.2(@testing-library/dom@9.3.4):
@@ -11093,7 +11326,7 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/braces@3.0.4:
     resolution: {integrity: sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==}
@@ -11104,7 +11337,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       '@types/responselike': 1.0.3
 
   /@types/caseless@0.12.5:
@@ -11127,12 +11360,12 @@ packages:
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/conventional-commits-parser@5.0.0:
     resolution: {integrity: sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
     dev: true
 
   /@types/cookie-parser@1.4.7:
@@ -11151,12 +11384,12 @@ packages:
   /@types/cors@2.8.17:
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/cross-spawn@6.0.6:
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
     dev: true
 
   /@types/crypto-js@4.2.2:
@@ -11231,7 +11464,7 @@ packages:
   /@types/express-serve-static-core@4.19.0:
     resolution: {integrity: sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -11266,7 +11499,7 @@ packages:
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/get-port@3.2.0:
     resolution: {integrity: sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==}
@@ -11275,13 +11508,13 @@ packages:
     resolution: {integrity: sha512-rTtf75rwyP9G2qO5yRpYtdJ6aU1QqEhWbtW55qEgquEDa6bXW0s2TWZfDm02GuppjEozOWG/F2UnPq5hAQb+gw==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/glob@8.1.0:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
@@ -11292,7 +11525,7 @@ packages:
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
     dev: true
 
   /@types/hast@2.3.10:
@@ -11310,7 +11543,7 @@ packages:
   /@types/hoist-non-react-statics@3.3.5:
     resolution: {integrity: sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==}
     dependencies:
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       hoist-non-react-statics: 3.3.2
     dev: false
 
@@ -11327,7 +11560,7 @@ packages:
   /@types/http-proxy@1.17.14:
     resolution: {integrity: sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/is-function@1.0.3:
     resolution: {integrity: sha512-/CLhCW79JUeLKznI6mbVieGbl4QU5Hfn+6udw1YHZoofASjbQ5zaP5LzAUZYDpRYEjS4/P+DhEgyJ/PQmGGTWw==}
@@ -11368,7 +11601,7 @@ packages:
   /@types/jsdom@20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       '@types/tough-cookie': 4.0.5
       parse5: 7.1.2
     dev: true
@@ -11386,7 +11619,7 @@ packages:
   /@types/jsonfile@6.1.4:
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/jsrsasign@10.5.14:
     resolution: {integrity: sha512-lppSlfK6etu+cuKs40K4rg8As79PH6hzIB+v55zSqImbSH3SE6Fm8MBHCiI91cWlAP3Z4igtJK1VL3fSN09blQ==}
@@ -11395,7 +11628,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/lodash-es@4.17.12:
     resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
@@ -11443,12 +11676,12 @@ packages:
   /@types/mkdirp@0.5.2:
     resolution: {integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/mock-fs@4.13.4:
     resolution: {integrity: sha512-mXmM0o6lULPI8z3XNnQCpL0BGxPwx1Ul1wXYEPBGl4efShyxW2Rln0JOPEWGyZaYZMM6OVXM/15zUuFMY52ljg==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
     dev: true
 
   /@types/ms@0.7.34:
@@ -11457,13 +11690,13 @@ packages:
   /@types/mute-stream@0.0.4:
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
     dev: true
 
   /@types/node-fetch@2.6.11:
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       form-data: 4.0.0
 
   /@types/node@16.18.97:
@@ -11479,11 +11712,16 @@ packages:
     dependencies:
       undici-types: 5.26.5
 
-  /@types/node@20.14.2:
-    resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
+  /@types/node@20.14.5:
+    resolution: {integrity: sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA==}
     dependencies:
       undici-types: 5.26.5
     dev: true
+
+  /@types/node@20.14.9:
+    resolution: {integrity: sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==}
+    dependencies:
+      undici-types: 5.26.5
 
   /@types/node@8.10.66:
     resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
@@ -11494,7 +11732,7 @@ packages:
   /@types/npmlog@4.1.6:
     resolution: {integrity: sha512-0l3z16vnlJGl2Mi/rgJFrdwfLZ4jfNYgE6ZShEpjqhHuGTqdEzNles03NpYHwUMVYZa+Tj46UxKIEpE78lQ3DQ==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
     dev: true
 
   /@types/parse-json@4.0.2:
@@ -11507,7 +11745,7 @@ packages:
   /@types/prompts@2.4.9:
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       kleur: 3.0.3
     dev: true
 
@@ -11523,7 +11761,7 @@ packages:
   /@types/reach__router@1.3.15:
     resolution: {integrity: sha512-5WEHKGglRjq/Ae3F8UQxg+GYUIhTUEiyBT9GKPoOLU/vPTn8iZrRbdzxqvarOaGludIejJykHLMdOCdhgWqaxA==}
     dependencies:
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
 
   /@types/react-dom@18.3.0:
     resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
@@ -11534,7 +11772,7 @@ packages:
   /@types/react-lazylog@4.5.4:
     resolution: {integrity: sha512-HYP+lVRyE0c+fGT+IGHMqzQS5X9I7oaQ3iZczor2MQyLUXyAZRv2AJoEcYjH1QNPDIc+vMBSteyuSuw8tkGJ5Q==}
     dependencies:
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       immutable: 4.3.5
     dev: true
 
@@ -11542,7 +11780,7 @@ packages:
     resolution: {integrity: sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==}
     dependencies:
       '@types/hoist-non-react-statics': 3.3.5
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       hoist-non-react-statics: 3.3.2
       redux: 4.2.1
     dev: false
@@ -11559,11 +11797,17 @@ packages:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
 
+  /@types/react@18.3.3:
+    resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
+    dependencies:
+      '@types/prop-types': 15.7.12
+      csstype: 3.1.3
+
   /@types/request@2.48.12:
     resolution: {integrity: sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==}
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.1
     dev: true
@@ -11579,7 +11823,7 @@ packages:
   /@types/responselike@1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/retry@0.12.1:
     resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
@@ -11588,7 +11832,7 @@ packages:
     resolution: {integrity: sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==}
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/semaphore@1.1.4:
     resolution: {integrity: sha512-W+KOVSGHKo5yoPXG69RFIKOdmvAcrAo2qnRrcDv80kIcxDnEUQ+c3IVKq0Jkp+BhhYfrbthPY9cXWFL0L9uzuw==}
@@ -11601,13 +11845,13 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/serve-static@1.15.7:
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       '@types/send': 0.17.4
 
   /@types/simple-oauth2@5.0.7:
@@ -11625,7 +11869,7 @@ packages:
   /@types/tar@6.1.13:
     resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       minipass: 4.2.8
     dev: true
 
@@ -11667,7 +11911,7 @@ packages:
   /@types/vfile@3.0.2:
     resolution: {integrity: sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       '@types/unist': 3.0.2
       '@types/vfile-message': 2.0.0
     dev: false
@@ -11693,7 +11937,7 @@ packages:
   /@types/ws@8.5.10:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -11713,7 +11957,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
     optional: true
 
   /@types/yoga-layout@1.9.2:
@@ -12297,7 +12541,7 @@ packages:
       vite: ^4 || ^5
     dependencies:
       '@swc/core': 1.5.5
-      vite: 5.2.11(@types/node@20.12.11)
+      vite: 5.2.11(@types/node@20.14.9)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -12313,7 +12557,23 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.24.5)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.2.11(@types/node@20.12.11)
+      vite: 5.2.11(@types/node@20.14.9)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vitejs/plugin-react@4.3.0(vite@5.2.12):
+    resolution: {integrity: sha512-KcEbMsn4Dpk+LIbHMj7gDPRKaTMStxxWRkRmxsg/jVdFdJCZWt1SchZcf0M4t8lIKdwwMsEyzhrcOXRrDPtOBw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/plugin-transform-react-jsx-self': 7.24.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.24.5)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 5.2.12(@types/node@20.14.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12326,6 +12586,14 @@ packages:
       chai: 4.4.1
     dev: true
 
+  /@vitest/expect@1.5.0:
+    resolution: {integrity: sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==}
+    dependencies:
+      '@vitest/spy': 1.5.0
+      '@vitest/utils': 1.5.0
+      chai: 4.4.1
+    dev: true
+
   /@vitest/expect@1.6.0:
     resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
     dependencies:
@@ -12333,12 +12601,28 @@ packages:
       '@vitest/utils': 1.6.0
       chai: 4.4.1
 
+  /@vitest/runner@1.5.0:
+    resolution: {integrity: sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==}
+    dependencies:
+      '@vitest/utils': 1.5.0
+      p-limit: 5.0.0
+      pathe: 1.1.2
+    dev: true
+
   /@vitest/runner@1.6.0:
     resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
     dependencies:
       '@vitest/utils': 1.6.0
       p-limit: 5.0.0
       pathe: 1.1.2
+
+  /@vitest/snapshot@1.5.0:
+    resolution: {integrity: sha512-qpv3fSEuNrhAO3FpH6YYRdaECnnRjg9VxbhdtPwPRnzSfHVXnNzzrpX4cJxqiwgRMo7uRMWDFBlsBq4Cr+rO3A==}
+    dependencies:
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+    dev: true
 
   /@vitest/snapshot@1.6.0:
     resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
@@ -12349,6 +12633,12 @@ packages:
 
   /@vitest/spy@1.3.1:
     resolution: {integrity: sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==}
+    dependencies:
+      tinyspy: 2.2.1
+    dev: true
+
+  /@vitest/spy@1.5.0:
+    resolution: {integrity: sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==}
     dependencies:
       tinyspy: 2.2.1
     dev: true
@@ -12370,10 +12660,19 @@ packages:
       pathe: 1.1.2
       picocolors: 1.0.0
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
+      vitest: 1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1)
 
   /@vitest/utils@1.3.1:
     resolution: {integrity: sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==}
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/utils@1.5.0:
+    resolution: {integrity: sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -12715,7 +13014,7 @@ packages:
   /@wry/context@0.4.4:
     resolution: {integrity: sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       tslib: 1.14.1
     dev: false
 
@@ -16453,13 +16752,13 @@ packages:
     engines: {node: '>= 12.0.0'}
     dev: false
 
-  /commitizen@4.3.0(@types/node@20.12.11)(typescript@5.4.5):
+  /commitizen@4.3.0(@types/node@20.14.9)(typescript@5.4.5):
     resolution: {integrity: sha512-H0iNtClNEhT0fotHvGV3E9tDejDeS04sN1veIebsKYGMuGscFaswRoYJKmT3eW85eIJAs0F28bG2+a/9wCOfPw==}
     engines: {node: '>= 12'}
     hasBin: true
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(@types/node@20.12.11)(typescript@5.4.5)
+      cz-conventional-changelog: 3.3.0(@types/node@20.14.9)(typescript@5.4.5)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -17053,7 +17352,7 @@ packages:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  /cosmiconfig-typescript-loader@5.0.0(@types/node@20.12.11)(cosmiconfig@9.0.0)(typescript@5.4.5):
+  /cosmiconfig-typescript-loader@5.0.0(@types/node@20.14.9)(cosmiconfig@9.0.0)(typescript@5.4.5):
     resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
     engines: {node: '>=v16'}
     peerDependencies:
@@ -17061,7 +17360,7 @@ packages:
       cosmiconfig: '>=8.2'
       typescript: '>=4'
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       cosmiconfig: 9.0.0(typescript@5.4.5)
       jiti: 1.21.0
       typescript: 5.4.5
@@ -17238,7 +17537,7 @@ packages:
       - ts-node
     dev: true
 
-  /create-jest@29.7.0(@types/node@20.12.11):
+  /create-jest@29.7.0(@types/node@20.14.9):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -17247,7 +17546,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.12.11)
+      jest-config: 29.7.0(@types/node@20.14.9)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -17578,6 +17877,13 @@ packages:
       cssom: 0.3.8
     dev: true
 
+  /cssstyle@4.0.1:
+    resolution: {integrity: sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      rrweb-cssom: 0.6.0
+    dev: true
+
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
@@ -17591,18 +17897,18 @@ packages:
   /cyclist@1.0.2:
     resolution: {integrity: sha512-0sVXIohTfLqVIW3kb/0n6IiWF3Ifj5nm2XaSrLq2DI6fKIGa2fYAZdk917rUneaeLVpYfFcyXE2ft0fe3remsA==}
 
-  /cz-conventional-changelog@3.3.0(@types/node@20.12.11)(typescript@5.4.5):
+  /cz-conventional-changelog@3.3.0(@types/node@20.14.9)(typescript@5.4.5):
     resolution: {integrity: sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==}
     engines: {node: '>= 10'}
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.0(@types/node@20.12.11)(typescript@5.4.5)
+      commitizen: 4.3.0(@types/node@20.14.9)(typescript@5.4.5)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 19.2.0(@types/node@20.12.11)(typescript@5.4.5)
+      '@commitlint/load': 19.2.0(@types/node@20.14.9)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -17646,6 +17952,14 @@ packages:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
+    dev: true
+
+  /data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.0.0
     dev: true
 
   /data-view-buffer@1.0.1:
@@ -17767,7 +18081,7 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
-  /decap-cms-app@3.1.10(@types/node@20.12.11)(@types/react@18.3.1)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1):
+  /decap-cms-app@3.1.10(@types/node@20.14.9)(@types/react@18.3.1)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-q9+HfnjawRf9nLjzGqglmFQifQr9cVm3c5An/VDDxwiw9h/geCOdKNAd+tBgtqT+7xaCPzfCp2KRsJmTqWRnxg==}
     peerDependencies:
       react: ^18.2.0
@@ -17785,7 +18099,7 @@ packages:
       decap-cms-backend-gitlab: 3.1.3(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(decap-cms-lib-auth@3.0.5)(decap-cms-lib-util@3.0.4)(decap-cms-ui-default@3.1.1)(graphql@15.8.0)(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@18.3.1)
       decap-cms-backend-proxy: 3.1.1(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(decap-cms-lib-util@3.0.4)(decap-cms-ui-default@3.1.1)(prop-types@15.8.1)(react@18.3.1)
       decap-cms-backend-test: 3.1.1(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(decap-cms-lib-util@3.0.4)(decap-cms-ui-default@3.1.1)(lodash@4.17.21)(prop-types@15.8.1)(react@18.3.1)(uuid@8.3.2)
-      decap-cms-core: 3.3.6(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/node@20.12.11)(@types/react@18.3.1)(decap-cms-editor-component-image@3.1.1)(decap-cms-lib-auth@3.0.5)(decap-cms-lib-util@3.0.4)(decap-cms-lib-widgets@3.0.2)(decap-cms-ui-default@3.1.1)(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1)(react-immutable-proptypes@2.2.0)(react@18.3.1)
+      decap-cms-core: 3.3.6(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/node@20.14.9)(@types/react@18.3.1)(decap-cms-editor-component-image@3.1.1)(decap-cms-lib-auth@3.0.5)(decap-cms-lib-util@3.0.4)(decap-cms-lib-widgets@3.0.2)(decap-cms-ui-default@3.1.1)(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1)(react-immutable-proptypes@2.2.0)(react@18.3.1)
       decap-cms-editor-component-image: 3.1.1(react@18.3.1)
       decap-cms-lib-auth: 3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2)
       decap-cms-lib-util: 3.0.4(immutable@3.8.2)(lodash@4.17.21)
@@ -18045,7 +18359,7 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /decap-cms-core@3.3.6(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/node@20.12.11)(@types/react@18.3.1)(decap-cms-editor-component-image@3.1.1)(decap-cms-lib-auth@3.0.5)(decap-cms-lib-util@3.0.4)(decap-cms-lib-widgets@3.0.2)(decap-cms-ui-default@3.1.1)(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1)(react-immutable-proptypes@2.2.0)(react@18.3.1):
+  /decap-cms-core@3.3.6(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/node@20.14.9)(@types/react@18.3.1)(decap-cms-editor-component-image@3.1.1)(decap-cms-lib-auth@3.0.5)(decap-cms-lib-util@3.0.4)(decap-cms-lib-widgets@3.0.2)(decap-cms-ui-default@3.1.1)(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1)(react-immutable-proptypes@2.2.0)(react@18.3.1):
     resolution: {integrity: sha512-PwLXQj9xt7Pb170VAI9gdrnqxgIos9tmcIFVM90NE0UoBOzHkkestYuvKGKLzPzLk0mQHz9ZjKgIH6E9G+1a4Q==}
     peerDependencies:
       '@emotion/react': ^11.11.1
@@ -18091,7 +18405,7 @@ packages:
       node-polyglot: 2.5.0
       prop-types: 15.8.1
       react: 18.3.1
-      react-dnd: 14.0.5(@types/node@20.12.11)(@types/react@18.3.1)(react@18.3.1)
+      react-dnd: 14.0.5(@types/node@20.14.9)(@types/react@18.3.1)(react@18.3.1)
       react-dnd-html5-backend: 14.1.0
       react-dom: 18.3.1(react@18.3.1)
       react-frame-component: 5.2.6(prop-types@15.8.1)(react-dom@18.3.1)(react@18.3.1)
@@ -19309,7 +19623,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.17
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -19663,7 +19977,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.12
       '@esbuild/win32-ia32': 0.19.12
       '@esbuild/win32-x64': 0.19.12
-    dev: true
 
   /esbuild@0.20.2:
     resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
@@ -20391,9 +20704,9 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       cross-spawn: 7.0.3
-      get-stream: 6.0.0
+      get-stream: 6.0.1
       human-signals: 2.1.0
-      is-stream: 2.0.0
+      is-stream: 2.0.1
       merge-stream: 2.0.0
       npm-run-path: 4.0.1
       onetime: 5.1.2
@@ -22894,7 +23207,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-config@5.0.3(@types/node@20.12.11)(graphql@16.8.1)(typescript@5.4.5):
+  /graphql-config@5.0.3(@types/node@20.14.9)(graphql@16.8.1)(typescript@5.4.5):
     resolution: {integrity: sha512-BNGZaoxIBkv9yy6Y7omvsaBUHOzfFcII3UN++tpH8MGOKFPFkCPZuwx09ggANMt8FgyWP1Od8SWPmrUEZca4NQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
@@ -22908,7 +23221,7 @@ packages:
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/load': 8.0.2(graphql@16.8.1)
       '@graphql-tools/merge': 9.0.4(graphql@16.8.1)
-      '@graphql-tools/url-loader': 8.0.2(@types/node@20.12.11)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@20.14.9)(graphql@16.8.1)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       cosmiconfig: 8.3.6(typescript@5.4.5)
       graphql: 16.8.1
@@ -23426,6 +23739,11 @@ packages:
       parse-passwd: 1.0.0
     dev: true
 
+  /hono@4.4.2:
+    resolution: {integrity: sha512-bRhZ+BM9r04lRN2i9wiZ18yQNbZxHsmmRIItoAb43nRkHnIDsFhFh4mJ0seEs06FvenibpAgSVNHQ8ZzcDQx2A==}
+    engines: {node: '>=16.0.0'}
+    dev: true
+
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -23472,6 +23790,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       whatwg-encoding: 2.0.0
+    dev: true
+
+  /html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      whatwg-encoding: 3.1.1
     dev: true
 
   /html-entities@2.5.2:
@@ -25060,7 +25385,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -25109,7 +25434,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-cli@29.7.0(@types/node@20.12.11):
+  /jest-cli@29.7.0(@types/node@20.14.9):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -25123,10 +25448,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.12.11)
+      create-jest: 29.7.0(@types/node@20.14.9)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.12.11)
+      jest-config: 29.7.0(@types/node@20.14.9)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -25177,7 +25502,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-config@29.7.0(@types/node@20.12.11):
+  /jest-config@29.7.0(@types/node@20.14.9):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -25192,7 +25517,7 @@ packages:
       '@babel/core': 7.24.5
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       babel-jest: 29.7.0(@babel/core@7.24.5)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -25262,7 +25587,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -25279,7 +25604,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -25299,7 +25624,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -25350,7 +25675,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       jest-util: 29.7.0
     dev: true
 
@@ -25408,7 +25733,7 @@ packages:
       create-jest-runner: 0.6.0
       dot-prop: 5.3.0
       eslint: 8.57.0
-      jest: 29.7.0(@types/node@20.12.11)
+      jest: 29.7.0(@types/node@20.14.9)
     dev: true
 
   /jest-runner@29.7.0:
@@ -25420,7 +25745,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -25451,7 +25776,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       chalk: 4.1.2
       cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
@@ -25503,7 +25828,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -25549,7 +25874,7 @@ packages:
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.3.0
-      jest: 29.7.0(@types/node@20.12.11)
+      jest: 29.7.0(@types/node@20.14.9)
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -25563,7 +25888,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -25583,7 +25908,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
@@ -25591,7 +25916,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -25599,7 +25924,7 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -25626,7 +25951,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest@29.7.0(@types/node@20.12.11):
+  /jest@29.7.0(@types/node@20.14.9):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -25639,7 +25964,7 @@ packages:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.12.11)
+      jest-cli: 29.7.0(@types/node@20.14.9)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -25793,6 +26118,42 @@ packages:
       whatwg-url: 11.0.0
       ws: 8.17.0
       xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /jsdom@24.1.0:
+    resolution: {integrity: sha512-6gpM7pRXCwIOKxX47cgOyvyQDN/Eh0f1MeKySBV2xGdKtqJBLj8P25eY3EVCWo2mglDDzozR2r2MW4T+JiNUZA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      cssstyle: 4.0.1
+      data-urls: 5.0.0
+      decimal.js: 10.4.3
+      form-data: 4.0.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.10
+      parse5: 7.1.2
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.0.0
+      ws: 8.17.0
+      xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -27473,7 +27834,7 @@ packages:
       '@types/node': 16.18.97
     dev: true
 
-  /meros@1.3.0(@types/node@20.12.11):
+  /meros@1.3.0(@types/node@20.14.9):
     resolution: {integrity: sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==}
     engines: {node: '>=13'}
     peerDependencies:
@@ -27482,7 +27843,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -27998,7 +28359,7 @@ packages:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
     dependencies:
-      braces: 3.0.2
+      braces: 3.0.3
       picomatch: 2.3.1
 
   /micromatch@4.0.7:
@@ -28864,6 +29225,150 @@ packages:
       - supports-color
       - uWebSockets.js
       - utf-8-validate
+    dev: true
+
+  /netlify-cli@17.23.2(@types/node@20.14.9):
+    resolution: {integrity: sha512-C/9gr4Gx5v4oONlzMGtk898AA6hIqe26XN4Fmbz537JIAIeJF86NoePljS4ukIlMu+5Kzr4J7maeDBhHVfRX1w==}
+    engines: {node: '>=18.14.0'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@bugsnag/js': 7.22.7
+      '@fastify/static': 6.12.0
+      '@netlify/blobs': 7.3.0
+      '@netlify/build': 29.41.2(@opentelemetry/api@1.8.0)(@types/node@20.14.9)
+      '@netlify/build-info': 7.13.2
+      '@netlify/config': 20.12.3
+      '@netlify/edge-bundler': 12.0.0
+      '@netlify/edge-functions': 2.5.1
+      '@netlify/local-functions-proxy': 1.1.1
+      '@netlify/zip-it-and-ship-it': 9.32.1(@opentelemetry/api@1.8.0)
+      '@octokit/rest': 19.0.13
+      '@opentelemetry/api': 1.8.0
+      ansi-escapes: 6.2.1
+      ansi-styles: 6.2.1
+      ansi-to-html: 0.7.2
+      ascii-table: 0.0.9
+      backoff: 2.5.0
+      better-opn: 3.0.2
+      boxen: 7.1.1
+      chalk: 5.3.0
+      chokidar: 3.6.0
+      ci-info: 3.8.0
+      clean-deep: 3.4.0
+      commander: 10.0.1
+      comment-json: 4.2.3
+      concordance: 5.0.4
+      configstore: 6.0.0
+      content-type: 1.0.5
+      cookie: 0.5.0
+      copy-template-dir: 1.4.0
+      cron-parser: 4.8.1
+      debug: 4.3.4(supports-color@5.5.0)
+      decache: 4.6.2
+      dot-prop: 7.2.0
+      dotenv: 16.0.3
+      env-paths: 3.0.0
+      envinfo: 7.8.1
+      etag: 1.8.1
+      execa: 5.1.1
+      express: 4.19.2
+      express-logging: 1.1.1
+      extract-zip: 2.0.1
+      fastest-levenshtein: 1.0.16
+      fastify: 4.17.0
+      find-up: 6.3.0
+      flush-write-stream: 2.0.0
+      folder-walker: 3.2.0
+      from2-array: 0.0.4
+      fuzzy: 0.1.3
+      get-port: 5.1.1
+      gh-release-fetch: 4.0.3
+      git-repo-info: 2.1.1
+      gitconfiglocal: 2.1.0
+      hasbin: 1.2.3
+      hasha: 5.2.2
+      http-proxy: 1.18.1(debug@4.3.4)
+      http-proxy-middleware: 2.0.6(@types/express@4.17.21)(debug@4.3.4)
+      https-proxy-agent: 7.0.4
+      inquirer: 6.5.2
+      inquirer-autocomplete-prompt: 1.4.0(inquirer@6.5.2)
+      ipx: 2.1.0(@netlify/blobs@7.3.0)
+      is-docker: 3.0.0
+      is-stream: 3.0.0
+      is-wsl: 2.2.0
+      isexe: 2.0.0
+      js-yaml: 4.1.0
+      jsonwebtoken: 9.0.2
+      jwt-decode: 3.1.2
+      lambda-local: 2.1.2
+      listr2: 7.0.2
+      locate-path: 7.2.0
+      lodash: 4.17.21
+      log-symbols: 5.1.0
+      log-update: 5.0.1
+      multiparty: 4.2.3
+      netlify: 13.1.15
+      netlify-headers-parser: 7.1.4
+      netlify-redirect-parser: 14.2.2
+      netlify-redirector: 0.5.0
+      node-fetch: 2.6.12
+      node-version-alias: 3.4.1
+      ora: 6.3.1
+      p-filter: 3.0.0
+      p-map: 5.5.0
+      p-wait-for: 5.0.2
+      parallel-transform: 1.2.0
+      parse-github-url: 1.0.2
+      parse-gitignore: 2.0.0
+      path-key: 4.0.0
+      prettyjson: 1.2.5
+      pump: 3.0.0
+      raw-body: 2.5.2
+      read-package-up: 11.0.0
+      semver: 7.6.0
+      source-map-support: 0.5.21
+      strip-ansi-control-characters: 2.0.0
+      tabtab: 3.0.2
+      tempy: 3.0.0
+      terminal-link: 3.0.0
+      through2-filter: 3.0.0
+      through2-map: 3.0.0
+      to-readable-stream: 3.0.0
+      toml: 3.0.0
+      tomlify-j0.4: 3.0.0
+      ulid: 2.3.0
+      unixify: 1.0.0
+      update-notifier: 6.0.2
+      uuid: 9.0.1
+      wait-port: 1.0.4
+      write-file-atomic: 5.0.1
+      ws: 8.14.2
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/opentelemetry-sdk-setup'
+      - '@planetscale/database'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/express'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - idb-keyval
+      - ioredis
+      - picomatch
+      - supports-color
+      - uWebSockets.js
+      - utf-8-validate
 
   /netlify-headers-parser@7.1.4:
     resolution: {integrity: sha512-fTVQf8u65vS4YTP2Qt1K6Np01q3yecRKXf6VMONMlWbfl5n3M/on7pZlZISNAXHNOtnVt+6Kpwfl+RIeALC8Kg==}
@@ -29441,6 +29946,10 @@ packages:
   /num2fraction@1.2.2:
     resolution: {integrity: sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==}
     dev: false
+
+  /nwsapi@2.2.10:
+    resolution: {integrity: sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==}
+    dev: true
 
   /nwsapi@2.2.9:
     resolution: {integrity: sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg==}
@@ -30572,12 +31081,28 @@ packages:
     hasBin: true
     dev: true
 
+  /playwright-core@1.44.1:
+    resolution: {integrity: sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dev: true
+
   /playwright@1.44.0:
     resolution: {integrity: sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
       playwright-core: 1.44.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /playwright@1.44.1:
+    resolution: {integrity: sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.44.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -31803,7 +32328,7 @@ packages:
       dnd-core: 14.0.1
     dev: false
 
-  /react-dnd@14.0.5(@types/node@20.12.11)(@types/react@18.3.1)(react@18.3.1):
+  /react-dnd@14.0.5(@types/node@20.14.9)(@types/react@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==}
     peerDependencies:
       '@types/hoist-non-react-statics': '>= 3.3.1'
@@ -31820,7 +32345,7 @@ packages:
     dependencies:
       '@react-dnd/invariant': 2.0.0
       '@react-dnd/shallowequal': 2.0.0
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
       '@types/react': 18.3.1
       dnd-core: 14.0.1
       fast-deep-equal: 3.1.3
@@ -31862,6 +32387,14 @@ packages:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  /react-dom@19.0.0-rc.0(react@19.0.0-rc.0):
+    resolution: {integrity: sha512-MhgN2RMYFUkZekkFbsXg9ycwEGaMBzATpTNvGGvWNA9BZZEkdzIL4pv7iDuZKn48YoGARk8ydu4S+Ehd8Yrc4g==}
+    peerDependencies:
+      react: 19.0.0-rc.0
+    dependencies:
+      react: 19.0.0-rc.0
+      scheduler: 0.25.0-rc.0
 
   /react-element-to-jsx-string@15.0.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
@@ -32181,6 +32714,20 @@ packages:
       react: 18.3.1
       webpack: 5.91.0
 
+  /react-server-dom-webpack@19.0.0-rc.0(react-dom@19.0.0-rc.0)(react@19.0.0-rc.0)(webpack@5.91.0):
+    resolution: {integrity: sha512-nnSBQnXKEgfgSx6veKJg3TdRmRyn+tyOuKwKdHCI1SuR+WL2JLDM+NfZrP5DFie7w5ZCNTjS/LdACV4YuRuxDg==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: 19.0.0-rc.0
+      react-dom: 19.0.0-rc.0
+      webpack: ^5.59.0
+    dependencies:
+      acorn-loose: 8.4.0
+      neo-async: 2.6.2
+      react: 19.0.0-rc.0
+      react-dom: 19.0.0-rc.0(react@19.0.0-rc.0)
+      webpack: 5.91.0(esbuild@0.19.12)
+
   /react-split-pane@0.1.92(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==}
     peerDependencies:
@@ -32326,6 +32873,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+
+  /react@19.0.0-rc.0:
+    resolution: {integrity: sha512-8nrDCl5uE54FHeKqKrEO0TS+10bT4cxutJGb2okiJc0FHMQ6I3FeItaqly/1nbijlhSO3HmAVyPIexIQQWYAtQ==}
+    engines: {node: '>=0.10.0'}
 
   /reactcss@1.2.3(react@18.3.1):
     resolution: {integrity: sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==}
@@ -33342,6 +33893,18 @@ packages:
       '@rollup/rollup-win32-x64-msvc': 4.17.2
       fsevents: 2.3.3
 
+  /rrweb-cssom@0.6.0:
+    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
+    dev: true
+
+  /rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+    dev: true
+
+  /rsc-html-stream@0.0.3:
+    resolution: {integrity: sha512-GrHT+ADZM1Mj+sfXNjJjtFCwvB/xK5gx9KHQqcHJQIKfZ0Nh3wd8O59Nvd7VLb8lyvdOkqnqi5d5TAtDICf8yQ==}
+    dev: true
+
   /run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -33456,6 +34019,9 @@ packages:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
     dependencies:
       loose-envify: 1.4.0
+
+  /scheduler@0.25.0-rc.0:
+    resolution: {integrity: sha512-B3aSqMfoRkucM94MztZD1CyNyf68W9A3dL/TT453G6uNcxMBqGQ+rhFKyxNnWH/mfRHlGBr0tF0F472JCETH4g==}
 
   /schema-utils@1.0.0:
     resolution: {integrity: sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==}
@@ -33693,6 +34259,14 @@ packages:
       send: 0.18.0
     transitivePeerDependencies:
       - supports-color
+
+  /server-only-context@0.1.0(react@19.0.0-rc.0):
+    resolution: {integrity: sha512-5Ba19yx9Bj9uSh40aZNsZNBvLF88tLY3na6QxWkqyrSLOSHPxtnzTs/JzjKwfac1NbHFlEodkN7T4M6UzvH2Ng==}
+    peerDependencies:
+      react: 19.0.0-rc.0
+    dependencies:
+      react: 19.0.0-rc.0
+    dev: false
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -35527,6 +36101,30 @@ packages:
       worker-farm: 1.7.0
     dev: true
 
+  /terser-webpack-plugin@5.3.10(esbuild@0.19.12)(webpack@5.91.0):
+    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      esbuild: 0.19.12
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.31.0
+      webpack: 5.91.0(esbuild@0.19.12)
+
   /terser-webpack-plugin@5.3.10(esbuild@0.20.2)(webpack@5.91.0):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
@@ -35876,6 +36474,13 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /tr46@5.0.0:
+    resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
+    engines: {node: '>=18'}
+    dependencies:
+      punycode: 2.3.1
+    dev: true
+
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -35917,7 +36522,6 @@ packages:
 
   /trim@0.0.1:
     resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
-    deprecated: Use String.prototype.trim() instead
     dev: false
 
   /triple-beam@1.4.1:
@@ -35952,6 +36556,10 @@ packages:
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  /ts-expect@1.3.0:
+    resolution: {integrity: sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==}
+    dev: true
 
   /ts-import@4.0.0-beta.10(typescript@5.4.5):
     resolution: {integrity: sha512-9AbXC09MF6rOxy4zMo75iu0daETf4DPqEDt8UU/S6HU2yXWcf4xQqAexJCOcGZzGwtViuRdB6p48YhdPLttQJw==}
@@ -36040,6 +36648,37 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.12.11
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /ts-node@10.9.2(@types/node@20.14.9)(typescript@5.4.5):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.9
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -37237,6 +37876,27 @@ packages:
       - rollup
     dev: true
 
+  /vite-node@1.5.0(@types/node@20.14.5):
+    resolution: {integrity: sha512-tV8h6gMj6vPzVCa7l+VGq9lwoJjW8Y79vst8QZZGiuRAfijU+EEWuc0kFpmndQrWhMMhet1jdSF+40KSZUqIIw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@5.5.0)
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.2.11(@types/node@20.14.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-node@1.6.0(@types/node@16.18.97):
     resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -37297,8 +37957,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
 
-  /vite-plugin-dts@3.9.1(@types/node@20.12.11)(typescript@5.4.5)(vite@5.2.11):
+  /vite-node@1.6.0(@types/node@20.14.9):
+    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@5.5.0)
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.2.11(@types/node@20.14.9)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  /vite-plugin-dts@3.9.1(@types/node@20.14.9)(typescript@5.4.5)(vite@5.2.11):
     resolution: {integrity: sha512-rVp2KM9Ue22NGWB8dNtWEr+KekN3rIgz1tWD050QnRGlriUCmaDwa7qA5zDEjbXg5lAXhYMSBJtx3q3hQIJZSg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -37308,14 +37989,14 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@microsoft/api-extractor': 7.43.0(@types/node@20.12.11)
+      '@microsoft/api-extractor': 7.43.0(@types/node@20.14.9)
       '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
       '@vue/language-core': 1.8.27(typescript@5.4.5)
       debug: 4.3.4(supports-color@5.5.0)
       kolorist: 1.8.0
       magic-string: 0.30.10
       typescript: 5.4.5
-      vite: 5.2.11(@types/node@20.12.11)
+      vite: 5.2.11(@types/node@20.14.9)
       vue-tsc: 1.8.27(typescript@5.4.5)
     transitivePeerDependencies:
       - '@types/node'
@@ -37428,6 +38109,171 @@ packages:
       rollup: 4.17.2
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vite@5.2.11(@types/node@20.14.5):
+    resolution: {integrity: sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.14.5
+      esbuild: 0.20.2
+      postcss: 8.4.38
+      rollup: 4.17.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vite@5.2.11(@types/node@20.14.9):
+    resolution: {integrity: sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.14.9
+      esbuild: 0.20.2
+      postcss: 8.4.38
+      rollup: 4.17.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  /vite@5.2.12(@types/node@20.14.5):
+    resolution: {integrity: sha512-/gC8GxzxMK5ntBwb48pR32GGhENnjtY30G4A0jemunsBkiEZFw60s8InGpN8gkhHEkjnRK1aSAxeQgwvFhUHAA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.14.5
+      esbuild: 0.20.2
+      postcss: 8.4.38
+      rollup: 4.17.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest@1.5.0(@types/node@20.14.5)(jsdom@24.1.0):
+    resolution: {integrity: sha512-d8UKgR0m2kjdxDWX6911uwxout6GHS0XaGH1cksSIVVG8kRlE7G7aBw7myKQCvDI5dT4j7ZMa+l706BIORMDLw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.5.0
+      '@vitest/ui': 1.5.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.14.5
+      '@vitest/expect': 1.5.0
+      '@vitest/runner': 1.5.0
+      '@vitest/snapshot': 1.5.0
+      '@vitest/spy': 1.5.0
+      '@vitest/utils': 1.5.0
+      acorn-walk: 8.3.2
+      chai: 4.4.1
+      debug: 4.3.4(supports-color@5.5.0)
+      execa: 8.0.1
+      jsdom: 24.1.0
+      local-pkg: 0.5.0
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      tinybench: 2.8.0
+      tinypool: 0.8.4
+      vite: 5.2.11(@types/node@20.14.5)
+      vite-node: 1.5.0(@types/node@20.14.5)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
 
   /vitest@1.6.0(@types/node@16.18.97):
     resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
@@ -37541,7 +38387,7 @@ packages:
       - supports-color
       - terser
 
-  /vitest@1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(happy-dom@14.10.1):
+  /vitest@1.6.0(@types/node@20.12.11):
     resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -37571,6 +38417,62 @@ packages:
       '@vitest/runner': 1.6.0
       '@vitest/snapshot': 1.6.0
       '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
+      acorn-walk: 8.3.2
+      chai: 4.4.1
+      debug: 4.3.4(supports-color@5.5.0)
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      tinybench: 2.8.0
+      tinypool: 0.8.4
+      vite: 5.2.11(@types/node@20.12.11)
+      vite-node: 1.6.0(@types/node@20.12.11)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@1.6.0(@types/node@20.14.9)(@vitest/ui@1.6.0)(happy-dom@14.10.1):
+    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.0
+      '@vitest/ui': 1.6.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.14.9
+      '@vitest/expect': 1.6.0
+      '@vitest/runner': 1.6.0
+      '@vitest/snapshot': 1.6.0
+      '@vitest/spy': 1.6.0
       '@vitest/ui': 1.6.0(vitest@1.6.0)
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.2
@@ -37586,8 +38488,8 @@ packages:
       strip-literal: 2.1.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.2.11(@types/node@20.12.11)
-      vite-node: 1.6.0(@types/node@20.12.11)
+      vite: 5.2.11(@types/node@20.14.9)
+      vite-node: 1.6.0(@types/node@20.14.9)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -37628,6 +38530,13 @@ packages:
       xml-name-validator: 4.0.0
     dev: true
 
+  /w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+    dependencies:
+      xml-name-validator: 5.0.0
+    dev: true
+
   /wait-on@7.2.0(debug@4.3.4):
     resolution: {integrity: sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==}
     engines: {node: '>=12.0.0'}
@@ -37652,6 +38561,37 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
+
+  /waku@0.21.0-alpha.2(@types/node@20.14.5)(react-dom@19.0.0-rc.0)(react-server-dom-webpack@19.0.0-rc.0)(react@19.0.0-rc.0):
+    resolution: {integrity: sha512-dwCm9F89vuNWqUTi9BqWvzcXOQgmh1zvDaVQLI9dGx1C4a/1Iwyrbz5SbqjSxZaw7XDtIBG1AQ7Jpgut+Me2uw==}
+    engines: {node: ^20.8.0 || ^18.17.0}
+    hasBin: true
+    peerDependencies:
+      react: 19.0.0-rc.0
+      react-dom: 19.0.0-rc.0
+      react-server-dom-webpack: 19.0.0-rc.0
+    dependencies:
+      '@hono/node-server': 1.11.2
+      '@swc/core': 1.5.24
+      '@vitejs/plugin-react': 4.3.0(vite@5.2.12)
+      dotenv: 16.4.5
+      hono: 4.4.2
+      react: 19.0.0-rc.0
+      react-dom: 19.0.0-rc.0(react@19.0.0-rc.0)
+      react-server-dom-webpack: 19.0.0-rc.0(react-dom@19.0.0-rc.0)(react@19.0.0-rc.0)(webpack@5.91.0)
+      rsc-html-stream: 0.0.3
+      vite: 5.2.12(@types/node@20.14.5)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
 
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -37911,6 +38851,45 @@ packages:
       - esbuild
       - uglify-js
 
+  /webpack@5.91.0(esbuild@0.19.12):
+    resolution: {integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.11.3
+      acorn-import-assertions: 1.9.0(acorn@8.11.3)
+      browserslist: 4.23.0
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.16.1
+      es-module-lexer: 1.5.2
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(esbuild@0.19.12)(webpack@5.91.0)
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
   /webpack@5.91.0(esbuild@0.20.2):
     resolution: {integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==}
     engines: {node: '>=10.13.0'}
@@ -37987,6 +38966,13 @@ packages:
       iconv-lite: 0.6.3
     dev: true
 
+  /whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: true
+
   /whatwg-fetch@2.0.4:
     resolution: {integrity: sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==}
     dev: true
@@ -37999,11 +38985,24 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  /whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+    dev: true
+
   /whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
     engines: {node: '>=12'}
     dependencies:
       tr46: 3.0.0
+      webidl-conversions: 7.0.0
+    dev: true
+
+  /whatwg-url@14.0.0:
+    resolution: {integrity: sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==}
+    engines: {node: '>=18'}
+    dependencies:
+      tr46: 5.0.0
       webidl-conversions: 7.0.0
     dev: true
 
@@ -38158,7 +39157,7 @@ packages:
   /wkx@0.5.0:
     resolution: {integrity: sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==}
     dependencies:
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
     dev: false
 
   /word-wrap@1.2.5:
@@ -38344,6 +39343,11 @@ packages:
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+    dev: true
+
+  /xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
     dev: true
 
   /xml-utils@1.8.0:
@@ -38608,7 +39612,7 @@ packages:
     hasBin: true
     optionalDependencies:
       '@types/fs-extra': 11.0.4
-      '@types/node': 20.12.11
+      '@types/node': 20.14.9
     dev: false
 
   github.com/AmazeeLabs/drupal-js-build/f766801580f10543c24ba8bfa59046a776848097(@typescript-eslint/parser@5.62.0):


### PR DESCRIPTION
BREAKING CHANGE: `useOperation` has been replaced by the `<Operation>`
component.

## Package(s) involved

`@amazeelabs/executors`

## Description of changes

* Introduce a new operations-API that works the same in server and client components.

## Motivation and context

Use the same operations api in server and client components.

## Related Issue(s)

[SLB-353](https://amazeelabs.atlassian.net/browse/SLB-353)

## How has this been tested?

* Unit tests
* Integraton tests


[SLB-353]: https://amazeelabs.atlassian.net/browse/SLB-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ