### PR TITLE
fix: allow to pass schema strings createResolveConfig

### DIFF
--- a/packages/npm/@amazeelabs/graphql-directives/src/resolvers.test.ts
+++ b/packages/npm/@amazeelabs/graphql-directives/src/resolvers.test.ts
@@ -103,7 +103,10 @@ describe('executeResolver', () => {
 
 describe('createResolveConfig', () => {
   it('creates a valid configuration', async () => {
-    const config = createResolveConfig(schema, { echo });
+    const config = createResolveConfig(
+      readFileSync('./src/test/schema.graphql').toString(),
+      { echo },
+    );
     const source = `
     query {
       value

--- a/packages/npm/@amazeelabs/graphql-directives/src/resolvers.ts
+++ b/packages/npm/@amazeelabs/graphql-directives/src/resolvers.ts
@@ -1,13 +1,16 @@
 import type { GraphQLFieldResolver, GraphQLSchema } from 'graphql';
-import { getArgumentValues, isObjectType } from 'graphql';
+import { buildSchema, getArgumentValues, isObjectType } from 'graphql';
 import { flow, isString } from 'lodash-es';
 
 export function createResolveConfig(
-  schema: GraphQLSchema,
+  schema: GraphQLSchema | string,
   directives: Record<string, GraphQLFieldResolver<any, any>>,
   api?: any,
 ): Record<string, Record<string, GraphQLFieldResolver<any, any>>> {
-  const mapping = extractResolverMapping(schema, directives);
+  const mapping = extractResolverMapping(
+    typeof schema === 'string' ? buildSchema(schema) : schema,
+    directives,
+  );
   const config: Record<
     string,
     Record<string, GraphQLFieldResolver<any, any>>


### PR DESCRIPTION

## Package(s) involved

`@amazeelabs/graphql-directives`

## Description of changes

`createResolveConfig` now also accepts strings as input and parses the schema itself.

## Motivation and context

To avoid "graphql realm" errors due to conflicting libraries.

## How has this been tested?

<!-- locally? written tests? -->
