### PR TITLE
fetch entity load_latest_revision flag

### DIFF
--- a/apps/silverback-drupal/generated/extra.composed.graphqls
+++ b/apps/silverback-drupal/generated/extra.composed.graphqls
@@ -133,7 +133,7 @@ Fetch an entity or entity revision based on id, rid or route
 Provided by the "silverback_gatsby" module.
 Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\EntityFetch".
 """
-directive @fetchEntity(type: String, id: String, rid: String, language: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+directive @fetchEntity(type: String, id: String, rid: String, language: String, operation: String, loadLatestRevision: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Load a given entity by it's path or type and id or uuid

--- a/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
+++ b/apps/silverback-drupal/generated/silverback_gatsby.composed.graphqls
@@ -133,7 +133,7 @@ Fetch an entity or entity revision based on id, rid or route
 Provided by the "silverback_gatsby" module.
 Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\EntityFetch".
 """
-directive @fetchEntity(type: String, id: String, rid: String, language: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+directive @fetchEntity(type: String, id: String, rid: String, language: String, operation: String, loadLatestRevision: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Load a given entity by it's path or type and id or uuid
@@ -720,7 +720,7 @@ Fetch an entity or entity revision based on id, rid or route
 Provided by the "silverback_gatsby" module.
 Implemented in "Drupal\silverback_gatsby\Plugin\GraphQL\Directive\EntityFetch".
 """
-directive @fetchEntity(type: String, id: String, rid: String, language: String, operation: String) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
+directive @fetchEntity(type: String, id: String, rid: String, language: String, operation: String, loadLatestRevision: Boolean) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """
 Retrieve the properties of an image.

--- a/packages/composer/amazeelabs/silverback_gatsby/directives.graphql
+++ b/packages/composer/amazeelabs/silverback_gatsby/directives.graphql
@@ -43,6 +43,7 @@ directive @fetchEntity(
   rid: String
   language: String
   operation: String
+  loadLatestRevision: Boolean
 ) repeatable on FIELD_DEFINITION | SCALAR | UNION | ENUM | INTERFACE | OBJECT
 
 """

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
@@ -67,6 +67,11 @@ use Symfony\Component\HttpFoundation\RequestStack;
  *       required = FALSE,
  *       default_value = "view"
  *     ),
+ *     "load_latest_revision" = @ContextDefinition("boolean",
+ *       label = @Translation("Load latest revision"),
+ *       required = FALSE,
+ *       default_value = FALSE
+ *     ),
  *   }
  * )
  */
@@ -186,6 +191,7 @@ class FetchEntity extends DataProducerPluginBase implements ContainerFactoryPlug
    * @param bool|null $access
    * @param \Drupal\Core\Session\AccountInterface|null $accessUser
    * @param string|null $accessOperation
+   * @param bool|null $loadLatestRevision
    * @param \Drupal\graphql\GraphQL\Execution\FieldContext $context
    *
    * @return \GraphQL\Deferred
@@ -199,6 +205,7 @@ class FetchEntity extends DataProducerPluginBase implements ContainerFactoryPlug
     ?bool $access,
     ?AccountInterface $accessUser,
     ?string $accessOperation,
+    ?bool $loadLatestRevision,
     FieldContext $context
   ) {
     if ($id[0] === '/') {
@@ -244,7 +251,7 @@ class FetchEntity extends DataProducerPluginBase implements ContainerFactoryPlug
       ? $this->entityRevisionBuffer->add($type, $revisionId)
       : $this->entityBuffer->add($type, $id);
 
-    return new Deferred(function () use ($type, $id, $revisionId, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation) {
+    return new Deferred(function () use ($type, $id, $revisionId, $language, $bundles, $resolver, $context, $access, $accessUser, $accessOperation, $loadLatestRevision) {
       /** @var $entity \Drupal\Core\Entity\EntityInterface */
       if (!$entity = $resolver()) {
         // If there is no entity with this id, add the list cache tags so that
@@ -274,7 +281,7 @@ class FetchEntity extends DataProducerPluginBase implements ContainerFactoryPlug
 
       // If we did not request a specific revision, then we just load the most
       // up to date one (the latest/active revision).
-      if (empty($revisionId)) {
+      if (empty($revisionId) && $loadLatestRevision) {
         $activeEntityContext = [];
         $additionalCacheContexts = [];
         if (isset($language)) {

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
@@ -280,7 +280,8 @@ class FetchEntity extends DataProducerPluginBase implements ContainerFactoryPlug
 
 
       // If we did not request a specific revision, then we just load the most
-      // up to date one (the latest/active revision).
+      // up to date one (the latest/active revision), but only if the flag is
+      // set.
       if (empty($revisionId) && $loadLatestRevision) {
         $activeEntityContext = [];
         $additionalCacheContexts = [];

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/EntityFetch.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/Directive/EntityFetch.php
@@ -17,7 +17,8 @@ use Drupal\graphql_directives\Plugin\GraphQL\Directive\ArgumentTrait;
  *     "id" = "String",
  *     "rid" = "String",
  *     "language" = "String",
- *     "operation" = "String"
+ *     "operation" = "String",
+ *     "loadLatestRevision" = "Boolean"
  *   }
  * )
  */
@@ -37,6 +38,7 @@ class EntityFetch extends PluginBase implements DirectiveInterface {
       'revision_id' => 'rid',
       'language' => 'language',
       'access_operation' => 'operation',
+      'load_latest_revision' => 'loadLatestRevision',
     ];
     foreach($argsMap as $argParameter => $argField) {
       if (isset($arguments[$argField])) {

--- a/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/tests/src/Kernel/EntityFeedTest.php
@@ -91,7 +91,7 @@ class EntityFeedTest extends EntityFeedTestBase {
 
     $query = $this->getQueryFromFile('translatable.gql');
     $metadata = $this->defaultCacheMetaData();
-    $metadata->addCacheContexts(['user.node_grants:view', 'static:language:zxx']);
+    $metadata->addCacheContexts(['user.node_grants:view']);
     $metadata->addCacheTags(['node:1', 'node_list']);
     $this->assertResults($query, ['id' => '1:zxx'], [
       '_loadPage' => [
@@ -123,7 +123,7 @@ class EntityFeedTest extends EntityFeedTestBase {
 
     $query = $this->getQueryFromFile('translatable.gql');
     $metadata = $this->defaultCacheMetaData();
-    $metadata->addCacheContexts(['user.node_grants:view', 'static:language:und']);
+    $metadata->addCacheContexts(['user.node_grants:view']);
     $metadata->addCacheTags(['node:1', 'node_list']);
     $this->assertResults($query, ['id' => '1:und'], [
       '_loadPage' => [
@@ -431,7 +431,6 @@ class EntityFeedTest extends EntityFeedTestBase {
     $node->save();
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheTags(['node:1']);
-    $metadata->addCacheContexts(['static:language:en']);
     $query = $this->getQueryFromFile('load-entity.gql');
     $this->assertResults($query, ['input' => '1:en'], [
       '_loadPage' => [
@@ -448,7 +447,6 @@ class EntityFeedTest extends EntityFeedTestBase {
     $node->save();
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheTags(['node:1']);
-    $metadata->addCacheContexts(['static:language:en']);
     $query = $this->getQueryFromFile('load-entity.gql');
     $this->assertResults($query, ['input' => $node->uuid() . ':en'], [
       '_loadPage' => [
@@ -465,7 +463,6 @@ class EntityFeedTest extends EntityFeedTestBase {
     $node->save();
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheTags(['node:1']);
-    $metadata->addCacheContexts(['static:language:en']);
     $query = $this->getQueryFromFile('load-entity.gql');
     $this->assertResults($query, ['input' => '/node/1:en'], [
       '_loadPage' => [
@@ -483,7 +480,6 @@ class EntityFeedTest extends EntityFeedTestBase {
     $this->createPathAlias('/node/1', '/test');
     $metadata = $this->defaultCacheMetaData();
     $metadata->addCacheTags(['node:1']);
-    $metadata->addCacheContexts(['static:language:en']);
     $query = $this->getQueryFromFile('load-entity.gql');
     $this->assertResults($query, ['input' => '/test:en'], [
       '_loadPage' => [


### PR DESCRIPTION
## Package(s) involved
@amazeelabs/silverback_gatsby

## Description of changes
In the latest changes that we introduced on the fetch_entity data producer, we assumed that, if there is revision requested then we should load the latest revision. This is not correct, since this data producer is also used to retrieve the actual public data for the frontend. This means that, if a node is not published, then by loading the latest revision we will try to load a draft, and that will fail, so the FE will just return a 404 even though there is actually an older, published, revision.

To fix this, there is a new flag introduced for the data producer: load_latest_revision and this one can be set to true if we want to actually load the latest revision of a node (for example on content preview).