### PR TITLE
chore(publisher): improve state error message

### DIFF
--- a/packages/npm/@amazeelabs/publisher/src/server.ts
+++ b/packages/npm/@amazeelabs/publisher/src/server.ts
@@ -222,7 +222,11 @@ const runServer = async (): Promise<HttpTerminator> => {
 
     // Check if the state matches.
     if (!stateMatches(req)) {
-      return res.status(500).json('State does not match.');
+      return res
+        .status(400)
+        .json(
+          'State does not match. Check if the Drupal Consumer entity redirect URI is properly set.',
+        );
     }
 
     const { code } = req.query;


### PR DESCRIPTION
## Package(s) involved

`publisher`

## Description of changes

Better error message for potential Consumer related error.

## Motivation and context

Consumers are content entities.

After syncing a DB, we inherit the entity from the source database, which will yield the vague State does not match. error message that can be confusing and hard to debug.

As this message is very unlikely to be exposed to regular end users (it's mostly a security measure), this simple fix should be good enough.

## Related Issue(s)

https://github.com/AmazeeLabs/silverback-template/pull/533

## How has this been tested?

Manually.
