### PR TITLE
refactor(mutator): add EntityBlockMutatorBase

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/README.md
+++ b/packages/composer/amazeelabs/silverback_gutenberg/README.md
@@ -28,11 +28,11 @@ structured block data. Allows to define `aggregated` and `ignored` blocks:
 type Page {
   title: String! @resolveProperty(path: "title.value")
   content: [Blocks!]!
-  @resolveEditorBlocks(
-    path: "body.value"
-    aggregated: ["core/paragraph", "core/list"]
-    ignored: ["core/group"]
-  )
+    @resolveEditorBlocks(
+      path: "body.value"
+      aggregated: ["core/paragraph", "core/list"]
+      ignored: ["core/group"]
+    )
 }
 ```
 
@@ -279,20 +279,20 @@ registerBlockType('custom/my-block', {
       blockCount: select('core/block-editor').getBlockCount(props.clientId),
     }));
     return (
-            <div>
-              <InnerBlocks
-                      templateLock={false}
-                      renderAppender={() => {
-                        if (blockCount >= MAX_BLOCKS) {
-                          return null;
-                        } else {
-                          return <InnerBlocks.ButtonBlockAppender />;
-                        }
-                      }}
-                      allowedBlocks={['core/block']}
-                      template={[]}
-              />
-            </div>
+      <div>
+        <InnerBlocks
+          templateLock={false}
+          renderAppender={() => {
+            if (blockCount >= MAX_BLOCKS) {
+              return null;
+            } else {
+              return <InnerBlocks.ButtonBlockAppender />;
+            }
+          }}
+          allowedBlocks={['core/block']}
+          template={[]}
+        />
+      </div>
     );
   },
   save: () => {
@@ -364,13 +364,14 @@ To enable the integration:
 Entity id references can be used as Gutenberg attributes.
 
 When using default content, we need to map the entity id with the uuid:
+
 - id to uuid on export
 - uuid to id on import
 
 This is especially useful for schema tests, when using entity reference.
 
-To facilitate this process, block mutator plugins can be used,
-the easiest way is to extend the `EntityBlockMutatorBase` base class.
+To facilitate this process, block mutator plugins can be used, the easiest way
+is to extend the `EntityBlockMutatorBase` base class.
 
 Example, with multi-valued Gutenberg attribute
 
@@ -406,7 +407,6 @@ class MediaBlockMutator extends EntityBlockMutatorBase {
 
 }
 ```
-
 
 Example, with single-valued Gutenberg attribute
 

--- a/packages/composer/amazeelabs/silverback_gutenberg/README.md
+++ b/packages/composer/amazeelabs/silverback_gutenberg/README.md
@@ -28,11 +28,11 @@ structured block data. Allows to define `aggregated` and `ignored` blocks:
 type Page {
   title: String! @resolveProperty(path: "title.value")
   content: [Blocks!]!
-    @resolveEditorBlocks(
-      path: "body.value"
-      aggregated: ["core/paragraph", "core/list"]
-      ignored: ["core/group"]
-    )
+  @resolveEditorBlocks(
+    path: "body.value"
+    aggregated: ["core/paragraph", "core/list"]
+    ignored: ["core/group"]
+  )
 }
 ```
 
@@ -279,20 +279,20 @@ registerBlockType('custom/my-block', {
       blockCount: select('core/block-editor').getBlockCount(props.clientId),
     }));
     return (
-      <div>
-        <InnerBlocks
-          templateLock={false}
-          renderAppender={() => {
-            if (blockCount >= MAX_BLOCKS) {
-              return null;
-            } else {
-              return <InnerBlocks.ButtonBlockAppender />;
-            }
-          }}
-          allowedBlocks={['core/block']}
-          template={[]}
-        />
-      </div>
+            <div>
+              <InnerBlocks
+                      templateLock={false}
+                      renderAppender={() => {
+                        if (blockCount >= MAX_BLOCKS) {
+                          return null;
+                        } else {
+                          return <InnerBlocks.ButtonBlockAppender />;
+                        }
+                      }}
+                      allowedBlocks={['core/block']}
+                      template={[]}
+              />
+            </div>
     );
   },
   save: () => {
@@ -358,3 +358,82 @@ To enable the integration:
     }}
   />
   ```
