### PR TITLE
feat(SLB-450): preview auth

### DIFF
--- a/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.routing.yml
+++ b/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.routing.yml
@@ -6,3 +6,27 @@ silverback_preview_link.settings:
     _description: 'Manage Preview link settings.'
   requirements:
     _permission: 'administer silverback preview link settings'
+
+silverback_preview_link.preview.access:
+  path: '/preview/access'
+  defaults:
+    _controller: '\Drupal\silverback_preview_link\Controller\PreviewController::hasAccess'
+  methods: [POST]
+  requirements:
+    # Required for the refresh token.
+    _access: 'TRUE'
+    _format: 'json'
+  options:
+    _auth: ['oauth2']
+    no_cache: TRUE
+
+silverback_preview_link.preview_link.access:
+  path: '/preview/link-access'
+  defaults:
+    _controller: '\Drupal\silverback_preview_link\Controller\PreviewController::hasLinkAccess'
+  methods: [POST]
+  requirements:
+    _access: 'TRUE'
+    _format: 'json'
+  options:
+    no_cache: TRUE

--- a/packages/composer/amazeelabs/silverback_preview_link/src/Controller/PreviewController.php
+++ b/packages/composer/amazeelabs/silverback_preview_link/src/Controller/PreviewController.php
@@ -13,7 +13,7 @@ class PreviewController extends ControllerBase {
    * Checks if the current user has access to the Preview app.
    */
   public function hasAccess() {
-    /** @var \Drupal\Core\Session\AccountProxyInterface $user */
+    /** @var \Drupal\Core\Session\AccountProxyInterface $userAccount */
     $userAccount = $this->currentUser();
     // Verify permission against User entity.
     $userEntity = User::load($userAccount->id());

--- a/packages/composer/amazeelabs/silverback_preview_link/src/Controller/PreviewController.php
+++ b/packages/composer/amazeelabs/silverback_preview_link/src/Controller/PreviewController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\silverback_preview_link\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\user\Entity\User;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class PreviewController extends ControllerBase {
+
+  /**
+   * Checks if the current user has access to the Preview app.
+   */
+  public function hasAccess() {
+    /** @var \Drupal\Core\Session\AccountProxyInterface $user */
+    $userAccount = $this->currentUser();
+    // Verify permission against User entity.
+    $userEntity = User::load($userAccount->id());
+    if ($userEntity->hasPermission('use external preview')) {
+      return new JsonResponse([
+        'access' => TRUE,
+      ], 200);
+    }
+    else {
+      return new JsonResponse([
+        'access' => FALSE,
+      ], 403);
+    }
+  }
+
+  /**
+   *  Skip Drupal authentication if there is a valid preview token.
+   */
+  public function hasLinkAccess() {
+    $requestContent = \Drupal::request()->getContent();
+    $body = json_decode($requestContent, TRUE);
+    if (
+      !empty($body['preview_access_token']) &&
+      !empty($body['entity_id']) &&
+      !empty($body['entity_type_id'])
+    ) {
+      try {
+        $entity = \Drupal::entityTypeManager()->getStorage($body['entity_type_id'])->load($body['entity_id']);
+        if ($entity instanceof ContentEntityInterface) {
+          $previewAccessChecker = \Drupal::service('access_check.silverback_preview_link');
+          $accessResult = $previewAccessChecker->access($entity, $body['preview_access_token']);
+          if ($accessResult->isAllowed()) {
+            return new JsonResponse([
+              'access' => TRUE,
+            ], 200);
+          }
+        }
+      }
+      catch (\Exception $e) {
+        $this->getLogger('silverback_preview_link')->error($e->getMessage());
+      }
+    }
+    return new JsonResponse([
+      'access' => FALSE,
+    ], 403);
+  }
+
+}


### PR DESCRIPTION
## Package(s) involved

`silverback_preview_link`

## Description of changes

- Checks permissions for a valid OAuth bearer token.
- Alternatively, grant access if there is a valid Preview link token for the entity

## Motivation and context

To be used by the Preview app in https://github.com/AmazeeLabs/silverback-template/pull/307

## How has this been tested?

Locally.