### PR TITLE
chore: add currentUser directive to graphql_directives

### DIFF
--- a/apps/silverback-drupal/generated/extra.composed.graphqls
+++ b/apps/silverback-drupal/generated/extra.composed.graphqls
@@ -6,6 +6,12 @@ directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | 
 
 """
 Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\CurrentUser".
+"""
+directive @currentUser repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
 """
 directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
@@ -291,6 +297,14 @@ Provided by the "silverback_gatsby" module.
 Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\ImageProps".
 """
 directive @imageProps repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieves the preferred langcode for a user entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\PreferredLanguage".
+"""
+directive @preferredLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Seek a specific element in a list.

--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -6,6 +6,12 @@ directive @arg(name: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | 
 
 """
 Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\CurrentUser".
+"""
+directive @currentUser repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\EntityReference".
 """
 directive @resolveEntityReference(field: String!) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
@@ -291,6 +297,14 @@ Provided by the "silverback_gatsby" module.
 Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\ImageProps".
 """
 directive @imageProps repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieves the preferred langcode for a user entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\PreferredLanguage".
+"""
+directive @preferredLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Seek a specific element in a list.
@@ -649,6 +663,20 @@ Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\DrupalView".
 """
 directive @drupalView(id: String!, args: String) repeatable on FIELD_DEFINITION
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\CurrentUser".
+"""
+directive @currentUser repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieves the preferred langcode for a user entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\PreferredLanguage".
+"""
+directive @preferredLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Directive for the responsive_image data producer.

--- a/packages/composer/amazeelabs/graphql_directives/directives.graphql
+++ b/packages/composer/amazeelabs/graphql_directives/directives.graphql
@@ -235,3 +235,17 @@ Provided by the "graphql_directives" module.
 Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\DrupalView".
 """
 directive @drupalView(id: String!, args: String) repeatable on FIELD_DEFINITION
