### PR TITLE
Move default preview user setting from config to state

### DIFF
--- a/packages/composer/amazeelabs/silverback_preview_link/config/schema/silverback_preview_link.schema.yml
+++ b/packages/composer/amazeelabs/silverback_preview_link/config/schema/silverback_preview_link.schema.yml
@@ -12,5 +12,3 @@ silverback_preview_link.settings:
     multiple_entities:
       label: Whether Preview Links can reference multiple entities.
       type: boolean
-    default_preview_user:
-      type: integer

--- a/packages/composer/amazeelabs/silverback_preview_link/src/Entity/SilverbackPreviewLink.php
+++ b/packages/composer/amazeelabs/silverback_preview_link/src/Entity/SilverbackPreviewLink.php
@@ -49,8 +49,8 @@ class SilverbackPreviewLink extends ContentEntityBase implements SilverbackPrevi
     parent::postCreate($storage);
     // If there is a default preview user set, then we add that user to the list
     // of entities attached to the link.
-    $config = \Drupal::config('silverback_preview_link.settings');
-    $default_preview_user = $config->get('default_preview_user');
+    $state = \Drupal::state();
+    $default_preview_user = $state->get('silverback_preview_link.default_preview_user');
     if ($default_preview_user) {
       $this->addEntity(User::load($default_preview_user));
     }

--- a/packages/composer/amazeelabs/silverback_preview_link/src/Form/SettingsForm.php
+++ b/packages/composer/amazeelabs/silverback_preview_link/src/Form/SettingsForm.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\silverback_preview_link\PreviewLinkUtility;
 use Drupal\user\Entity\User;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -24,6 +25,7 @@ class SettingsForm extends ConfigFormBase {
   public function __construct(ConfigFactoryInterface $configFactory,
     protected EntityTypeBundleInfoInterface $bundleInfo,
     protected EntityTypeManagerInterface $entityTypeManager,
+    protected StateInterface $state,
   ) {
     parent::__construct($configFactory);
   }
@@ -36,6 +38,7 @@ class SettingsForm extends ConfigFormBase {
       $container->get('config.factory'),
       $container->get('entity_type.bundle.info'),
       $container->get('entity_type.manager'),
+      $container->get('state'),
     );
   }
 
@@ -107,7 +110,7 @@ class SettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('expiry_seconds') ?: 604800,
       '#min' => 1,
     ];
-    $preview_user_id = $config->get('default_preview_user');
+    $preview_user_id = $this->state->get('silverback_preview_link.default_preview_user');
     $form['default_preview_user'] = [
       '#type' => 'entity_autocomplete',
       '#target_type' => 'user',
@@ -128,7 +131,7 @@ class SettingsForm extends ConfigFormBase {
 
     $config->set('multiple_entities', $form_state->getValue('multiple_entities'));
     $config->set('expiry_seconds', $form_state->getValue('expiry_seconds'));
-    $config->set('default_preview_user', $form_state->getValue('default_preview_user'));
+    $this->state->set('silverback_preview_link.default_preview_user', $form_state->getValue('default_preview_user'));
 
     $config->clear('enabled_entity_types');
     foreach (array_keys(array_filter($form_state->getValue('enabled_entity_types'))) as $enabledBundle) {


### PR DESCRIPTION
## Package(s) involved
amazeelabs/silverback_preview_link

## Description of changes
The default preview user is now stored inside state instead of config.
