### PR TITLE
chore: use authMiddleWare for publisher root

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/server.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server.ts
@@ -267,7 +267,7 @@ const runServer = async (): Promise<HttpTerminator> => {
 
   app.use(
     '/',
-    //authMiddleware,
+    authMiddleware,
     createProxyMiddleware({
       pathFilter: () => app.locals.isReady,
       target: `http://127.0.0.1:${getConfig().commands.serve.port}`,


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

Add authentication middleware to `/`

## Motivation and context

When accessing the build as an anonymous user, I am redirected to the authentication provider.

## How has this been tested?

Locally, with the template.
