### PR TITLE
Avoid duplicates in `_drupalFeedInfo.changes`

### DIFF
--- a/.idea/php-test-framework.xml
+++ b/.idea/php-test-framework.xml
@@ -7,6 +7,7 @@
           <versions>
             <info id="Local" version="9.5.8" />
             <info id="Local/Users/pmelab/Code/silverback-mono/apps/silverback-drupal/vendor/autoload.php" version="9.6.15" />
+            <info id="Local/apps/silverback-drupal/vendor/autoload.php" version="9.6.20" />
           </versions>
         </cache>
       </tool>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -26,7 +26,7 @@
       <path value="$PROJECT_DIR$/apps/silverback-drupal/web/modules/contrib" />
     </include_path>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="8.2">
+  <component name="PhpProjectSharedConfiguration" php_language_level="8.3">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
   <component name="PhpStan">

--- a/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTracker.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/GatsbyUpdateTracker.php
@@ -81,6 +81,7 @@ class GatsbyUpdateTracker implements GatsbyUpdateTrackerInterface {
       ->condition('id', $lastBuild, '>')
       ->condition('id', $currentBuild, '<=')
       ->condition('server', $server)
+      ->distinct()
       ->execute()
       ->fetchAll());
   }

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/GatsbyUpdateTrackerTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/GatsbyUpdateTrackerTest.php
@@ -167,4 +167,22 @@ class GatsbyUpdateTrackerTest extends KernelTestBase {
     ], $this->tracker->diff(3, 4, 'bar'));
   }
 
+  public function testDuplicateItems() {
+    $this->tracker->track('foo', 'Page', '1');
+    $this->tracker->track('foo', 'Page', '2');
+
+    // Simulate a new PHP request to track a duplicate. Otherwise, it won't be
+    // tracked.
+    $this->tracker->clear();
+
+    // Add a duplicate entry.
+    $this->tracker->track('foo', 'Page', '2');
+
+    // Expect no duplicates in the diff.
+    $this->assertEquals(
+      [new GatsbyUpdate('Page', '2')],
+      $this->tracker->diff(1, 3, 'foo')
+    );
+  }
+
 }

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/README.md
@@ -54,6 +54,8 @@ The following configuration options are supported:
   GraphQL query. Defaults to 100.
 - `type_prefix` **(optional)**: A prefix to be added to all generated GraphQL
   types. Defaults to `Drupal`.
+- `request_timeout` **(optional)**: The timeout for the GraphQL requests in
+  milliseconds. Defaults to 60_000.
 
 The optional credential parameters can be used to enable different workflows. On
 production, they can be omitted to make sure Drupal handles these requests

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/gatsby-node.ts
@@ -49,6 +49,7 @@ export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
     schema_configuration: Joi.string().optional(),
     directives: Joi.object().pattern(Joi.string(), Joi.function()).optional(),
     sources: Joi.object().pattern(Joi.string(), Joi.function()).optional(),
+    request_timeout: Joi.number().optional().min(1),
   });
 
 const getForwardedHeaders = (url: URL) => ({

--- a/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
+++ b/packages/npm/@amazeelabs/gatsby-source-silverback/src/utils.ts
@@ -23,6 +23,8 @@ export type Options = {
   directives?: Record<string, Function>;
   // A list of functions that will be available as data source.
   sources?: Record<string, Function>;
+  // Request timeout for GraphQL queries in milliseconds. Defaults to 60_000.
+  request_timeout?: number;
 };
 
 export const validOptions = (options: {


### PR DESCRIPTION
## Package(s) involved

`silverback_gatsby`

## Description of changes

Avoid re-fetching same entities multiple times during incremental builds.

Bonus: Configurable GraphQL request timeout.

## Motivation and context

Noticed on a project: An incremental build was fetching the same entities 20 times 🙈 

## How has this been tested?

Unit tests.
