### PR TITLE
Make the token authenticator run at the end

### DIFF
--- a/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.services.yml
+++ b/packages/composer/amazeelabs/silverback_preview_link/silverback_preview_link.services.yml
@@ -26,6 +26,6 @@ services:
       - {
           name: authentication_provider,
           provider_id: 'preview_token',
-          priority: 0,
+          priority: -10000,
           global: TRUE,
         }


### PR DESCRIPTION
## Package(s) involved
amazeelabs/silverback_preview_link

## Description of changes
The token based authenticator runs last now (it has a very low priority) to make sure that this will be used only if there is no other way of authentication mechanism that can log the user in.

## How has this been tested?
Locally, manually.
