### PR TITLE
fix(SLB-449): don't trigger authentication for the build process

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/core/tools/oAuth2.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tools/oAuth2.ts
@@ -40,6 +40,10 @@ const ENCRYPTION_KEY =
  */
 export const oAuth2AuthCodeMiddleware: RequestHandler = ((): RequestHandler => {
   return async (req: Request, res: Response, next: NextFunction) => {
+    // Don't trigger authentication for the build process.
+    if (req.path === '/build.json') {
+      return next();
+    }
     if (await isAuthenticated(req)) {
       const accessPublisher = await hasPublisherAccess(req);
       if (accessPublisher) {


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

Skip OAuth for build.json.

## Motivation and context

Fix authentication that is triggered in https://github.com/AmazeeLabs/silverback-mono/blob/development/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyBuildTrigger.php#L124 and makes the build initialization fail when it is started from Drupal.

## How has this been tested?

Manually.