### PR TITLE
feat: add a json-mode to codegen-autoloader

### DIFF
--- a/packages/npm/@amazeelabs/codegen-autoloader/src/index.ts
+++ b/packages/npm/@amazeelabs/codegen-autoloader/src/index.ts
@@ -5,12 +5,13 @@ import {
 import {
   generateAutoloader,
   printDrupalAutoload,
+  printJSONAutoload,
   printJsAutoload,
 } from './lib';
 
 type Config = {
   context: Array<string>;
-  mode: 'js' | 'drupal';
+  mode: 'js' | 'drupal' | 'json';
 };
 
 export const validate: PluginValidateFn<Config> = (_, __, config) => {
@@ -19,9 +20,11 @@ export const validate: PluginValidateFn<Config> = (_, __, config) => {
   }
 };
 
+const modes = {
+  js: printJsAutoload,
+  drupal: printDrupalAutoload,
+  json: printJSONAutoload,
+};
+
 export const plugin: PluginFunction<Config> = (schema, _, config) =>
-  generateAutoloader(
-    schema,
-    config.context,
-    config.mode === 'js' ? printJsAutoload : printDrupalAutoload,
-  );
+  generateAutoloader(schema, config.context, modes[config.mode]);

--- a/packages/npm/@amazeelabs/codegen-autoloader/src/lib.test.ts
+++ b/packages/npm/@amazeelabs/codegen-autoloader/src/lib.test.ts
@@ -8,6 +8,7 @@ import {
   printDrupalAutoload,
   generateAutoloader,
   contextSuggestions,
+  printJSONAutoload,
 } from './lib';
 
 describe('extractDocstrings', () => {
@@ -180,6 +181,31 @@ describe('printJsAutoload', () => {
         '  myDirective: al0,',
         '};',
       ].join('\n'),
+    );
+  });
+});
+
+describe('printJSONAutoload', () => {
+  it('prints an empty object if there are no implementations', () => {
+    expect(printJSONAutoload({})).toEqual('{}');
+  });
+
+  it('prints a single default implementation', () => {
+    expect(
+      printJSONAutoload({
+        myDirective: '@my/package#function',
+      }),
+    ).toEqual(
+      JSON.stringify(
+        {
+          myDirective: {
+            package: '@my/package',
+            export: 'function',
+          },
+        },
+        null,
+        2,
+      ),
     );
   });
 });

--- a/packages/npm/@amazeelabs/codegen-autoloader/src/lib.ts
+++ b/packages/npm/@amazeelabs/codegen-autoloader/src/lib.ts
@@ -112,6 +112,21 @@ export const printJsAutoload = (implementations: Record<string, string>) => {
   ].join('\n');
 };
 
+export const printJSONAutoload = (implementations: Record<string, string>) => {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.keys(implementations)
+        .map((directive) => {
+          const impl = parseJsImplementation(implementations[directive]);
+          return impl ? [directive, impl] : undefined;
+        })
+        .filter((dir): dir is [string, JsImplementation] => !!dir),
+    ),
+    null,
+    2,
+  );
+};
+
 type DrupalImplementation =
   | {
       service: string;


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/codegen-autoloader`

## Description of changes

Added a JSON mode for javascript autoloading.

## Motivation and context

To be able to dynamically load directives relative to the consuming package.

## How has this been tested?

* Unit tests
