### PR TITLE
Fix default content

### DIFF
--- a/apps/silverback-drupal/web/modules/custom/silverback_default_content/content/node/f9778402-1375-4bc0-a550-00610ad3865d.yml
+++ b/apps/silverback-drupal/web/modules/custom/silverback_default_content/content/node/f9778402-1375-4bc0-a550-00610ad3865d.yml
@@ -7,6 +7,7 @@ _meta:
   depends:
     378fdfc0-05fa-4d50-aaed-3342cd5f844c: media
     fd3a7238-807a-483d-a703-c9b1b6b4a8e8: media
+    c997198a-a4a5-484a-8567-46ca6a24301a: node
 default:
   revision_uid:
     -


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_gutenberg`

## Description of changes

In the code.

## Motivation and context

Entity usage isn't tracked for links when the content is imported from the default content.

## Related Issue(s)

SLB-502

## How has this been tested?

We have entity usage tests in silverback-template. They were failing after the content re-export. Now they should pass again.
