### PR TITLE
Do not store the preview access token in cookies anymore

### DIFF
--- a/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.services.yml
+++ b/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.services.yml
@@ -29,4 +29,3 @@ services:
           priority: 0,
           global: TRUE,
         }
-      - { name: 'event_subscriber' }


### PR DESCRIPTION
## Package(s) involved
silverback_preview_link

## Description of changes
The preview token authentication provider does not use cookies to store and read the preview token. It only uses the query parameters.

## Motivation and context
There are a few issues with storing the token in cookies:
 - we might have CORS issues when there are different domains for the FE app and for the CMS
 - this might conflict with the session authentication, which also uses the session cookie. For example: if a preview link is used once in the same browser as the CMS, then the preview token cookie gets stored and, if the token authentication provider runs before the session one, then the user will be logged in with the token instead of the session cookie. Also, there is no easy possibility to logout at the moment, the user would have to just manually remove the cookie.

The changes in this PR move the responsability into the FE (preview) app to forward the preview token with every request.

## How has this been tested?

<!-- Locally, manually-->
