### PR TITLE
chore(SLB-449): move publisher wildcard route after the root one

### DIFF
--- a/packages/npm/@amazeelabs/publisher/publisher.config.ts
+++ b/packages/npm/@amazeelabs/publisher/publisher.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   // oAuth2 takes precedence.
   oAuth2: {
     clientId: process.env.OAUTH2_CLIENT_ID || 'publisher',
-    clientSecret: process.env.OAUTH2_CLIENT_ID || 'publisher',
+    clientSecret: process.env.OAUTH2_CLIENT_SECRET || 'publisher',
     // Applies for ResourceOwnerPassword only.
     scope: process.env.OAUTH2_SCOPE || 'publisher',
     tokenHost: process.env.OAUTH2_TOKEN_HOST || 'http://127.0.0.1:8888',

--- a/packages/npm/@amazeelabs/publisher/src/server.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server.ts
@@ -253,18 +253,6 @@ const runServer = async (): Promise<HttpTerminator> => {
     res.redirect('/oauth/login');
   });
 
-  app.get('*', (req, res, next) => {
-    if (!req.app.locals.isReady) {
-      if (req.accepts('text/html')) {
-        res.redirect(302, `/___status/status.html?dest=${req.originalUrl}`);
-      } else {
-        res.status(404);
-      }
-      res.end();
-    }
-    next();
-  });
-
   const servePort = getConfig().commands.serve?.port;
   if (servePort) {
     // Use the authentication middleware for the proxy.
@@ -283,6 +271,18 @@ const runServer = async (): Promise<HttpTerminator> => {
       res.redirect('/___status/');
     });
   }
+
+  app.get('*', (req, res, next) => {
+    if (!req.app.locals.isReady) {
+      if (req.accepts('text/html')) {
+        res.redirect(302, `/___status/status.html?dest=${req.originalUrl}`);
+      } else {
+        res.status(404);
+      }
+      res.end();
+    }
+    next();
+  });
 
   const host = getConfig().publisherHost || '0.0.0.0';
   const port = getConfig().publisherPort;


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

Move the wildcard `*` route after the root `/` one.

## Motivation and context

It causes a cannot set headers after they are sent to the client error in some situations, like authentication.