### PR TITLE
refactor(SLB-458): optimize modal display for smaller screens

### DIFF
--- a/packages/composer/amazeelabs/silverback_preview_link/css/modal.css
+++ b/packages/composer/amazeelabs/silverback_preview_link/css/modal.css
@@ -1,0 +1,17 @@
+.preview-link .preview-link__copy,
+.preview-link p {
+  margin: 0;
+}
+
+.silverback-preview-link-entity-form .messages__header {
+  display: none;
+}
+
+.silverback-preview-link-entity-form .messages-list {
+  margin-block: 0;
+}
+
+.silverback-preview-link-entity-form .messages {
+  padding-block: 8px;
+  padding-inline: 0;
+}

--- a/packages/composer/amazeelabs/silverback_preview_link/js/copy.js
+++ b/packages/composer/amazeelabs/silverback_preview_link/js/copy.js
@@ -26,7 +26,7 @@
         copy = () => {
           navigator.clipboard.writeText(copyText.value).then(
             () => setSuccessMessage(),
-            (err) => (console.log('Error: ' + err)),
+            (err) => console.log('Error: ' + err),
           );
         };
       }

--- a/packages/composer/amazeelabs/silverback_preview_link/js/copy.js
+++ b/packages/composer/amazeelabs/silverback_preview_link/js/copy.js
@@ -3,19 +3,18 @@
     attach: function (context) {
       const copyText = document.querySelector('.preview-link__copy .form-text');
       const copyButton = document.querySelector('.preview-link__copy button');
-      const copyResult = document.querySelector(
-        '.preview-link__copy .form-item__description',
-      );
 
-      if (!copyText || !copyButton || !copyResult) {
+      if (!copyText || !copyButton) {
         return;
       }
+
       const setSuccessMessage = () => {
-        const copySuccessMessage = Drupal.t('Link copied ✨ ready to share!');
-        copyResult.textContent = copySuccessMessage;
+        const originalLabel = copyButton.textContent;
+        const copySuccessLabel = Drupal.t('Copied ✨');
+        copyButton.textContent = copySuccessLabel;
         setTimeout(() => {
-          copyResult.textContent = ' ';
-        }, 3000);
+          copyButton.textContent = originalLabel;
+        }, 2000);
       };
       // Fallback for browsers that don't support navigator.clipboard.
       let copy = () => {
@@ -27,7 +26,7 @@
         copy = () => {
           navigator.clipboard.writeText(copyText.value).then(
             () => setSuccessMessage(),
-            (err) => (copyResult.textContent = 'Error: ' + err),
+            (err) => (console.log('Error: ' + err)),
           );
         };
       }

--- a/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.libraries.yml
+++ b/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.libraries.yml
@@ -2,3 +2,8 @@ copy:
   version: VERSION
   js:
     js/copy.js: {}
+modal:
+  version: VERSION
+  css:
+    theme:
+      css/modal.css: {}

--- a/packages/composer/amazeelabs/silverback_preview_link/src/Form/PreviewLinkForm.php
+++ b/packages/composer/amazeelabs/silverback_preview_link/src/Form/PreviewLinkForm.php
@@ -232,6 +232,7 @@ final class PreviewLinkForm extends ContentEntityForm {
     }
     unset($form['actions']['submit']);
     $form['#attached']['library'][] = 'silverback_preview_link/copy';
+    $form['#attached']['library'][] = 'silverback_preview_link/modal';
 
     return $form;
   }

--- a/packages/composer/amazeelabs/silverback_preview_link/templates/preview-link.html.twig
+++ b/packages/composer/amazeelabs/silverback_preview_link/templates/preview-link.html.twig
@@ -7,13 +7,10 @@
              name="preview-link__copy--text"
              type="text"
              value="{{ preview_url }}"
-             size="32"
+             size="28"
              class="form-text required form-element form-element--type-text form-element--api-textfield"
       >
-      <button class="button">{{ 'Copy' }}</button>
-      <div id="preview-link__copy--result" class="form-item__description">
-        &nbsp;
-      </div>
+      <button class="button button--primary">{{ 'Copy' }}</button>
     </div>
   {% endif %}
   {% if preview_link_has_expired and display_gif %}


### PR DESCRIPTION
## Package(s) involved

`silverback_preview_link`

## Description of changes

Optimize modal display for smaller screens to minimize the usage of scrollbars.

- Move the copied link confirmation state in the button label
- Reduce vertical space