### PR TITLE
fix: allow arbitrary types to implement interfaces in gatsby

### DIFF
--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.test.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.test.ts
@@ -32,6 +32,7 @@ describe('extractNodeTypes', () => {
     expect(extractNodeTypes(schema)).toEqual([
       'Customer',
       'Employee',
+      'Celebrity',
       'WithDirective',
       'WithCustomAndDefaultDirective',
     ]);
@@ -71,6 +72,11 @@ describe('cleanSchema', () => {
       type Employee implements Contact {
         id: ID!
         role: String!
+        name: String!
+        email: Email!
+      }
+      type Celebrity implements Contact {
+        id: ID!
         name: String!
         email: Email!
       }

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/helpers/schema.ts
@@ -45,13 +45,16 @@ export function extractNodeTypes(schema: GraphQLSchema) {
 
   for (const type of Object.values(schema.getTypeMap())) {
     if (isObjectType(type)) {
+      const interfaces = type.astNode?.interfaces?.map(
+        (iface) => iface.name.value,
+      );
       const directives = (type.astNode?.directives || [])
         .map((dir) => dir.name.value)
         .filter((dir) => dir !== 'type');
       const firstDefault = directives.indexOf('default');
       const relevantDirectives =
         firstDefault === -1 ? directives : directives.slice(0, firstDefault);
-      if (relevantDirectives.length > 0) {
+      if (relevantDirectives.length > 0 || interfaces?.length) {
         sources.push(type.name);
       }
     }

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/test/schema/schema.graphql
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/test/schema/schema.graphql
@@ -25,6 +25,12 @@ type Employee implements Contact @sourceFrom(fn: "sourceEmployees") {
   email: Email!
 }
 
+type Celebrity implements Contact {
+  id: ID!
+  name: String!
+  email: Email!
+}
+
 # Arbitrary directive that produces values.
 directive @value repeatable on OBJECT
 # @type directive used by the Drupal module.


### PR DESCRIPTION
## Package(s) involved

`@amazeelabs/gatsby-source-silverback`

## Description of changes

Mark all types that implement interfaces to also implement `Node`, so that they can be queried with Gatsby.