+
+"""
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\CurrentUser".
+"""
+directive @currentUser repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+
+"""
+Retrieves the preferred langcode for a user entity.
+
+Provided by the "graphql_directives" module.
+Implemented in "Drupal\graphql_directives\Plugin\GraphQL\Directive\PreferredLanguage".
+"""
+directive @preferredLanguage repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/CurrentUserEntity.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/CurrentUserEntity.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\DataProducer;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\graphql\GraphQL\Execution\FieldContext;
+use Drupal\graphql\Plugin\GraphQL\DataProducer\User\CurrentUser;
+use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
+
+/**
+ * @DataProducer(
+ *   id = "current_user_entity",
+ *   name = @Translation("Current User Entity"),
+ *   description = @Translation("Returns the current authenticated user. Extends the core current_user, to return the User entity instead of the AccountProxy."),
+ *   produces = @ContextDefinition("entity:user",
+ *     label = @Translation("User")
+ *   )
+ * )
+ */
+class CurrentUserEntity extends CurrentUser {
+
+  /**
+   * Returns the current user.
+   *
+   * @param \Drupal\graphql\GraphQL\Execution\FieldContext $field_context
+   *   Field context.
+   *
+   * @return \Drupal\user\UserInterface
+   *   The current user.
+   */
+  public function resolve(FieldContext $field_context): UserInterface {
+    // Response must be cached based on current user as a cache context,
+    // otherwise a new user would become a previous user.
+    $field_context->addCacheableDependency($this->currentUser);
+    $user = NULL;
+    if ($this->currentUser instanceof AccountProxyInterface) {
+      $user = User::load($this->currentUser->id());
+    }
+    return $user;
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/PreferredLanguage.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/DataProducer/PreferredLanguage.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\DataProducer;
+
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\user\UserInterface;
+
+/**
+ * Returns the preferred language of a user.
+ *
+ * @DataProducer(
+ *   id = "preferred_language",
+ *   name = @Translation("User preferred language"),
+ *   description = @Translation("Returns the preferred language of a user."),
+ *   produces = @ContextDefinition("string",
+ *     label = @Translation("Preferred language")
+ *   ),
+ *   consumes = {
+ *     "user" = @ContextDefinition("any",
+ *       label = @Translation("User")
+ *     )
+ *   }
+ * )
+ */
+class PreferredLanguage extends DataProducerPluginBase {
+
+  /**
+   * Resolves the preferred language for a user.
+   *
+   * @param mixed $user
+   *   The user entity.
+   *
+   * @return string|null
+   *   The preferred language code or null if not set.
+   */
+  public function resolve($user) {
+    if ($user instanceof UserInterface && $user->hasField('preferred_langcode') && !$user->get('preferred_langcode')->isEmpty()) {
+      return $user->get('preferred_langcode')->value;
+    }
+    return 'en';
+  }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/CurrentUser.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/CurrentUser.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\Directive;
+
+
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+
+/**
+ * @Directive(
+ *   id = "currentUser",
+ *   arguments = {}
+ * )
+ */
+class CurrentUser extends PluginBase implements DirectiveInterface {
+    public function buildResolver(ResolverBuilder $builder, array $arguments): ResolverInterface {
+        return $builder->produce('current_user_entity');
+    }
+}

--- a/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/PreferredLanguage.php
+++ b/packages/composer/amazeelabs/graphql_directives/src/Plugin/GraphQL/Directive/PreferredLanguage.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\graphql_directives\Plugin\GraphQL\Directive;
+
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+
+/**
+ * @Directive(
+ *   id = "preferredLanguage",
+ *   description = "Retrieves the preferred langcode for a user entity."
+ * )
+ */
+class PreferredLanguage extends PluginBase implements DirectiveInterface {
+
+    public function buildResolver(ResolverBuilder $builder, array $arguments): ResolverInterface {
+        return $builder->produce('preferred_language')
+            ->map('user', $builder->fromParent());
+    }
+
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/users/.graphqlconfig
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/users/.graphqlconfig
@@ -1,0 +1,5 @@
+{
+  "name": "Directives Test - Users",
+  "schemaPath": "./schema.graphqls",
+  "includes": ["./directives.graphqls"]
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/assets/users/schema.graphqls
+++ b/packages/composer/amazeelabs/graphql_directives/tests/assets/users/schema.graphqls
@@ -1,0 +1,8 @@
+type Query {
+  currentUser: User @currentUser
+}
+
+type User {
+  id: ID! @resolveEntityId
+  preferredLanguage: String @preferredLanguage
+}

--- a/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/UserDirectivesTest.php
+++ b/packages/composer/amazeelabs/graphql_directives/tests/src/Kernel/UserDirectivesTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Drupal\Tests\graphql_directives\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Tests\graphql\Kernel\GraphQLTestBase;
+use Drupal\Tests\graphql_directives\Traits\GraphQLDirectivesTestTrait;
+use Drupal\user\Entity\User;
+
+/**
+ * Tests the currentUser and preferredLanguage directives.
+ *
+ * @group graphql_directives
+ */
+class UserDirectivesTest extends GraphQLTestBase {
+  use GraphQLDirectivesTestTrait;
+
+  public static $modules = [
+    'user',
+    'language',
+    'graphql_directives',
+    'silverback_gatsby',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installConfig(['user', 'language']);
+    $this->setupDirectableSchema(__DIR__ . '/../../assets/users');
+  }
+
+  /**
+   * Tests the currentUser directive with anonymous user.
+   */
+  public function testCurrentUserDirectiveAnonymous() {
+    // Set anonymous user as current user
+    $anonymous = User::load(0);
+    $this->setCurrentUser($anonymous);
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($anonymous);
+    $metadata->setCacheMaxAge(0);
+    $this->assertResults('query { currentUser { id  } }', [], [
+      'currentUser' => [
+        'id' => '0',
+      ]
+    ], $metadata);
+  }
+
+  /**
+   * Tests the currentUser directive with authenticated user.
+   */
+  public function testCurrentUserDirectiveAuthenticated() {
+    // Create and set an authenticated user
+    $user = User::create([
+      'name' => 'test_user',
+      'mail' => 'test@example.com',
+      'status' => 1,
+    ]);
+    $user->save();
+    $this->setCurrentUser($user);
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($user);
+    $metadata->setCacheMaxAge(0);
+    $this->assertResults('query { currentUser { id } }', [], [
+      'currentUser' => [
+        'id' => $user->id(),
+      ]
+    ], $metadata);
+  }
+
+  /**
+   * Tests the preferredLanguage directive with default language.
+   */
+  public function testPreferredLanguageDirectiveDefault() {
+    // Create a user with default language preference
+    $user = User::create([
+      'name' => 'language_user',
+      'mail' => 'language@example.com',
+      'status' => 1,
+      'preferred_langcode' => 'en',
+    ]);
+    $user->save();
+    $this->setCurrentUser($user);
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($user);
+    $metadata->setCacheMaxAge(0);
+    $this->assertResults('query { currentUser { id preferredLanguage } }', [], [
+      'currentUser' => [
+        'id' => $user->id(),
+        'preferredLanguage' => 'en',
+      ]
+    ], $metadata);
+  }
+
+  /**
+   * Tests the preferredLanguage directive with custom language.
+   */
+  public function testPreferredLanguageDirectiveCustom() {
+    // Create a user with French language preference
+    $user = User::create([
+      'name' => 'french_user',
+      'mail' => 'french@example.com',
+      'status' => 1,
+      'preferred_langcode' => 'fr',
+    ]);
+    $user->save();
+    $this->setCurrentUser($user);
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($user);
+    $metadata->setCacheMaxAge(0);
+    $this->assertResults('query { currentUser { id preferredLanguage } }', [], [
+      'currentUser' => [
+        'id' => $user->id(),
+        'preferredLanguage' => 'fr',
+      ]
+    ], $metadata);
+  }
+
+  /**
+   * Tests both directives together in a more complex query.
+   */
+  public function testCombinedDirectives() {
+    // Create a user with German language preference
+    $user = User::create([
+      'name' => 'german_user',
+      'mail' => 'german@example.com',
+      'status' => 1,
+      'preferred_langcode' => 'de',
+    ]);
+    $user->save();
+    $this->setCurrentUser($user);
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($user);
+    $metadata->setCacheMaxAge(0);
+    $this->assertResults('
+      query { 
+        currentUser { 
+          id 
+          preferredLanguage 
+        } 
+      }', [], [
+      'currentUser' => [
+        'id' => $user->id(),
+        'preferredLanguage' => 'de',
+      ]
+    ], $metadata);
+  }
+
+  /**
+   * Tests the preferredLanguage directive with a user that has no preference set.
+   */
+  public function testPreferredLanguageDirectiveNoPreference() {
+    // Create a user without explicit language preference
+    $user = User::create([
+      'name' => 'no_pref_user',
+      'mail' => 'nopref@example.com',
+      'status' => 1,
+      // No preferred_langcode set
+    ]);
+    $user->save();
+    $this->setCurrentUser($user);
+
+    $metadata = $this->defaultCacheMetaData();
+    $metadata->addCacheableDependency($user);
+    $metadata->setCacheMaxAge(0);
+    // Should return null or site default
+    $this->assertResults('query { currentUser { id preferredLanguage } }', [], [
+      'currentUser' => [
+        'id' => $user->id(),
+        'preferredLanguage' => 'en'
+      ]
+    ], $metadata);
+  }
+} 


### PR DESCRIPTION
## Package(s) involved

`graphql_directives`

## Description of changes

Add `@currentUser` and associated `@preferredLanguage` directives.

## Motivation and context

Initially intended for our SEO analysis tool introduced with [SLB-496](https://amazeelabs.atlassian.net/browse/SLB-496), to enable interface translation in the correct language on the frontend, but can be used for other contexts.


## How has this been tested?

Added Drupal kernel tests


[SLB-496]: https://amazeelabs.atlassian.net/browse/SLB-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