### PR TITLE
chore: default preview user for preview links

### DIFF
--- a/packages/composer/amazeelabs/silverback_preview_link/config/schema/silverback_preview_link.schema.yml
+++ b/packages/composer/amazeelabs/silverback_preview_link/config/schema/silverback_preview_link.schema.yml
@@ -12,3 +12,5 @@ silverback_preview_link.settings:
     multiple_entities:
       label: Whether Preview Links can reference multiple entities.
       type: boolean
+    default_preview_user:
+      type: integer

--- a/packages/composer/amazeelabs/silverback_preview_link/src/Entity/SilverbackPreviewLink.php
+++ b/packages/composer/amazeelabs/silverback_preview_link/src/Entity/SilverbackPreviewLink.php
@@ -7,10 +7,12 @@ namespace Drupal\silverback_preview_link\Entity;
 use Drupal\Component\Assertion\Inspector;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Url;
+use Drupal\user\Entity\User;
 
 /**
  * Defines the Silverback preview link entity class.
@@ -40,6 +42,19 @@ class SilverbackPreviewLink extends ContentEntityBase implements SilverbackPrevi
    * @var bool
    */
   protected $needsNewToken = FALSE;
+  /**
+   * {@inheritDoc}
+   */
+  public function postCreate(EntityStorageInterface $storage) {
+    parent::postCreate($storage);
+    // If there is a default preview user set, then we add that user to the list
+    // of entities attached to the link.
+    $config = \Drupal::config('silverback_preview_link.settings');
+    $default_preview_user = $config->get('default_preview_user');
+    if ($default_preview_user) {
+      $this->addEntity(User::load($default_preview_user));
+    }
+  }
 
   /**
    * {@inheritdoc}

--- a/packages/composer/amazeelabs/silverback_preview_link/src/Form/SettingsForm.php
+++ b/packages/composer/amazeelabs/silverback_preview_link/src/Form/SettingsForm.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\silverback_preview_link\PreviewLinkUtility;
+use Drupal\user\Entity\User;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -106,6 +107,15 @@ class SettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('expiry_seconds') ?: 604800,
       '#min' => 1,
     ];
+    $preview_user_id = $config->get('default_preview_user');
+    $form['default_preview_user'] = [
+      '#type' => 'entity_autocomplete',
+      '#target_type' => 'user',
+      '#default_value' => $preview_user_id ? User::load($preview_user_id) : NULL,
+      '#selection_settings' => ['include_anonymous' => FALSE],
+      '#title' => $this->t('Default preview user'),
+      '#description' => $this->t('Attach a default user to all the preview links. By choosing an user, when the preview link will be accessed, the request will be authenticated using that user.'),
+    ];
 
     return $form;
   }
@@ -118,6 +128,7 @@ class SettingsForm extends ConfigFormBase {
 
     $config->set('multiple_entities', $form_state->getValue('multiple_entities'));
     $config->set('expiry_seconds', $form_state->getValue('expiry_seconds'));
+    $config->set('default_preview_user', $form_state->getValue('default_preview_user'));
 
     $config->clear('enabled_entity_types');
     foreach (array_keys(array_filter($form_state->getValue('enabled_entity_types'))) as $enabledBundle) {


### PR DESCRIPTION
## Package(s) involved
amazeelabs/silverback_preview_link

## Description of changes
Adds a default preview user setting which will attach a user, if defined, to the preview links.