### PR TITLE
Use correct revision id on latest_version route

### DIFF
--- a/packages/composer/amazeelabs/graphql_directives/README.md
+++ b/packages/composer/amazeelabs/graphql_directives/README.md
@@ -405,7 +405,8 @@ Reserved keys:
 The rest of keys are taken as filters.
 
 Array values are allowed in the format of NPM `query-string` package with
-`arrayFormat` set to `bracket`, e.g. `tag[]=1&tag[]=2`. Ensure that the view filter Selection type is set to Dropdown not Autocomplete for entity references.
+`arrayFormat` set to `bracket`, e.g. `tag[]=1&tag[]=2`. Ensure that the view
+filter Selection type is set to Dropdown not Autocomplete for entity references.
 
 #### Returning result
 


### PR DESCRIPTION
## Package(s) involved

`amazeelabs/silverback_external_preview`

## Description of changes

Fix revision ID on `entity.node.latest_version` route.

## Motivation and context

Currently `{lang}/node/{nid}/latest` displays the preview iframe for the latest revision, not considering the language. And the preview query can fail to load data if the language/revisionId pair is incorrect.

## How has this been tested?

Manually on a project.
