### PR TITLE
fix: ensure cardinality validation considers block content

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/GutenbergValidation/GutenbergCardinalityValidatorTrait.php
@@ -79,7 +79,27 @@ trait GutenbergCardinalityValidatorTrait {
       if (!isset($countInnerBlockInstances[$innerBlock['blockName']])) {
         $countInnerBlockInstances[$innerBlock['blockName']] = 0;
       }
-      $countInnerBlockInstances[$innerBlock['blockName']]++;
+
+      $hasContent = FALSE;
+
+      // Check if the inner blocks have content.
+      if (!empty($innerBlock['innerBlocks'])) {
+        foreach ($innerBlock['innerBlocks'] as $innerBlockContent) {
+          if (trim(strip_tags($innerBlockContent['innerHTML'])) !== '') {
+            $hasContent = TRUE;
+            break;
+          }
+        }
+      }
+      else {
+        // Check the content of the block itself if there are no inner blocks.
+        $hasContent = trim(strip_tags($innerBlock['innerHTML'])) !== '';
+      }
+
+      // Increment the counter if the block has meaningful content.
+      if ($hasContent) {
+        $countInnerBlockInstances[$innerBlock['blockName']]++;
+      }
     }
 
     foreach ($expected_children as $child) {


### PR DESCRIPTION
## Motivation
The cardinality validation in silverback_gutenberg allows empty blocks to be saved when there is a minimum block count set, as the block is there, just empty. This adds an additional check that the block has some content in it.