### PR TITLE
executors reloading state

### DIFF
--- a/packages/npm/@amazeelabs/executors/src/client.tsx
+++ b/packages/npm/@amazeelabs/executors/src/client.tsx
@@ -91,6 +91,7 @@ function DelayedOperation<T extends any>({
   const [error, setError] = useState<unknown>();
 
   useEffect(() => {
+    setState('loading');
     operation()
       .then((result) => {
         setData(result);
@@ -101,7 +102,7 @@ function DelayedOperation<T extends any>({
         setError(error);
         setState('error');
       });
-  }, [operation]);
+  }, [operation, setData, setError, setState]);
 
   return <>{children({ state, error, data: data! })}</>;
 }

--- a/packages/npm/@amazeelabs/executors/src/types.ts
+++ b/packages/npm/@amazeelabs/executors/src/types.ts
@@ -79,10 +79,6 @@ export type ExecutionState<T extends any> =
       error: unknown;
     }
   | {
-      state: 'updating';
-      data: T;
-    }
-  | {
       state: 'success';
       data: T;
     };

--- a/packages/npm/@amazeelabs/executors/test/src/add-client.tsx
+++ b/packages/npm/@amazeelabs/executors/test/src/add-client.tsx
@@ -1,11 +1,29 @@
 'use client';
+import { useEffect, useState } from 'react';
+
 import { Operation, OperationExecutorsProvider } from '../../src/client.js';
-import { TestComponent } from './add.js';
+import { Calc, DelayedAdd, TestComponent } from './add.js';
+
+function CountUp() {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCount(count + 1);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [count, setCount]);
+  return <Calc label={'Count'} a={count} b={0} Operation={Operation} />;
+}
 
 export const Add = () => (
-  <TestComponent
-    label={'Client'}
-    OperationExecutorsProvider={OperationExecutorsProvider}
-    Operation={Operation}
-  />
+  <>
+    <TestComponent
+      label={'Client'}
+      OperationExecutorsProvider={OperationExecutorsProvider}
+      Operation={Operation}
+    />
+    <OperationExecutorsProvider executors={[DelayedAdd]}>
+      <CountUp />
+    </OperationExecutorsProvider>
+  </>
 );

--- a/packages/npm/@amazeelabs/executors/test/src/add.tsx
+++ b/packages/npm/@amazeelabs/executors/test/src/add.tsx
@@ -87,15 +87,13 @@ export function Calc({
   return (
     <Operation id={AddOperation} variables={{ a, b }}>
       {(props) => {
-        if (props.state === 'loading') {
-          return <p data-testid={label}>Loading...</p>;
-        }
         if (props.state === 'error') {
           return <p data-testid={label}>Error: {`${props.error}`}</p>;
         }
         return (
           <p data-testid={label}>
-            {label}: {a} + {b} = {props.data.result}
+            {label}: {a} + {b} ={' '}
+            {props.state === 'loading' ? '...' : props.data.result}
           </p>
         );
       }}


### PR DESCRIPTION
- **refactor(executors): remove leftover "updating" state**
- **fix(executors): fall back into "loading" state if arguments change**

## Package(s) involved

`@amazeelabs/executors`

## Description of changes

Remove the `updating` state from `<Operation/>` typing. It was never really emitted and just confusing.
To implement more complex client side updates that keep the previous result, executors should be used directly
in combination with a client side fetching library like "tanstack-query" or "useSWR" that manage state and cache.
