### PR TITLE
refactor(executors): don't wrap executors in a function to omit id arguments

### DIFF
--- a/packages/npm/@amazeelabs/executors/src/client.tsx
+++ b/packages/npm/@amazeelabs/executors/src/client.tsx
@@ -58,11 +58,7 @@ export const useOperationExecutor: HookType = <
   variables?: OperationVariables<TOperation>,
 ): Executor<TOperation> => {
   const { executors } = useContext(ExecutorsContext);
-  const executor = findExecutor(executors, id, variables);
-  if (executor instanceof Function) {
-    return (vars?: OperationVariables<TOperation>) => executor(id, vars);
-  }
-  return executor;
+  return findExecutor(executors, id, variables);
 };
 
 export const useAllOperationExecutors: AllHookType = <
@@ -72,9 +68,7 @@ export const useAllOperationExecutors: AllHookType = <
   variables?: OperationVariables<TOperation>,
 ) => {
   const { executors } = useContext(ExecutorsContext);
-  return findExecutors(executors, id, variables).map((exec) =>
-    exec instanceof Function ? (vars) => exec(id, vars) : () => exec,
-  );
+  return findExecutors(executors, id, variables);
 };
 
 function DelayedOperation<T>({

--- a/packages/npm/@amazeelabs/executors/src/lib.test.tsx
+++ b/packages/npm/@amazeelabs/executors/src/lib.test.tsx
@@ -30,7 +30,7 @@ function Consumer({
 }) {
   const executor = useOperationExecutor(id as AnyOperationId, variables);
   return (
-    <p>{typeof executor === 'function' ? executor(variables) : executor}</p>
+    <p>{typeof executor === 'function' ? executor(id, variables) : executor}</p>
   );
 }
 
@@ -38,7 +38,7 @@ function MultiConsumer({
   id,
   variables,
 }: {
-  id: string;
+  id: AnyOperationId;
   variables?: Record<string, any>;
 }) {
   const executors = useAllOperationExecutors(id as AnyOperationId, variables);
@@ -47,7 +47,7 @@ function MultiConsumer({
   ) : (
     executors.map((executor, index) => (
       <p key={index}>
-        {typeof executor === 'function' ? executor(variables) : executor}
+        {typeof executor === 'function' ? executor(id, variables) : executor}
       </p>
     ))
   );

--- a/packages/npm/@amazeelabs/executors/src/server.tsx
+++ b/packages/npm/@amazeelabs/executors/src/server.tsx
@@ -56,10 +56,7 @@ export const useOperationExecutor: HookType = <
   id: TOperation,
   variables: OperationVariables<TOperation>,
 ): ExecutorFunction<TOperation> => {
-  const executor = findExecutor(getRegistry(), id, variables);
-  return executor instanceof Function
-    ? (vars) => executor(id, vars)
-    : () => executor;
+  return findExecutor(getRegistry(), id, variables);
 };
 
 export const useAllOperationExecutors: AllHookType = <
@@ -68,9 +65,7 @@ export const useAllOperationExecutors: AllHookType = <
   id: TOperation,
   variables: OperationVariables<TOperation>,
 ): Array<ExecutorFunction<TOperation>> => {
-  return findExecutors(getRegistry(), id, variables).map((exec) =>
-    exec instanceof Function ? (vars) => exec(id, vars) : () => exec,
-  );
+  return findExecutors(getRegistry(), id, variables);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/npm/@amazeelabs/executors/src/types.ts
+++ b/packages/npm/@amazeelabs/executors/src/types.ts
@@ -14,15 +14,13 @@ type TestWithoutVariables = OperationId<
 >;
 
 export type ExecutorFunction<TOperation extends AnyOperationId> = (
+  id: TOperation,
   variables: OperationVariables<TOperation>,
 ) => Promise<OperationResult<TOperation>>;
 
 export type Executor<TOperation extends AnyOperationId> =
   | OperationResult<TOperation>
-  | ((
-      id: TOperation,
-      variables: OperationVariables<TOperation>,
-    ) => Promise<OperationResult<TOperation>>);
+  | ExecutorFunction<TOperation>;
 
 type ExecutorWithVariables = Executor<TestWithVariables>;
 type ExecutorWithoutVariables = Executor<TestWithoutVariables>;


### PR DESCRIPTION
This way its easier to distinguish from the outside if an executor is
dynamic or static.
