### PR TITLE
Instant preview based on user permissions

### DIFF
--- a/packages/composer/amazeelabs/silverback_autosave/src/Storage/AutosaveEntityFormDatabaseStorage.php
+++ b/packages/composer/amazeelabs/silverback_autosave/src/Storage/AutosaveEntityFormDatabaseStorage.php
@@ -121,7 +121,7 @@ class AutosaveEntityFormDatabaseStorage implements AutosaveEntityFormStorageInte
   /**
    * {@inheritdoc}
    */
-  public function getEntityAndFormState($form_id, $entity_type_id, $entity_id, $langcode, $uid, $form_session_id = NULL, $autosaved_timestamp = NULL) {
+  public function getEntityAndFormState($form_id, $entity_type_id, $entity_id, $langcode, $uid = NULL, $form_session_id = NULL, $autosaved_timestamp = NULL) {
     $result = NULL;
     $query = $this->connection->select(static::AUTOSAVE_ENTITY_FORM_TABLE, 'cefa')
       ->fields('cefa', ['entity', 'form_state', 'timestamp'])
@@ -134,8 +134,11 @@ class AutosaveEntityFormDatabaseStorage implements AutosaveEntityFormStorageInte
 
     $query->condition('entity_type_id', $entity_type_id)
       ->condition('entity_id', $entity_id)
-      ->condition('langcode', $langcode)
-      ->condition('uid', $uid);
+      ->condition('langcode', $langcode);
+
+    if (isset($uid)) {
+      $query->condition('uid', $uid);
+    }
 
     if (isset($autosaved_timestamp)) {
       $query->condition('timestamp', $autosaved_timestamp);

--- a/packages/composer/amazeelabs/silverback_autosave/src/Storage/AutosaveEntityFormStorageInterface.php
+++ b/packages/composer/amazeelabs/silverback_autosave/src/Storage/AutosaveEntityFormStorageInterface.php
@@ -63,7 +63,7 @@ interface AutosaveEntityFormStorageInterface {
    *   An array containing the entity object and the form state object, keyed
    *   accordingly with 'entity' and 'form_state'.
    */
-  public function getEntityAndFormState($form_id, $entity_type_id, $entity_id, $langcode, $uid, $form_session_id = NULL, $timestamp = NULL);
+  public function getEntityAndFormState($form_id, $entity_type_id, $entity_id, $langcode, $uid = NULL, $form_session_id = NULL, $timestamp = NULL);
 
   /**
    * Retrieves the stored entity.

--- a/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.permissions.yml
+++ b/packages/composer/amazeelabs/silverback_gatsby/silverback_gatsby.permissions.yml
@@ -4,3 +4,5 @@ trigger a gatsby build:
   title: 'Trigger a Gatsby Build'
 access publisher:
   title: 'Access Publisher'
+fetch any autosaved entity:
+  title: 'Fetch any autosaved entity'

--- a/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
+++ b/packages/composer/amazeelabs/silverback_gatsby/src/Plugin/GraphQL/DataProducer/FetchEntity.php
@@ -334,7 +334,8 @@ class FetchEntity extends DataProducerPluginBase implements ContainerFactoryPlug
         // @todo Add DI to both.
         /** @var \Drupal\silverback_autosave\Storage\AutosaveEntityFormStorageInterface $autoSaveFormStorage */
         $autoSaveFormStorage = \Drupal::service('silverback_autosave.entity_form_storage');
-        $autosaveUserId = \Drupal::currentUser()->id();
+        $currentUser = \Drupal::currentUser();
+        $autosaveUserId = $currentUser->hasPermission('fetch any autosaved entity') ? NULL : $currentUser->id();
 
         /**
          * This causes leaked metadata error.


### PR DESCRIPTION
## Package(s) involved
amazeelabs/silverback_autosave
amazeelabs/silverback_gatsby

## Description of changes
To support instant preview shareable links, a new permission has been introduced, fetch any autosaved entity, that can be assigned to the user roles that can access preview links. If they have the permission, they will be able to see the instant updates of content (created with the autosaved module).

## How has this been tested?
Locally, manually
