### PR TITLE
feat: prevent .envrc from overriding any changes you make.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ cd silverback-mono
 pnpm i
 pnpm build
 ```
+
+## Notes
+
+- `.envrc` is created automatically via composer install, however it won't be
+  overwritten If it already exists.

--- a/packages/composer/amazeelabs/silverback-cli/composer.json
+++ b/packages/composer/amazeelabs/silverback-cli/composer.json
@@ -24,7 +24,10 @@
     "drupal-scaffold": {
       "file-mapping": {
         "[project-root]/.env.local.example": "assets/.env.local.example",
-        "[project-root]/.envrc": "assets/.envrc",
+        "[project-root]/.envrc": {
+          "path": "assets/.envrc",
+          "override": false
+        },
         "[project-root]/.gitignore": {
           "append": "assets/.gitignore.append.txt",
           "force-append": true


### PR DESCRIPTION
## Package(s) involved
- sliverback-cli

## Description of changes
Adding `override: false` on the scaffolding of `.envrc`

## Motivation and context
If I want to make changes locally for example configure `devbox` I don't want my changes to be overiden every time I run `composer install`.