### PR TITLE
refactor(SLB-458): consolidate qr generation

### DIFF
--- a/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.module
+++ b/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.module
@@ -52,6 +52,7 @@ function silverback_preview_link_theme(array $existing, string $type, string $th
         'preview_link_has_expired' => FALSE,
         'preview_url' => NULL,
         'preview_qr_code_url' => NULL,
+        'preview_qr_code_fallback' => NULL,
         'expiry_description' => NULL,
         'actions_description' => NULL,
         'display_gif' => FALSE,

--- a/packages/composer/amazeelabs/silverback_preview_link/src/Controller/PreviewController.php
+++ b/packages/composer/amazeelabs/silverback_preview_link/src/Controller/PreviewController.php
@@ -67,7 +67,7 @@ class PreviewController extends ControllerBase {
    * Returns the QR SVG file.
    */
   public function getQRCode(string $base64_url): CacheableResponse {
-    $decodedUrl = base64_decode($base64_url);
+    $decodedUrl = base64_decode(str_replace(['_'], ['/'], $base64_url));
     $qrCode = new QRCodeWithLogo();
     $result = $qrCode->getQRCode($decodedUrl);
     return new CacheableResponse($result, 200, ['Content-Type' => 'image/svg+xml']);

--- a/packages/composer/amazeelabs/silverback_preview_link/templates/preview-link.html.twig
+++ b/packages/composer/amazeelabs/silverback_preview_link/templates/preview-link.html.twig
@@ -19,12 +19,18 @@
   {% if preview_link_has_expired and display_gif %}
     <iframe src="https://giphy.com/embed/CZGcUfnAy3ayJw2eZX" width="480" height="398" style="" frameBorder="0" class="giphy-embed" allowFullScreen></iframe>
   {% endif %}
-  {% if preview_qr_code_url is not empty and not preview_link_has_expired %}
+  {% if preview_url is not empty and not preview_link_has_expired %}
     <div class="preview-link__qr">
       <p>{{ 'Scan the QR Code to open the preview on another device.' }}</p>
-      <div class="preview-link__qr--wrapper" style="display: flex; align-items: center; justify-content: center;">
-        <img src="{{ preview_qr_code_url }}" alt="{{ preview_url }}" width="300" height="300" />
-      </div>
+        <div class="preview-link__qr--wrapper" style="display: flex; align-items: center; justify-content: center;">
+          {% if preview_qr_code_url %}
+            <img src="{{ preview_qr_code_url }}" alt="{{ preview_url }}" width="300" height="300" />
+          {% elseif preview_qr_code_fallback is not empty %}
+            <img src="{{ preview_qr_code_fallback }}" alt="{{ preview_url }}" width="250" height="250" />
+          {% else %}
+            <p>{{ '❌ Error while generating the QR Code.' | t }}</p>
+          {% endif %}
+        </div>
     </div>
   {% endif %}
   {% if expiry_description is not empty %}


### PR DESCRIPTION
## Package(s) involved

`silverback_preview_link`

## Description of changes

- Fix an issue with base64_encode
- Progressive degradation instead of fatal error so the copy link feature is still available
- Log if the branded QR fails to generate and fallback to a generic QR
- Log and display a short message on the UI if the generic QR fails to generate

## How has this been tested?

Manually.