+
+## Gutenberg block mutator
+
+Entity id references can be used as Gutenberg attributes.
+
+When using default content, we need to map the entity id with the uuid:
+- id to uuid on export
+- uuid to id on import
+
+This is especially useful for schema tests, when using entity reference.
+
+To facilitate this process, block mutator plugins can be used,
+the easiest way is to extend the `EntityBlockMutatorBase` base class.
+
+Example, with multi-valued Gutenberg attribute
+
+```php
+<?php
+
+namespace Drupal\silverback_gutenberg\Plugin\GutenbergBlockMutator;
+
+use Drupal\silverback_gutenberg\Attribute\GutenbergBlockMutator;
+use Drupal\silverback_gutenberg\BlockMutator\EntityBlockMutatorBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[GutenbergBlockMutator(
+  id: "media_block_mutator",
+  label: new TranslatableMarkup("Media IDs to UUIDs and viceversa."),
+)]
+class MediaBlockMutator extends EntityBlockMutatorBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public bool $isMultiple = TRUE;
+
+  /**
+   * {@inheritDoc}
+   */
+  public string $gutenbergAttribute = 'mediaEntityIds';
+
+  /**
+   * {@inheritDoc}
+   */
+  public string $entityTypeId = 'media';
+
+}
+```
+
+
+Example, with single-valued Gutenberg attribute
+
+```php
+<?php
+
+namespace Drupal\silverback_gutenberg\Plugin\GutenbergBlockMutator;
+
+use Drupal\silverback_gutenberg\Attribute\GutenbergBlockMutator;
+use Drupal\silverback_gutenberg\BlockMutator\EntityBlockMutatorBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[GutenbergBlockMutator(
+  id: "node_block_mutator",
+  label: new TranslatableMarkup("Node ID to UUID and viceversa."),
+)]
+class NodeBlockMutator extends EntityBlockMutatorBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public string $gutenbergAttribute = 'nodeId';
+
+  /**
+   * {@inheritDoc}
+   */
+  public string $entityTypeId = 'node';
+
+}
+```

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Annotation/GutenbergBlockMutator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Annotation/GutenbergBlockMutator.php
@@ -6,6 +6,8 @@ use Drupal\Component\Annotation\Plugin;
 
 /**
  * @Annotation
+ * 
+ * @deprecated
  */
 class GutenbergBlockMutator extends Plugin {
 

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Attribute/GutenbergBlockMutator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Attribute/GutenbergBlockMutator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\silverback_gutenberg\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class GutenbergBlockMutator extends Plugin {
+
+  /**
+   * Constructs a GutenbergBlockMutator attribute.
+   *
+   * @param string $id
+   *   The plugin ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|null $label
+   *   (optional) The human-readable name of the mutator.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|null $description
+   *   (optional) A short description of the mutator.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly ?TranslatableMarkup $label = NULL,
+    public readonly ?TranslatableMarkup $description = NULL,
+  ) {}
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/BlockMutator/BlockMutatorManager.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/BlockMutator/BlockMutatorManager.php
@@ -5,6 +5,8 @@ namespace Drupal\silverback_gutenberg\BlockMutator;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\silverback_gutenberg\BlockMutator\BlockMutatorInterface;
+use Drupal\silverback_gutenberg\Attribute\GutenbergBlockMutator;
 
 /**
  * The block mutator plugin manager class.
@@ -27,8 +29,10 @@ class BlockMutatorManager extends DefaultPluginManager implements BlockMutatorMa
       'Plugin/GutenbergBlockMutator',
       $namespaces,
       $module_handler,
-      'Drupal\silverback_gutenberg\BlockMutator\BlockMutatorInterface',
-      'Drupal\silverback_gutenberg\Annotation\GutenbergBlockMutator'
+      BlockMutatorInterface::class,
+      GutenbergBlockMutator::class,
+      // Keeping BC for deprecated Annotation
+      'Drupal\silverback_gutenberg\Annotation\GutenbergBlockMutator',
     );
     $this->alterInfo('gutenberg_block_mutator_info');
     $this->setCacheBackend($cache_backend, 'gutenberg_block_mutator_info_plugins');

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/BlockMutator/EntityBlockMutatorBase.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/BlockMutator/EntityBlockMutatorBase.php
@@ -14,11 +14,26 @@ abstract class EntityBlockMutatorBase extends PluginBase implements
   BlockMutatorInterface,
   ContainerFactoryPluginInterface {
 
+  /**
+   * The Gutenberg attribute id.
+   *
+   * @var string $gutenbergAttribute
+   */
   public string $gutenbergAttribute;
 
-  public string $entityTypeId;
-
+  /**
+   * Indicates if the Gutenberg attribute is a collection or a single value.
+   *
+   * @var bool $isMultiple
+   */
   public bool $isMultiple = FALSE;
+
+  /**
+   * The Drupal entity type id.
+   *
+   * @var string $entityTypeId
+   */
+  public string $entityTypeId;
 
   /**
    * EntityBlockMutatorBase constructor.

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/BlockMutator/EntityBlockMutatorBase.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/BlockMutator/EntityBlockMutatorBase.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\BlockMutator;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+abstract class EntityBlockMutatorBase extends PluginBase implements
+  BlockMutatorInterface,
+  ContainerFactoryPluginInterface {
+
+  public string $gutenbergAttribute;
+
+  public string $entityTypeId;
+
+  public bool $isMultiple = FALSE;
+
+  /**
+   * EntityBlockMutatorBase constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $repository
+   */
+  public function __construct(
+    array $configuration,
+          $plugin_id,
+          $plugin_definition,
+    private readonly EntityRepositoryInterface $entityRepository,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity.repository'),
+      $container->get('entity_type.manager'),
+      $container->get('logger.factory'),
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function applies(array $block) : bool {
+    if (empty($this->gutenbergAttribute)) {
+      $this->loggerFactory->get('silverback_gutenberg')->warning(
+        $this->t('Block mutator attribute is not set for @class, ignoring.', [
+          '@class' => self::class,
+        ])
+      );
+      return FALSE;
+    }
+
+    if (empty($this->entityTypeId)) {
+      $this->loggerFactory->get('silverback_gutenberg')->warning(
+        $this->t('Block mutator attribute @attribute does not specifiy the entity type id for @class, ignoring.', [
+          '@attribute' => $this->gutenbergAttribute,
+          '@class' => self::class,
+        ])
+      );
+      return FALSE;
+    }
+
+    $entityTypes = $this->entityTypeManager->getDefinitions();
+    if (!array_key_exists($this->entityTypeId, $entityTypes)) {
+      throw new \Exception(
+        $this->t('Block mutator attribute @attribute does not have a valid entity type @entity_type_id for @class, ignoring.', [
+          '@attribute' => $this->gutenbergAttribute,
+          '@entity_type_id' => $this->entityTypeId,
+          '@class' => self::class,
+        ])
+      );
+    }
+
+    if (empty($block['attrs'][$this->gutenbergAttribute])) {
+      return FALSE;
+    }
+
+    if (
+      $this->isMultiple &&
+      !is_array($block['attrs'][$this->gutenbergAttribute])
+    ) {
+      throw new \Exception(
+        $this->t('Block mutator attribute @attribute is set to be multiple but is not iterable.', [
+          '@attribute' => $this->gutenbergAttribute,
+        ])
+      );
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function mutateExport(array &$block, array &$dependencies) : void {
+    if ($this->isMultiple) {
+      $block['attrs'][$this->gutenbergAttribute] = array_values(array_map(
+        function (ContentEntityInterface $entity) use (&$dependencies) {
+          $dependencies[$entity->uuid()] = $this->entityTypeId;
+          return $entity->uuid();
+        },
+        $this->entityRepository
+          ->getCanonicalMultiple($this->entityTypeId, $block['attrs'][$this->gutenbergAttribute])
+      ));
+    } else {
+      $entity = $this->entityRepository->getCanonical($this->entityTypeId, $block['attrs'][$this->gutenbergAttribute]);
+      if (!$entity instanceof ContentEntityInterface) {
+        $block['attrs'][$this->gutenbergAttribute] = '';
+        return;
+      }
+      $block['attrs'][$this->gutenbergAttribute] = $entity->uuid();
+      $dependencies[$entity->uuid()] = $this->entityTypeId;
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function mutateImport(array &$block) : void {
+    if ($this->isMultiple) {
+      $block['attrs'][$this->gutenbergAttribute] = array_map(
+        function (string $uuid) {
+          try {
+            $entity = $this->entityRepository->loadEntityByUuid($this->entityTypeId, $uuid);
+            return $entity->id();
+          }
+          catch (\Throwable $e) {
+            $this->loggerFactory->get('silverback_gutenberg')->warning(
+              $this->t(
+                '@class: Could not load @entity_type_id by uuid @uuid on import.', [
+                  '@class' => self::class,
+                  '@entity_type_id' => $this->entityTypeId,
+                  '@uuid' => $uuid,
+                ]
+              )
+            );
+            return $uuid;
+          }
+        },
+        $block['attrs'][$this->gutenbergAttribute]
+      );
+    } else {
+      try {
+        $entity = $this->entityRepository->loadEntityByUuid($this->entityTypeId, $block['attrs'][$this->gutenbergAttribute]);
+        $block['attrs'][$this->gutenbergAttribute] = $entity->id();
+      }
+      catch (\Throwable $e) {
+        $this->loggerFactory->get('silverback_gutenberg')->warning(
+          $this->t(
+            '@class: Could not load @entity_type_id by uuid @uuid on import.', [
+              '@class' => self::class,
+              '@entity_type_id' => $this->entityTypeId,
+              '@uuid' => $uuid,
+            ]
+          )
+        );
+      }
+    }
+  }
+
+}

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/MediaBlockMutator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/MediaBlockMutator.php
@@ -6,20 +6,16 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\silverback_gutenberg\BlockMutator\BlockMutatorBase;
+use Drupal\silverback_gutenberg\Attribute\GutenbergBlockMutator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * Class MediaBlockMutator
- *
- * Replace referenced media ids with uuids on export and the other way around on
- * import.
- *
- * @GutenbergBlockMutator(
- *   id="media_block_mutator",
- *   label = @Translation("Media ID to UUID and viceversa mutator")
- * )
- */
+#[GutenbergBlockMutator(
+  id: "media_block_mutator",
+  label: new TranslatableMarkup("Media ID to UUID and viceversa mutator"),
+)]
 class MediaBlockMutator extends BlockMutatorBase implements ContainerFactoryPluginInterface {
+
   /**
    * An entity repository to load entities from.
    *

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/MediaBlockMutator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/MediaBlockMutator.php
@@ -4,6 +4,7 @@ namespace Drupal\silverback_gutenberg\Plugin\GutenbergBlockMutator;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\silverback_gutenberg\BlockMutator\BlockMutatorBase;
 use Drupal\silverback_gutenberg\Attribute\GutenbergBlockMutator;
@@ -17,31 +18,30 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class MediaBlockMutator extends BlockMutatorBase implements ContainerFactoryPluginInterface {
 
   /**
-   * An entity repository to load entities from.
-   *
-   * @var \Drupal\Core\Entity\EntityRepositoryInterface
-   */
-  protected EntityRepositoryInterface $repository;
-
-  /**
    * MediaIdToUuidBlockMutator constructor.
    *
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $repository
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityRepositoryInterface $repository) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly EntityRepositoryInterface $entityRepository,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->repository = $repository;
   }
 
   /**
    * {@inheritDoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
       $configuration,
       $plugin_id,
       $plugin_definition,
       $container->get('entity.repository'),
+      $container->get('logger.factory'),
     );
   }
 
@@ -61,7 +61,7 @@ class MediaBlockMutator extends BlockMutatorBase implements ContainerFactoryPlug
         $dependencies[$entity->uuid()] = 'media';
         return $entity->uuid();
       },
-      $this->repository
+      $this->entityRepository
         ->getCanonicalMultiple('media', $block['attrs']['mediaEntityIds'])
     ));
   }
@@ -73,11 +73,11 @@ class MediaBlockMutator extends BlockMutatorBase implements ContainerFactoryPlug
     $block['attrs']['mediaEntityIds'] = array_map(
       function (string $uuid) {
         try {
-          $entity = $this->repository->loadEntityByUuid('media', $uuid);
+          $entity = $this->entityRepository->loadEntityByUuid('media', $uuid);
           return $entity->id();
         }
         catch (\Throwable $e) {
-          \Drupal::logger('silverback_gutenberg')->warning(
+          $this->loggerFactory->get('silverback_gutenberg')->warning(
             "MediaBlockMutator: Could not load media by uuid '{$uuid}' on import."
           );
           return $uuid;

--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/NodeBlockMutator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/NodeBlockMutator.php
@@ -7,24 +7,19 @@ use Drupal\silverback_gutenberg\BlockMutator\EntityBlockMutatorBase;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 #[GutenbergBlockMutator(
-  id: "media_block_mutator",
-  label: new TranslatableMarkup("Media IDs to UUIDs and viceversa."),
+  id: "node_block_mutator",
+  label: new TranslatableMarkup("Node ID to UUID and viceversa."),
 )]
-class MediaBlockMutator extends EntityBlockMutatorBase {
+class NodeBlockMutator extends EntityBlockMutatorBase {
 
   /**
    * {@inheritDoc}
    */
-  public bool $isMultiple = TRUE;
+  public string $gutenbergAttribute = 'nodeId';
 
   /**
    * {@inheritDoc}
    */
-  public string $gutenbergAttribute = 'mediaEntityIds';
-
-  /**
-   * {@inheritDoc}
-   */
-  public string $entityTypeId = 'media';
+  public string $entityTypeId = 'node';
 
 }


### PR DESCRIPTION
## Package(s) involved

`silverback_gutenberg`

## Description of changes

- Introduce a new `EntityBlockMutatorBase`
- Update existing `mediaEntityIds` mutator
- Add single `nodeId` mutator
- Convert annotations to attributes, with BC
- Documentation


## Motivation and context

- Make it easier to create new plugins
- Use latest PHP / Drupal standards

## How has this been tested?

Manually by converting new plugins on a project.