### PR TITLE
feat: added the ability to convert tid to uuid and vice versa

### DIFF
--- a/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/TermReferenceBlockMutator.php
+++ b/packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/TermReferenceBlockMutator.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\silverback_gutenberg\Plugin\GutenbergBlockMutator;
+
+use Drupal\silverback_gutenberg\Attribute\GutenbergBlockMutator;
+use Drupal\silverback_gutenberg\BlockMutator\EntityBlockMutatorBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[GutenbergBlockMutator(
+  id: "term_reference_block_mutator",
+  label: new TranslatableMarkup("Term References to UUIDs and vice versa."),
+)]
+class TermReferenceBlockMutator extends EntityBlockMutatorBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public string $entityTypeId = 'taxonomy_term';
+
+  /**
+   * {@inheritDoc}
+   */
+  public function applies(array $block): bool {
+    // Skip the parent applies() check since we want to be more flexible
+    if (empty($block['attrs'])) {
+      return FALSE;
+    }
+
+    // Check if any attribute is registered as a term reference
+    foreach ($block['attrs'] as $attrName => $value) {
+      // Skip empty values
+      if (empty($value)) {
+        continue;
+      }
+
+      // Check if attribute is marked as a term reference
+      if ($this->isTermReferenceAttribute($attrName, $block, $value)) {
+        // Store the current attribute being processed
+        $this->gutenbergAttribute = $attrName;
+
+        // Auto-detect if multiple values
+        $this->isMultiple = is_array($value);
+
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Determine if an attribute is a term reference.
+   *
+   * @param string $attrName
+   *   The attribute name to check.
+   * @param array $block
+   *   The block data.
+   * @param mixed $value
+   *   The attribute value.
+   *
+   * @return bool
+   *   TRUE if the attribute is a term reference.
+   */
+  protected function isTermReferenceAttribute(string $attrName, array $block, $value): bool {
+    if (preg_match('/(Term|Terms|TermId)$/i', $attrName)) {
+      // For single values
+      if (!is_array($value)) {
+        return $this->isValidTermIdentifier($value);
+      }
+      // For multiple values, check if all values are valid identifiers
+      elseif (is_array($value) && !empty($value)) {
+        return array_reduce($value, function ($carry, $item) {
+          return $carry && $this->isValidTermIdentifier($item);
+        }, TRUE);
+      }
+    }
+
+    // Add other checks here if needed
+    return FALSE;
+  }
+
+  /**
+   * Check if a value is a valid term identifier (numeric ID or UUID).
+   *
+   * @param mixed $value
+   *   The value to check.
+   *
+   * @return bool
+   *   TRUE if the value is a valid term identifier.
+   */
+  protected function isValidTermIdentifier($value): bool {
+    // Check if it's a numeric term ID
+    if (is_numeric($value)) {
+      return TRUE;
+    }
+
+    // Check if it's a UUID format
+    if (is_string($value) && preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $value)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `TermReferenceBlockMutator` class in the `silverback_gutenberg` module. The class is designed to handle the conversion of term reference attributes in Gutenberg blocks to UUIDs and vice versa. Below are the key changes and features:

### New functionality for term reference handling:

* **Addition of `TermReferenceBlockMutator` class**: Implements logic to identify and process attributes in Gutenberg blocks that reference taxonomy terms, converting them to UUIDs or validating them as term identifiers. This class extends `EntityBlockMutatorBase` and is annotated with the `GutenbergBlockMutator` attribute. (`[packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/TermReferenceBlockMutator.phpR1-R104](diffhunk://#diff-ed81d7b2fa5e8521059f30f9a4c3151adf19febf7d424cac85a358c49757c1f7R1-R104)`)

* **Custom `applies` method**: Overrides the base `applies` method to determine if a block contains attributes marked as term references. It skips empty attributes and uses a custom helper method to validate term reference attributes. (`[packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/TermReferenceBlockMutator.phpR1-R104](diffhunk://#diff-ed81d7b2fa5e8521059f30f9a4c3151adf19febf7d424cac85a358c49757c1f7R1-R104)`)

* **Helper methods for attribute validation**:
  - `isTermReferenceAttribute`: Checks if an attribute is a term reference based on naming conventions and validates its value(s).
  - [`isValidTermIdentifier`](diffhunk://#diff-ed81d7b2fa5e8521059f30f9a4c3151adf19febf7d424cac85a358c49757c1f7R1-R104): Validates whether a term identifier is a numeric ID or a UUID. (`[packages/composer/amazeelabs/silverback_gutenberg/src/Plugin/GutenbergBlockMutator/TermReferenceBlockMutator.phpR1-R104](diffhunk://#diff-ed81d7b2fa5e8521059f30f9a4c3151adf19febf7d424cac85a358c49757c1f7R1-R104)`)