### PR TITLE
Cacheable metadata object on link processor service

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GraphQL/DataProducer/EditorBlocks.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GraphQL/DataProducer/EditorBlocks.php
@@ -96,6 +96,7 @@ class EditorBlocks extends DataProducerPluginBase {
     }
 
     $linkProcessor = \Drupal::service(LinkProcessor::class);
+    $linkProcessor->resetCacheableMetadata();
 
     $context = new RenderContext();
     $result = \Drupal::service('renderer')->executeInRenderContext(
@@ -109,6 +110,8 @@ class EditorBlocks extends DataProducerPluginBase {
     if (!$context->isEmpty()) {
       $field->addCacheableDependency($context->pop());
     }
+    $field->addCacheableDependency($linkProcessor->getCacheableMetadata());
+    $linkProcessor->resetCacheableMetadata();
 
     $ignored = array_merge(['core/group'], $ignored ?? []);
 


### PR DESCRIPTION
## Package(s) involved
@amazeelabs/silverback_gutenberg

## Description of changes
The LinkProcessor service has now support for storing cacheable metadata objects.

## Motivation and context
During link processing, it might be the case that there are inline links to files or other nodes (and not only in paragraphs, but maybe in other custom blocks) and if those referenced entities are updated (for example a file gets replaced inside a media item) then the cache tags which result by processing those blocks (for example during resolving a graphql request) should contain the cache tags of that media as well. To fix that, a cacheable metadata object has been added to the LinkProcessor service. That object can be accessed either from the class itself, or from alter hooks (the processor object gets sent as a context parameter) so any code can alter that metadata and add its dependencies. The EditorBlocks data producer makes use of that cacheable metadata object and attaches it to the field context.