### PR TITLE
Run multiple operations at once

### DIFF
--- a/packages/npm/@amazeelabs/executors/src/client.tsx
+++ b/packages/npm/@amazeelabs/executors/src/client.tsx
@@ -1,18 +1,25 @@
 'use client';
 import {
   AnyOperationId,
-  OperationResult,
   OperationVariables,
 } from '@amazeelabs/codegen-operation-ids';
-import { createContext, useContext, useEffect, useState } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 import type {
   Operation as ComponentType,
   OperationExecutorsProvider as ProviderType,
+  useAllOperationExecutors as AllHookType,
   useOperationExecutor as HookType,
 } from './interface.js';
-import { findExecutor, mergeExecutors } from './lib.js';
+import { findExecutor, findExecutors, mergeExecutors } from './lib.js';
 import type {
+  ExecutionState,
   ExecutorFunction,
   OperationProps,
   RegistryEntry,
@@ -46,44 +53,42 @@ export const useOperationExecutor: HookType = <
 >(
   id: TOperation,
   variables?: OperationVariables<TOperation>,
-) => {
+): ExecutorFunction<TOperation> => {
   const { executors } = useContext(ExecutorsContext);
-  const op = findExecutor(executors, id, variables);
-  if (typeof op.executor === 'function') {
-    return (vars?: OperationVariables<TOperation>) => op.executor(id, vars);
+  const executor = findExecutor(executors, id, variables);
+  if (executor instanceof Function) {
+    return (vars?: OperationVariables<TOperation>) => executor(id, vars);
   }
-  return op.executor;
+  return () => executor;
 };
 
-function StaticOperation<TOperation extends AnyOperationId>({
-  children,
-  result,
-}: Pick<OperationProps<TOperation>, 'children'> & {
-  result: OperationResult<TOperation>;
-}) {
-  return children({ state: 'success', data: result });
-}
-
-function DelayedOperation<TOperation extends AnyOperationId>({
-  variables,
-  children,
-  executor,
-}: OperationProps<TOperation> & {
-  executor: ExecutorFunction<TOperation>;
-}) {
-  const [state, setState] =
-    useState<Parameters<OperationProps<TOperation>['children']>[0]['state']>(
-      'loading',
-    );
-
-  const [data, setData] = useState<OperationResult<TOperation> | undefined>(
-    undefined,
+export const useAllOperationExecutors: AllHookType = <
+  TOperation extends AnyOperationId,
+>(
+  id: TOperation,
+  variables?: OperationVariables<TOperation>,
+) => {
+  const { executors } = useContext(ExecutorsContext);
+  return findExecutors(executors, id, variables).map((exec) =>
+    exec instanceof Function ? (vars) => exec(id, vars) : () => exec,
   );
+};
+
+function DelayedOperation<T extends any>({
+  children,
+  operation,
+}: {
+  children: (props: ExecutionState<T>) => ReactNode;
+  operation: () => Promise<T>;
+}) {
+  const [state, setState] = useState<ExecutionState<T>['state']>('loading');
+
+  const [data, setData] = useState<T | undefined>(undefined);
 
   const [error, setError] = useState<unknown>();
 
   useEffect(() => {
-    executor(variables)
+    operation()
       .then((result) => {
         setData(result);
         setState('success');
@@ -93,22 +98,57 @@ function DelayedOperation<TOperation extends AnyOperationId>({
         setError(error);
         setState('error');
       });
-  }, [executor, variables]);
+  }, [operation]);
 
-  return children({ state, error, data });
+  return <>{children({ state, error, data: data! })}</>;
 }
 
-export const Operation: ComponentType = <TOperation extends AnyOperationId>({
-  id,
-  variables,
-  children,
-}: OperationProps<TOperation>) => {
-  const executor = useOperationExecutor(id, variables);
-  return executor instanceof Function ? (
-    <DelayedOperation id={id} variables={variables} executor={executor}>
-      {children}
-    </DelayedOperation>
-  ) : (
-    <StaticOperation result={executor}>{children}</StaticOperation>
+function SingleOperation<TOperation extends AnyOperationId>(
+  props: Omit<OperationProps<TOperation, false>, 'all'>,
+) {
+  const registry = useContext(ExecutorsContext).executors;
+  const executor = findExecutor(registry, props.id, props.variables);
+  if (!(executor instanceof Function)) {
+    return props.children({ state: 'success', data: executor });
+  }
+  return (
+    <DelayedOperation
+      {...props}
+      operation={() => executor(props.id, props.variables)}
+    />
   );
+}
+
+function MultiOperation<TOperation extends AnyOperationId>(
+  props: Omit<OperationProps<TOperation, true>, 'all'>,
+) {
+  const registry = useContext(ExecutorsContext).executors;
+  const executors = findExecutors(registry, props.id, props.variables);
+
+  if (executors.every((exec) => !(exec instanceof Function))) {
+    return props.children({ state: 'success', data: executors });
+  }
+  return (
+    <DelayedOperation
+      {...props}
+      operation={() =>
+        Promise.all(
+          executors.map((exec) =>
+            exec instanceof Function ? exec(props.id, props.variables) : exec,
+          ),
+        )
+      }
+    />
+  );
+}
+
+export const Operation: ComponentType = <
+  TOperation extends AnyOperationId,
+  TAll extends boolean,
+>({
+  all,
+  ...props
+}: OperationProps<TOperation, TAll>) => {
+  // @ts-ignore: Not sure how to fix this, but typing works from the outside.
+  return all ? <MultiOperation {...props} /> : <SingleOperation {...props} />;
 };

--- a/packages/npm/@amazeelabs/executors/src/interface.ts
+++ b/packages/npm/@amazeelabs/executors/src/interface.ts
@@ -6,10 +6,15 @@ import type { PropsWithChildren, ReactElement } from 'react';
 
 import type { ExecutorFunction, OperationProps, RegistryEntry } from './types';
 
-export type Operation = <TOperation extends AnyOperationId>(
+export type { RegistryEntry } from './types';
+
+export type Operation = <
+  TOperation extends AnyOperationId,
+  TAll extends boolean = false,
+>(
   props: undefined extends OperationVariables<TOperation>
-    ? Omit<OperationProps<TOperation>, 'variables'>
-    : OperationProps<TOperation> & {
+    ? Omit<OperationProps<TOperation, TAll>, 'variables'>
+    : OperationProps<TOperation, TAll> & {
         variables: OperationVariables<TOperation>;
       },
 ) => ReactElement;
@@ -18,6 +23,11 @@ export type useOperationExecutor = <TOperation extends AnyOperationId>(
   id: TOperation,
   variables?: OperationVariables<TOperation>,
 ) => ExecutorFunction<TOperation>;
+
+export type useAllOperationExecutors = <TOperation extends AnyOperationId>(
+  id: TOperation,
+  variables?: OperationVariables<TOperation>,
+) => Array<ExecutorFunction<TOperation>>;
 
 export type OperationExecutorsProvider = (
   props: PropsWithChildren<{ executors: Array<RegistryEntry<AnyOperationId>> }>,

--- a/packages/npm/@amazeelabs/executors/src/interface.ts
+++ b/packages/npm/@amazeelabs/executors/src/interface.ts
@@ -8,15 +8,8 @@ import type { ExecutorFunction, OperationProps, RegistryEntry } from './types';
 
 export type { RegistryEntry } from './types';
 
-export type Operation = <
-  TOperation extends AnyOperationId,
-  TAll extends boolean = false,
->(
-  props: undefined extends OperationVariables<TOperation>
-    ? Omit<OperationProps<TOperation, TAll>, 'variables'>
-    : OperationProps<TOperation, TAll> & {
-        variables: OperationVariables<TOperation>;
-      },
+export type Operation = <TOperation extends AnyOperationId>(
+  props: OperationProps<TOperation>,
 ) => ReactElement;
 
 export type useOperationExecutor = <TOperation extends AnyOperationId>(

--- a/packages/npm/@amazeelabs/executors/src/server.tsx
+++ b/packages/npm/@amazeelabs/executors/src/server.tsx
@@ -79,13 +79,12 @@ type ServerComponentType = Promisify<ComponentType>;
 
 export const Operation: ComponentType = (async <
   TOperation extends AnyOperationId,
-  TAll extends boolean,
 >({
   id,
   variables,
   children,
   all,
-}: OperationProps<TOperation, TAll>) => {
+}: OperationProps<TOperation>) => {
   try {
     const executors = all
       ? findExecutors(getRegistry(), id, variables)

--- a/packages/npm/@amazeelabs/executors/src/types.ts
+++ b/packages/npm/@amazeelabs/executors/src/types.ts
@@ -70,7 +70,7 @@ expectType<RegistryEntryWithoutVariables>({
   executor: { hasVariables: false },
 });
 
-type OperationChildProps<TOperation extends AnyOperationId> =
+export type ExecutionState<T extends any> =
   | {
       state: 'loading';
     }
@@ -80,15 +80,37 @@ type OperationChildProps<TOperation extends AnyOperationId> =
     }
   | {
       state: 'updating';
-      data: OperationResult<TOperation>;
+      data: T;
     }
   | {
       state: 'success';
-      data: OperationResult<TOperation>;
+      data: T;
     };
 
-export type OperationProps<TOperation extends AnyOperationId> = {
+type Exact<a, b, left, right> = a extends b
+  ? b extends a
+    ? left
+    : right
+  : right;
+
+type OperationChildProps<
+  TOperation extends AnyOperationId,
+  TAll extends boolean,
+> = ExecutionState<
+  Exact<
+    TAll,
+    true,
+    Array<OperationResult<TOperation>>,
+    OperationResult<TOperation>
+  >
+>;
+
+export type OperationProps<
+  TOperation extends AnyOperationId,
+  TAll extends boolean,
+> = {
   id: TOperation;
-  children: (props: OperationChildProps<TOperation>) => ReactNode;
+  children: (props: OperationChildProps<TOperation, TAll>) => ReactNode;
   variables?: OperationVariables<TOperation>;
+  all?: TAll;
 };

--- a/packages/npm/@amazeelabs/executors/src/types.ts
+++ b/packages/npm/@amazeelabs/executors/src/types.ts
@@ -87,30 +87,26 @@ export type ExecutionState<T extends any> =
       data: T;
     };
 
-type Exact<a, b, left, right> = a extends b
-  ? b extends a
-    ? left
-    : right
-  : right;
-
-type OperationChildProps<
-  TOperation extends AnyOperationId,
-  TAll extends boolean,
-> = ExecutionState<
-  Exact<
-    TAll,
-    true,
-    Array<OperationResult<TOperation>>,
-    OperationResult<TOperation>
-  >
->;
-
-export type OperationProps<
-  TOperation extends AnyOperationId,
-  TAll extends boolean,
-> = {
-  id: TOperation;
-  children: (props: OperationChildProps<TOperation, TAll>) => ReactNode;
-  variables?: OperationVariables<TOperation>;
-  all?: TAll;
-};
+export type OperationProps<TOperation extends AnyOperationId> = (
+  | {
+      id: TOperation;
+      children: (
+        props: ExecutionState<OperationResult<TOperation>>,
+      ) => ReactNode;
+      all?: false | undefined;
+    }
+  | {
+      id: TOperation;
+      children: (
+        props: ExecutionState<Array<OperationResult<TOperation>>>,
+      ) => ReactNode;
+      all: true;
+    }
+) &
+  (undefined extends OperationVariables<TOperation>
+    ? {
+        variables?: never;
+      }
+    : {
+        variables: OperationVariables<TOperation>;
+      });

--- a/packages/npm/@amazeelabs/executors/test/executors.spec.ts
+++ b/packages/npm/@amazeelabs/executors/test/executors.spec.ts
@@ -6,6 +6,7 @@ import { expect, test } from '@playwright/test';
     Delayed: 'Delayed: 2 + 3 = 5',
     Error: 'Error: I dont like 6es!',
     DelayedError: 'Error: I dont like 7s!',
+    Sum: 'Sum: 6',
   };
   Object.entries(cases).forEach(([label, expected]) => {
     test(`${render}: ${label}`, async ({ page }) => {


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/executors`

## Description of changes

Extend the executors API so that it can be used to run **all** executors matching an operation and return a list of results sets.

## Motivation and context

Retrieve data from multiple sources and merge it on the client.

## Related Issue(s)

Decap integration.

## How has this been tested?

- Manually
- Unit tests
- Integration tests
