### PR TITLE
fix: extracting label option from object

### DIFF
--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/DrupalView.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/DrupalView.php
@@ -99,6 +99,9 @@ class DrupalView extends DataProducerPluginBase {
         foreach (Element::children($form) as $key) {
           if (isset($form[$key]['#options'])) {
             foreach ($form[$key]['#options'] as $value => $label) {
+              if (is_object($label) && isset($label->option)) {
+                $label = $label->option;
+              }
               $filters[$key][] = [
                 'value' => (string)$value,
                 'label' => (string)$label,


### PR DESCRIPTION
## Package(s) involved
- `packages/composer/amazeelabs/graphql_directives`

## Description of changes

Checking if a "string" is an "object" to help prevent throwing errors when trying to convert to string.

## Motivation and context

After adding taxonomy filters to sliverback template, errors were being thrown as it tried to get "label", checking if is object first prevents this problem.

The error I was getting:
```
For error #0: Error: Object of class stdClass could not be converted to string in Drupal\graphql_directives\Plugin\GraphQL\DataProducer\DrupalView->Drupal\graphql_directives\Plugin\GraphQL\DataProducer\{closure}() (line 104 of template/apps/cms/web/modules/contrib/graphql_directives/src/Plugin/GraphQL/DataProducer/DrupalView.php
```

## Related Issue(s)
https://amazeelabs.atlassian.net/browse/SLB-512
