### PR TITLE
chore(SLB-449): publisher optional serve

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/core/tasks/serve/serveStart.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tasks/serve/serveStart.ts
@@ -4,13 +4,18 @@ import { TaskJob } from '../../tools/queue';
 import { run } from '../../tools/runner';
 
 export const serveStartTask: TaskJob = async (controller) => {
+  const serve = getConfig().commands.serve;
+  if (!serve) {
+    return true;
+  }
+
   if (core.serveProcess) {
     return true;
   }
 
   const promise = new Promise<void>((resolve) => {
     const _serveProcess = run({
-      command: getConfig().commands.serve.command,
+      command: serve.command,
       controller,
     });
     core.serveProcess = _serveProcess;
@@ -24,13 +29,13 @@ export const serveStartTask: TaskJob = async (controller) => {
         return true;
       });
     _serveProcess.output.subscribe((chunk) => {
-      if (chunk.includes(getConfig().commands.serve.readyPattern)) {
+      if (chunk.includes(serve.readyPattern)) {
         resolve();
       }
     });
   });
 
-  const timeout = getConfig().commands.serve.readyTimeout;
+  const timeout = serve.readyTimeout;
   const result = timeout
     ? await Promise.any([
         promise,

--- a/packages/npm/@amazeelabs/publisher/src/core/tools/config.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tools/config.ts
@@ -49,7 +49,7 @@ export type PublisherConfig = {
     /**
      * Serve the build.
      */
-    serve: {
+    serve?: {
       /**
        * Example: "pnpm gatsby serve"
        */

--- a/packages/npm/@amazeelabs/publisher/src/server.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server.ts
@@ -265,14 +265,17 @@ const runServer = async (): Promise<HttpTerminator> => {
     next();
   });
 
-  app.use(
-    '/',
-    authMiddleware,
-    createProxyMiddleware({
-      pathFilter: () => app.locals.isReady,
-      target: `http://127.0.0.1:${getConfig().commands.serve.port}`,
-    }),
-  );
+  const servePort = getConfig().commands.serve?.port;
+  if (servePort) {
+    app.use(
+      '/',
+      authMiddleware,
+      createProxyMiddleware({
+        pathFilter: () => app.locals.isReady,
+        target: `http://127.0.0.1:${servePort}`,
+      }),
+    );
+  }
 
   const host = getConfig().publisherHost || '0.0.0.0';
   const port = getConfig().publisherPort;

--- a/packages/npm/@amazeelabs/publisher/src/server.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server.ts
@@ -267,6 +267,7 @@ const runServer = async (): Promise<HttpTerminator> => {
 
   const servePort = getConfig().commands.serve?.port;
   if (servePort) {
+    // Use the authentication middleware for the proxy.
     app.use(
       '/',
       authMiddleware,
@@ -275,6 +276,12 @@ const runServer = async (): Promise<HttpTerminator> => {
         target: `http://127.0.0.1:${servePort}`,
       }),
     );
+  } else {
+    // When not serving, redirect to the status
+    // that will use the authentication middleware if needed.
+    app.get('/', async (req, res) => {
+      res.redirect('/___status/');
+    });
   }
 
   const host = getConfig().publisherHost || '0.0.0.0';


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

- Backport optional serve from Publisher 3
- When not serving, defer the authentication to `___status`

## Motivation and context

Proxying can lead to authentication issues when a build is running. This can cause monitoring issues.
As we mostly want to serve on local dev to simulate the Netlify environment, we don't really need to authenticate in this case. So make serve optional to be able to configure it based on the environment.

## How has this been tested?

Manually