### PR TITLE
Support for configurable response headers in publisher

### DIFF
--- a/packages/npm/@amazeelabs/publisher/publisher.config.ts
+++ b/packages/npm/@amazeelabs/publisher/publisher.config.ts
@@ -45,4 +45,8 @@ export default defineConfig({
     },
   },
   databaseUrl: './test/database.sqlite',
+  responseHeaders: (new Map())
+    .set('X-Frame-Options', 'deny')
+    .set('X-Content-Type-Options', 'nosniff')
+    .set('Content-Security-Policy', "frame-ancestors 'none'")
 });

--- a/packages/npm/@amazeelabs/publisher/publisher.config.ts
+++ b/packages/npm/@amazeelabs/publisher/publisher.config.ts
@@ -45,8 +45,8 @@ export default defineConfig({
     },
   },
   databaseUrl: './test/database.sqlite',
-  responseHeaders: (new Map())
+  responseHeaders: new Map()
     .set('X-Frame-Options', 'deny')
     .set('X-Content-Type-Options', 'nosniff')
-    .set('Content-Security-Policy', "frame-ancestors 'none'")
+    .set('Content-Security-Policy', "frame-ancestors 'none'"),
 });

--- a/packages/npm/@amazeelabs/publisher/src/core/tools/config.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tools/config.ts
@@ -131,7 +131,7 @@ export type PublisherConfig = {
    * Example: (new Map()).set('X-Frame-Options', 'deny')
    * The above would set the "X-Frame-Options" response header to "deny".
    */
-  responseHeaders?: Map<string, string>,
+  responseHeaders?: Map<string, string>;
   /**
    * Proxy settings.
    *

--- a/packages/npm/@amazeelabs/publisher/src/core/tools/config.ts
+++ b/packages/npm/@amazeelabs/publisher/src/core/tools/config.ts
@@ -126,6 +126,13 @@ export type PublisherConfig = {
     origin: Array<string>;
   };
   /**
+   * A Map of response headers that should be added to every route.
+   *
+   * Example: (new Map()).set('X-Frame-Options', 'deny')
+   * The above would set the "X-Frame-Options" response header to "deny".
+   */
+  responseHeaders?: Map<string, string>,
+  /**
    * Proxy settings.
    *
    * Example:

--- a/packages/npm/@amazeelabs/publisher/src/server.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server.ts
@@ -72,9 +72,11 @@ const runServer = async (): Promise<HttpTerminator> => {
     // if we have a Map with two items: key1 => value1, key2 => value2, then
     // the spread operator applied on the Map would return
     // [["key1", "value1"], ["key2", "value2"]].
-    [...(getConfig().responseHeaders || new Map<string, string>())].map(responseHeader => {
-      res.set(responseHeader[0], responseHeader[1]);
-    });
+    [...(getConfig().responseHeaders || new Map<string, string>())].map(
+      (responseHeader) => {
+        res.set(responseHeader[0], responseHeader[1]);
+      },
+    );
     next();
   });
 

--- a/packages/npm/@amazeelabs/publisher/src/server.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server.ts
@@ -66,6 +66,18 @@ const runServer = async (): Promise<HttpTerminator> => {
     next();
   });
 
+  // Add any configured response headers which should apply on every route.
+  app.use((req, res, next) => {
+    // The spread operator applied on a Map generates a 2D key-value array. So
+    // if we have a Map with two items: key1 => value1, key2 => value2, then
+    // the spread operator applied on the Map would return
+    // [["key1", "value1"], ["key2", "value2"]].
+    [...(getConfig().responseHeaders || new Map<string, string>())].map(responseHeader => {
+      res.set(responseHeader[0], responseHeader[1]);
+    });
+    next();
+  });
+
   core.state.applicationState$.subscribe((state) => {
     app.locals.isReady = state === ApplicationState.Ready;
     stateNotify(state);


### PR DESCRIPTION
## Package(s) involved
amazeelabs/publisher

## Description of changes
After the feedback from the LGT penetration test, there is the need for additional response headers in the publisher app. Some of them might makes sense for some cases, others not, so this change gives the possibility to have configure custom response headers (that apply for every route in the publisher app).
The default setup is to set the following headers:
- X-Frame-Options: deny
- X-Content-Type-Options: nosniff
- Content-Security-Policy: frame-ancestors 'none'
The above list could be of course amended for the default setup.

## How has this been tested?
Locally, manually.
