### PR TITLE
DrupalView data producer fatal error fix

### DIFF
--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/DrupalView.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/DrupalView.php
@@ -95,13 +95,15 @@ class DrupalView extends DataProducerPluginBase {
 
       $form = $view->exposed_widgets;
       $filters = [];
-      foreach (Element::children($form) as $key) {
-        if (isset($form[$key]['#options'])) {
-          foreach ($form[$key]['#options'] as $value => $label) {
-            $filters[$key][] = [
-              'value' => (string) $value,
-              'label' => (string) $label,
-            ];
+      if (!empty($form)) {
+        foreach (Element::children($form) as $key) {
+          if (isset($form[$key]['#options'])) {
+            foreach ($form[$key]['#options'] as $value => $label) {
+              $filters[$key][] = [
+                'value' => (string)$value,
+                'label' => (string)$label,
+              ];
+            }
           }
         }
       }


### PR DESCRIPTION
## Package(s) involved
@amazeelabs/graphql_drectives

## Description of changes
The drupalView data producer iterates over the exposed filter form widgets using Element::children(), but if there are no widgets the $form variable is null intead of an empty array, so there is a fatal error thrown by PHP.

## How has this been tested?
Locally, manually.
