### PR TITLE
fix: forward refs into link components

### DIFF
--- a/packages/npm/@amazeelabs/bridge-gatsby/src/index.tsx
+++ b/packages/npm/@amazeelabs/bridge-gatsby/src/index.tsx
@@ -5,12 +5,15 @@ import type {
 } from '@amazeelabs/bridge';
 import { useLocation as gatsbyUseLocation } from '@reach/router';
 import { Link as GatsbyLink, navigate as gatsbyNavigate } from 'gatsby';
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, forwardRef } from 'react';
 
-export const Link: LinkType &
-  Pick<ComponentProps<typeof GatsbyLink>, 'ref'> = ({ href, ...props }) => {
-  return <GatsbyLink to={href || '/'} {...props} />;
-};
+export const Link: LinkType = forwardRef<
+  HTMLAnchorElement,
+  ComponentProps<LinkType>
+>(function Link({ href, ...props }, ref) {
+  // @ts-expect-error: gatsby ref typing issues
+  return <GatsbyLink to={href || '/'} {...props} ref={ref} />;
+});
 
 export const useLocation: useLocationType = () => {
   const location = gatsbyUseLocation();

--- a/packages/npm/@amazeelabs/bridge-storybook/src/index.tsx
+++ b/packages/npm/@amazeelabs/bridge-storybook/src/index.tsx
@@ -5,7 +5,13 @@ import type {
   useLocationType,
 } from '@amazeelabs/bridge';
 import { action } from '@storybook/addon-actions';
-import React, { createContext, useContext, useState } from 'react';
+import React, {
+  ComponentProps,
+  createContext,
+  forwardRef,
+  useContext,
+  useState,
+} from 'react';
 
 type SetLocation = (location: LocationType) => void;
 
@@ -49,11 +55,15 @@ export const useLocation: useLocationType = () => {
   ];
 };
 
-export const Link: LinkType = ({ onClick, ...props }) => {
+export const Link: LinkType = forwardRef<
+  HTMLAnchorElement,
+  ComponentProps<LinkType>
+>(function Link({ onClick, ...props }, ref) {
   const [, navigate] = useLocation();
   return (
     <a
       {...props}
+      ref={ref}
       onClick={
         onClick
           ? onClick
@@ -68,4 +78,4 @@ export const Link: LinkType = ({ onClick, ...props }) => {
       {props.children}
     </a>
   );
-};
+});

--- a/packages/npm/@amazeelabs/scalars/src/index.tsx
+++ b/packages/npm/@amazeelabs/scalars/src/index.tsx
@@ -11,6 +11,7 @@ import React, {
   ComponentType,
   createElement,
   DetailedHTMLProps,
+  forwardRef,
 } from 'react';
 import rehypeParse from 'rehype-parse';
 import rehypeReact from 'rehype-react';
@@ -105,12 +106,16 @@ export const isDownload = (url?: Url | LocationType) => {
 const isLocation = (input?: Url | LocationType): input is LocationType =>
   typeof input !== 'string';
 
-export function Link({ href, search, hash, target, ...props }: LinkProps) {
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  { href, search, hash, target, ...props }: LinkProps,
+  ref,
+) {
   if (isInternalTarget(target) && isRelative(href) && !isDownload(href)) {
     return (
       <LinkComponent
         href={overrideUrlParameters(href, search, hash)}
         target={target}
+        ref={ref}
         {...props}
       />
     );
@@ -120,13 +125,14 @@ export function Link({ href, search, hash, target, ...props }: LinkProps) {
         target={target || '_blank'}
         rel={props.rel || (isRelative(href) ? undefined : 'noreferrer')}
         href={overrideUrlParameters(href, search, hash)}
+        ref={ref}
         {...props}
       >
         {props.children}
       </a>
     );
   }
-}
+});
 
 export function useLocation(): [
   LocationType,


### PR DESCRIPTION
## Package(s) involved

@amazeelabs/bridge
@amazeelabs/bridge-\*

## Description of changes

Forward refs into Link components.

## Motivation and context

Make them compatible with UI libraries like radix.
