### PR TITLE
SLB: add key auth option to silverback gatbsy ajax build route

### DIFF
--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.routing.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.routing.yml
@@ -12,6 +12,8 @@ silverback_gatsby.build:
   path: '/silverback_gatsby/ajax/build'
   defaults:
     _controller: '\Drupal\silverback_gatsby\Controller\BuildController::build'
+  options:
+    _auth: ['key_auth']
   requirements:
     _permission: 'trigger a gatsby build'
 publisher.access:


### PR DESCRIPTION
## Package(s) involved

- `silverback_gatbsy` module

## Description of changes

- Add option for `key_auth` authentication to the `silverback_gatsby.build` route (routes need to specify the authentication providers they want to support)

## How has this been tested?

- Manually
